### PR TITLE
feat(mcp): implement TaskService and task CLI commands

### DIFF
--- a/mcp/bin/avo.dart
+++ b/mcp/bin/avo.dart
@@ -28,6 +28,7 @@ import 'package:args/command_runner.dart';
 import 'package:avodah_core/avodah_core.dart';
 import 'package:avodah_mcp/cli/commands.dart';
 import 'package:avodah_mcp/config/paths.dart';
+import 'package:avodah_mcp/services/task_service.dart';
 import 'package:avodah_mcp/services/timer_service.dart';
 import 'package:avodah_mcp/storage/database_opener.dart';
 
@@ -42,8 +43,9 @@ Future<void> main(List<String> args) async {
   final nodeId = paths.getNodeIdSync();
   final clock = HybridLogicalClock(nodeId: nodeId);
 
-  // Create timer service
+  // Create services
   final timerService = TimerService(db: db, clock: clock);
+  final taskService = TaskService(db: db, clock: clock);
 
   try {
     final runner = CommandRunner<void>(
@@ -56,7 +58,7 @@ Future<void> main(List<String> args) async {
       ..addCommand(PauseCommand(timerService))
       ..addCommand(ResumeCommand(timerService))
       ..addCommand(CancelCommand(timerService))
-      ..addCommand(TaskCommand(db))
+      ..addCommand(TaskCommand(taskService))
       ..addCommand(TodayCommand(db))
       ..addCommand(WeekCommand(db))
       ..addCommand(JiraCommand(db));

--- a/mcp/lib/services/task_service.dart
+++ b/mcp/lib/services/task_service.dart
@@ -1,0 +1,131 @@
+/// Service layer for task operations against the SQLite database.
+library;
+
+import 'package:avodah_core/avodah_core.dart';
+
+/// Wraps all task-related database operations.
+class TaskService {
+  final AppDatabase db;
+  final HybridLogicalClock clock;
+
+  TaskService({required this.db, required this.clock});
+
+  /// Saves a task document via upsert.
+  Future<void> _saveTask(TaskDocument task) async {
+    await db
+        .into(db.tasks)
+        .insertOnConflictUpdate(task.toDriftCompanion());
+  }
+
+  /// Creates a new task with the given title and optional project ID.
+  Future<TaskDocument> add({
+    required String title,
+    String? projectId,
+  }) async {
+    final task = TaskDocument.create(
+      clock: clock,
+      title: title,
+      projectId: projectId,
+    );
+
+    await _saveTask(task);
+    return task;
+  }
+
+  /// Lists tasks from the database.
+  ///
+  /// By default returns only active (not done, not deleted) tasks.
+  /// Set [includeCompleted] to true to include completed tasks.
+  Future<List<TaskDocument>> list({bool includeCompleted = false}) async {
+    final rows = await db.select(db.tasks).get();
+
+    return rows
+        .map((row) => TaskDocument.fromDrift(task: row, clock: clock))
+        .where((task) {
+          if (task.isDeleted) return false;
+          if (!includeCompleted && task.isDone) return false;
+          return true;
+        })
+        .toList();
+  }
+
+  /// Finds a task by exact ID or unique prefix match.
+  ///
+  /// Throws [TaskNotFoundException] if no task matches.
+  /// Throws [AmbiguousTaskIdException] if multiple tasks match the prefix.
+  Future<TaskDocument> show(String idOrPrefix) async {
+    // Try exact match first
+    final exactRows = await (db.select(db.tasks)
+          ..where((t) => t.id.equals(idOrPrefix)))
+        .get();
+
+    if (exactRows.isNotEmpty) {
+      return TaskDocument.fromDrift(task: exactRows.first, clock: clock);
+    }
+
+    // Try prefix match
+    final allRows = await db.select(db.tasks).get();
+    final matches = allRows
+        .where((row) => row.id.startsWith(idOrPrefix))
+        .toList();
+
+    if (matches.isEmpty) {
+      throw TaskNotFoundException(idOrPrefix);
+    }
+    if (matches.length > 1) {
+      throw AmbiguousTaskIdException(
+        idOrPrefix,
+        matches.map((r) => r.id).toList(),
+      );
+    }
+
+    return TaskDocument.fromDrift(task: matches.first, clock: clock);
+  }
+
+  /// Marks a task as done by exact ID or prefix match.
+  ///
+  /// Throws [TaskNotFoundException] if no task matches.
+  /// Throws [AmbiguousTaskIdException] if multiple tasks match.
+  /// Throws [TaskAlreadyDoneException] if the task is already completed.
+  Future<TaskDocument> done(String idOrPrefix) async {
+    final task = await show(idOrPrefix);
+
+    if (task.isDone) {
+      throw TaskAlreadyDoneException(task);
+    }
+
+    task.markDone();
+    await _saveTask(task);
+    return task;
+  }
+}
+
+/// Thrown when no task matches the given ID or prefix.
+class TaskNotFoundException implements Exception {
+  final String idOrPrefix;
+  TaskNotFoundException(this.idOrPrefix);
+
+  @override
+  String toString() => 'No task found matching "$idOrPrefix".';
+}
+
+/// Thrown when multiple tasks match a prefix.
+class AmbiguousTaskIdException implements Exception {
+  final String prefix;
+  final List<String> matchingIds;
+  AmbiguousTaskIdException(this.prefix, this.matchingIds);
+
+  @override
+  String toString() =>
+      'Multiple tasks match "$prefix": ${matchingIds.map((id) => id.substring(0, 8)).join(', ')}. '
+      'Use a longer prefix.';
+}
+
+/// Thrown when trying to mark an already-done task as done.
+class TaskAlreadyDoneException implements Exception {
+  final TaskDocument task;
+  TaskAlreadyDoneException(this.task);
+
+  @override
+  String toString() => 'Task "${task.title}" is already done.';
+}

--- a/packages/avodah_core/lib/avodah_core.dart
+++ b/packages/avodah_core/lib/avodah_core.dart
@@ -19,5 +19,6 @@ export 'storage/tables/jira_integrations.dart';
 export 'storage/tables/timer.dart';
 
 // CRDT Document types
+export 'documents/task_document.dart';
 export 'documents/timer_document.dart';
 export 'documents/worklog_document.dart';

--- a/packages/avodah_core/lib/documents/task_document.dart
+++ b/packages/avodah_core/lib/documents/task_document.dart
@@ -9,8 +9,8 @@ import 'dart:convert';
 import 'package:drift/drift.dart';
 import 'package:uuid/uuid.dart';
 
-import 'package:avodah_core/crdt/crdt.dart';
-import 'package:avodah_core/storage/database.dart';
+import '../crdt/crdt.dart';
+import '../storage/database.dart';
 
 /// Field keys for TaskDocument.
 class TaskFields {

--- a/test/features/tasks/models/task_document_test.dart
+++ b/test/features/tasks/models/task_document_test.dart
@@ -1,5 +1,4 @@
-import 'package:avodah_core/crdt/crdt.dart';
-import 'package:avodah/features/tasks/models/task_document.dart';
+import 'package:avodah_core/avodah_core.dart';
 import 'package:test/test.dart';
 
 void main() {


### PR DESCRIPTION
## Summary

- **Move TaskDocument to avodah_core** — relocated from `lib/features/tasks/models/` to `packages/avodah_core/lib/documents/` so the MCP package can import it (zero Flutter dependencies)
- **Add TaskService** (`mcp/lib/services/task_service.dart`) — `add()`, `list()`, `show()`, `done()` with short-ID prefix matching and custom exceptions
- **Wire CLI commands** — replace all 4 stub task subcommands (`add`, `list`, `done`, `show`) with working implementations backed by TaskService

## Test plan

- [x] `flutter test` — all 244+ existing tests pass (validates TaskDocument move)
- [x] `cd mcp && dart test` — 17 new TaskService tests pass
- [x] Manual: `avo task add "Test task"` → prints ID
- [x] Manual: `avo task list` → shows task
- [x] Manual: `avo task done <short-id>` → marks done
- [x] Manual: `avo task show <short-id>` → detailed view

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)