### PR TITLE
feat(mcp): WorklogService + today/week CLI commands (#6)

### DIFF
--- a/mcp/bin/avo.dart
+++ b/mcp/bin/avo.dart
@@ -30,6 +30,7 @@ import 'package:avodah_mcp/cli/commands.dart';
 import 'package:avodah_mcp/config/paths.dart';
 import 'package:avodah_mcp/services/task_service.dart';
 import 'package:avodah_mcp/services/timer_service.dart';
+import 'package:avodah_mcp/services/worklog_service.dart';
 import 'package:avodah_mcp/storage/database_opener.dart';
 
 Future<void> main(List<String> args) async {
@@ -46,6 +47,7 @@ Future<void> main(List<String> args) async {
   // Create services
   final timerService = TimerService(db: db, clock: clock);
   final taskService = TaskService(db: db, clock: clock);
+  final worklogService = WorklogService(db: db, clock: clock);
 
   try {
     final runner = CommandRunner<void>(
@@ -59,8 +61,9 @@ Future<void> main(List<String> args) async {
       ..addCommand(ResumeCommand(timerService))
       ..addCommand(CancelCommand(timerService))
       ..addCommand(TaskCommand(taskService))
-      ..addCommand(TodayCommand(db))
-      ..addCommand(WeekCommand(db))
+      ..addCommand(TodayCommand(
+          worklogService: worklogService, taskService: taskService))
+      ..addCommand(WeekCommand(worklogService: worklogService))
       ..addCommand(JiraCommand(db));
 
     await runner.run(args);

--- a/mcp/lib/services/worklog_service.dart
+++ b/mcp/lib/services/worklog_service.dart
@@ -1,0 +1,175 @@
+/// Service layer for worklog operations against the SQLite database.
+library;
+
+import 'package:avodah_core/avodah_core.dart';
+
+/// Summary of a single task's logged time.
+class TaskTimeSummary {
+  final String taskId;
+  final String taskTitle;
+  final Duration total;
+
+  const TaskTimeSummary({
+    required this.taskId,
+    required this.taskTitle,
+    required this.total,
+  });
+
+  String get formattedDuration {
+    final hours = total.inHours;
+    final minutes = total.inMinutes % 60;
+    if (hours > 0) return '${hours}h ${minutes}m';
+    return '${minutes}m';
+  }
+}
+
+/// Summary of a day's logged time.
+class DaySummary {
+  final String date;
+  final Duration total;
+  final List<TaskTimeSummary> tasks;
+
+  const DaySummary({
+    required this.date,
+    required this.total,
+    required this.tasks,
+  });
+
+  String get formattedDuration {
+    final hours = total.inHours;
+    final minutes = total.inMinutes % 60;
+    if (hours > 0) return '${hours}h ${minutes}m';
+    return '${minutes}m';
+  }
+}
+
+/// Wraps all worklog-related database operations.
+class WorklogService {
+  final AppDatabase db;
+  final HybridLogicalClock clock;
+
+  WorklogService({required this.db, required this.clock});
+
+  /// Saves a worklog document via upsert.
+  Future<void> _saveWorklog(WorklogDocument worklog) async {
+    await db
+        .into(db.worklogEntries)
+        .insertOnConflictUpdate(worklog.toDriftCompanion());
+  }
+
+  /// Returns today's summary: total duration and per-task breakdown.
+  Future<DaySummary> todaySummary() async {
+    final now = DateTime.now();
+    final today = _formatDate(now);
+
+    final rows = await (db.select(db.worklogEntries)
+          ..where((w) => w.date.equals(today)))
+        .get();
+
+    return _buildDaySummary(today, rows);
+  }
+
+  /// Returns this week's summary (Mon-Sun), one DaySummary per day.
+  Future<List<DaySummary>> weekSummary() async {
+    final now = DateTime.now();
+    // Monday of current week
+    final monday = now.subtract(Duration(days: now.weekday - 1));
+
+    final days = <String>[];
+    for (var i = 0; i < 7; i++) {
+      days.add(_formatDate(monday.add(Duration(days: i))));
+    }
+
+    final rows = await db.select(db.worklogEntries).get();
+    final weekRows = rows.where((r) => days.contains(r.date)).toList();
+
+    final summaries = <DaySummary>[];
+    for (final day in days) {
+      final dayRows = weekRows.where((r) => r.date == day).toList();
+      summaries.add(_buildDaySummary(day, dayRows));
+    }
+
+    return summaries;
+  }
+
+  /// Creates a manual worklog entry.
+  Future<WorklogDocument> manualLog({
+    required String taskId,
+    required int durationMinutes,
+    String? comment,
+  }) async {
+    final now = DateTime.now();
+    final durationMs = durationMinutes * 60 * 1000;
+    final start = now.subtract(Duration(minutes: durationMinutes));
+
+    final worklog = WorklogDocument.create(
+      clock: clock,
+      taskId: taskId,
+      start: start.millisecondsSinceEpoch,
+      end: now.millisecondsSinceEpoch,
+      comment: comment,
+    );
+
+    await _saveWorklog(worklog);
+    return worklog;
+  }
+
+  /// Returns the most recent worklogs.
+  Future<List<WorklogDocument>> listRecent({int limit = 10}) async {
+    final rows = await db.select(db.worklogEntries).get();
+
+    final docs = rows
+        .map((row) => WorklogDocument.fromDrift(worklog: row, clock: clock))
+        .where((doc) => !doc.isDeleted)
+        .toList()
+      ..sort((a, b) => b.createdMs.compareTo(a.createdMs));
+
+    return docs.take(limit).toList();
+  }
+
+  /// Builds a DaySummary from worklog rows.
+  DaySummary _buildDaySummary(String date, List<WorklogEntry> rows) {
+    final docs = rows
+        .map((row) => WorklogDocument.fromDrift(worklog: row, clock: clock))
+        .where((doc) => !doc.isDeleted)
+        .toList();
+
+    // Group by taskId
+    final byTask = <String, List<WorklogDocument>>{};
+    for (final doc in docs) {
+      byTask.putIfAbsent(doc.taskId, () => []).add(doc);
+    }
+
+    final taskSummaries = byTask.entries.map((entry) {
+      final totalMs = entry.value.fold<int>(0, (sum, w) => sum + w.durationMs);
+      // Use taskId as title — the caller can resolve to a task name
+      return TaskTimeSummary(
+        taskId: entry.key,
+        taskTitle: entry.key,
+        total: Duration(milliseconds: totalMs),
+      );
+    }).toList()
+      ..sort((a, b) => b.total.compareTo(a.total));
+
+    final totalMs = docs.fold<int>(0, (sum, w) => sum + w.durationMs);
+
+    return DaySummary(
+      date: date,
+      total: Duration(milliseconds: totalMs),
+      tasks: taskSummaries,
+    );
+  }
+
+  static String _formatDate(DateTime dt) {
+    return '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
+  }
+}
+
+/// Thrown when no worklog matches the given ID.
+class WorklogNotFoundException implements Exception {
+  final String id;
+  WorklogNotFoundException(this.id);
+
+  @override
+  String toString() => 'No worklog found matching "$id".';
+}

--- a/mcp/test/services/worklog_service_test.dart
+++ b/mcp/test/services/worklog_service_test.dart
@@ -1,0 +1,222 @@
+import 'package:avodah_core/avodah_core.dart';
+import 'package:avodah_mcp/services/worklog_service.dart';
+import 'package:avodah_mcp/storage/database_opener.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late AppDatabase db;
+  late HybridLogicalClock clock;
+  late WorklogService service;
+
+  setUp(() {
+    db = openMemoryDatabase();
+    clock = HybridLogicalClock(nodeId: 'test-node');
+    service = WorklogService(db: db, clock: clock);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('todaySummary', () {
+    test('returns empty summary when no worklogs', () async {
+      final summary = await service.todaySummary();
+
+      expect(summary.total, equals(Duration.zero));
+      expect(summary.tasks, isEmpty);
+    });
+
+    test('returns summary with multiple worklogs', () async {
+      final now = DateTime.now();
+      final today =
+          '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+
+      // Create worklogs for today
+      final w1 = WorklogDocument.create(
+        clock: clock,
+        taskId: 'task-1',
+        start: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+      );
+      final w2 = WorklogDocument.create(
+        clock: clock,
+        taskId: 'task-2',
+        start: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+        end: now.millisecondsSinceEpoch,
+      );
+
+      await db
+          .into(db.worklogEntries)
+          .insert(w1.toDriftCompanion());
+      await db
+          .into(db.worklogEntries)
+          .insert(w2.toDriftCompanion());
+
+      final summary = await service.todaySummary();
+
+      expect(summary.date, equals(today));
+      expect(summary.tasks, hasLength(2));
+      expect(summary.total.inMinutes, greaterThan(0));
+    });
+
+    test('groups worklogs by taskId', () async {
+      final now = DateTime.now();
+
+      // Two worklogs for same task
+      final w1 = WorklogDocument.create(
+        clock: clock,
+        taskId: 'task-1',
+        start: now.subtract(const Duration(hours: 3)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+      );
+      final w2 = WorklogDocument.create(
+        clock: clock,
+        taskId: 'task-1',
+        start: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+        end: now.millisecondsSinceEpoch,
+      );
+
+      await db
+          .into(db.worklogEntries)
+          .insert(w1.toDriftCompanion());
+      await db
+          .into(db.worklogEntries)
+          .insert(w2.toDriftCompanion());
+
+      final summary = await service.todaySummary();
+
+      expect(summary.tasks, hasLength(1));
+      expect(summary.tasks.first.taskId, equals('task-1'));
+      // ~2 hours total
+      expect(summary.tasks.first.total.inMinutes, greaterThanOrEqualTo(119));
+    });
+  });
+
+  group('weekSummary', () {
+    test('returns 7 day summaries', () async {
+      final summaries = await service.weekSummary();
+
+      expect(summaries, hasLength(7));
+    });
+
+    test('includes worklogs across days', () async {
+      final now = DateTime.now();
+      final yesterday = now.subtract(const Duration(days: 1));
+
+      final w1 = WorklogDocument.create(
+        clock: clock,
+        taskId: 'task-1',
+        start: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+        end: now.millisecondsSinceEpoch,
+      );
+      final w2 = WorklogDocument.create(
+        clock: clock,
+        taskId: 'task-1',
+        start: yesterday
+            .subtract(const Duration(hours: 1))
+            .millisecondsSinceEpoch,
+        end: yesterday.millisecondsSinceEpoch,
+      );
+
+      await db
+          .into(db.worklogEntries)
+          .insert(w1.toDriftCompanion());
+      await db
+          .into(db.worklogEntries)
+          .insert(w2.toDriftCompanion());
+
+      final summaries = await service.weekSummary();
+      final nonEmpty =
+          summaries.where((s) => s.total.inMilliseconds > 0).toList();
+
+      expect(nonEmpty.length, greaterThanOrEqualTo(1));
+    });
+  });
+
+  group('manualLog', () {
+    test('creates valid worklog', () async {
+      final worklog = await service.manualLog(
+        taskId: 'task-1',
+        durationMinutes: 90,
+        comment: 'Code review',
+      );
+
+      expect(worklog.id, isNotEmpty);
+      expect(worklog.taskId, equals('task-1'));
+      expect(worklog.durationMs, equals(90 * 60 * 1000));
+      expect(worklog.comment, equals('Code review'));
+    });
+
+    test('persists worklog to database', () async {
+      await service.manualLog(
+        taskId: 'task-1',
+        durationMinutes: 30,
+      );
+
+      final recent = await service.listRecent();
+      expect(recent, hasLength(1));
+      expect(recent.first.taskId, equals('task-1'));
+    });
+  });
+
+  group('listRecent', () {
+    test('returns empty list when no worklogs', () async {
+      final recent = await service.listRecent();
+
+      expect(recent, isEmpty);
+    });
+
+    test('respects limit', () async {
+      final now = DateTime.now();
+      for (var i = 0; i < 5; i++) {
+        final w = WorklogDocument.create(
+          clock: clock,
+          taskId: 'task-$i',
+          start:
+              now.subtract(Duration(hours: i + 1)).millisecondsSinceEpoch,
+          end: now.subtract(Duration(hours: i)).millisecondsSinceEpoch,
+        );
+        await db
+            .into(db.worklogEntries)
+            .insert(w.toDriftCompanion());
+      }
+
+      final recent = await service.listRecent(limit: 3);
+
+      expect(recent, hasLength(3));
+    });
+
+    test('returns most recent first', () async {
+      final now = DateTime.now();
+      final w1 = WorklogDocument.create(
+        clock: clock,
+        taskId: 'old',
+        start: now.subtract(const Duration(hours: 5)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 4)).millisecondsSinceEpoch,
+      );
+      // Manually set an older createdMs
+      w1.createdMs = now.subtract(const Duration(hours: 4)).millisecondsSinceEpoch;
+
+      final w2 = WorklogDocument.create(
+        clock: clock,
+        taskId: 'new',
+        start: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+        end: now.millisecondsSinceEpoch,
+      );
+      // Ensure newer createdMs
+      w2.createdMs = now.millisecondsSinceEpoch;
+
+      await db
+          .into(db.worklogEntries)
+          .insert(w1.toDriftCompanion());
+      await db
+          .into(db.worklogEntries)
+          .insert(w2.toDriftCompanion());
+
+      final recent = await service.listRecent();
+
+      expect(recent.first.taskId, equals('new'));
+      expect(recent.last.taskId, equals('old'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `WorklogService` with `todaySummary()`, `weekSummary()`, `manualLog()`, and `listRecent()` methods
- Wire `TodayCommand` and `WeekCommand` to use WorklogService with formatted output (per-task breakdown, weekly bar charts)
- Add 10 unit tests covering all WorklogService methods

## Test plan
- [x] `dart test` — all 27 tests pass (17 existing + 10 new)
- [ ] Manual: `avo start "test task" && avo stop && avo today` shows logged time
- [ ] Manual: `avo week` shows weekly summary with bar chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)