### PR TITLE
feat(mcp): ProjectService + project CLI commands (#7)

### DIFF
--- a/mcp/bin/avo.dart
+++ b/mcp/bin/avo.dart
@@ -28,6 +28,7 @@ import 'package:args/command_runner.dart';
 import 'package:avodah_core/avodah_core.dart';
 import 'package:avodah_mcp/cli/commands.dart';
 import 'package:avodah_mcp/config/paths.dart';
+import 'package:avodah_mcp/services/project_service.dart';
 import 'package:avodah_mcp/services/task_service.dart';
 import 'package:avodah_mcp/services/timer_service.dart';
 import 'package:avodah_mcp/services/worklog_service.dart';
@@ -48,6 +49,7 @@ Future<void> main(List<String> args) async {
   final timerService = TimerService(db: db, clock: clock);
   final taskService = TaskService(db: db, clock: clock);
   final worklogService = WorklogService(db: db, clock: clock);
+  final projectService = ProjectService(db: db, clock: clock);
 
   try {
     final runner = CommandRunner<void>(
@@ -61,6 +63,7 @@ Future<void> main(List<String> args) async {
       ..addCommand(ResumeCommand(timerService))
       ..addCommand(CancelCommand(timerService))
       ..addCommand(TaskCommand(taskService))
+      ..addCommand(ProjectCommand(projectService))
       ..addCommand(TodayCommand(
           worklogService: worklogService, taskService: taskService))
       ..addCommand(WeekCommand(worklogService: worklogService))

--- a/mcp/lib/services/project_service.dart
+++ b/mcp/lib/services/project_service.dart
@@ -1,0 +1,115 @@
+/// Service layer for project operations against the SQLite database.
+library;
+
+import 'package:avodah_core/avodah_core.dart';
+
+/// Wraps all project-related database operations.
+class ProjectService {
+  final AppDatabase db;
+  final HybridLogicalClock clock;
+
+  ProjectService({required this.db, required this.clock});
+
+  /// Saves a project document via upsert.
+  Future<void> _saveProject(ProjectDocument project) async {
+    await db
+        .into(db.projects)
+        .insertOnConflictUpdate(project.toDriftCompanion());
+  }
+
+  /// Creates a new project with the given title and optional icon.
+  Future<ProjectDocument> add({
+    required String title,
+    String? icon,
+  }) async {
+    final project = ProjectDocument.create(
+      clock: clock,
+      title: title,
+      icon: icon,
+    );
+
+    await _saveProject(project);
+    return project;
+  }
+
+  /// Lists projects from the database.
+  ///
+  /// By default returns only active (not archived, not deleted) projects.
+  /// Set [includeArchived] to true to include archived projects.
+  Future<List<ProjectDocument>> list({bool includeArchived = false}) async {
+    final rows = await db.select(db.projects).get();
+
+    return rows
+        .map((row) => ProjectDocument.fromDrift(project: row, clock: clock))
+        .where((project) {
+          if (project.isDeleted) return false;
+          if (!includeArchived && project.isArchived) return false;
+          return true;
+        })
+        .toList();
+  }
+
+  /// Finds a project by exact ID or unique prefix match.
+  ///
+  /// Throws [ProjectNotFoundException] if no project matches.
+  /// Throws [AmbiguousProjectIdException] if multiple projects match.
+  Future<ProjectDocument> show(String idOrPrefix) async {
+    // Try exact match first
+    final exactRows = await (db.select(db.projects)
+          ..where((p) => p.id.equals(idOrPrefix)))
+        .get();
+
+    if (exactRows.isNotEmpty) {
+      return ProjectDocument.fromDrift(project: exactRows.first, clock: clock);
+    }
+
+    // Try prefix match
+    final allRows = await db.select(db.projects).get();
+    final matches = allRows
+        .where((row) => row.id.startsWith(idOrPrefix))
+        .toList();
+
+    if (matches.isEmpty) {
+      throw ProjectNotFoundException(idOrPrefix);
+    }
+    if (matches.length > 1) {
+      throw AmbiguousProjectIdException(
+        idOrPrefix,
+        matches.map((r) => r.id).toList(),
+      );
+    }
+
+    return ProjectDocument.fromDrift(project: matches.first, clock: clock);
+  }
+
+  /// Returns the number of active tasks for a given project.
+  Future<int> taskCount(String projectId) async {
+    final rows = await db.select(db.tasks).get();
+    return rows
+        .map((row) => TaskDocument.fromDrift(task: row, clock: clock))
+        .where((task) =>
+            !task.isDeleted && !task.isDone && task.projectId == projectId)
+        .length;
+  }
+}
+
+/// Thrown when no project matches the given ID or prefix.
+class ProjectNotFoundException implements Exception {
+  final String idOrPrefix;
+  ProjectNotFoundException(this.idOrPrefix);
+
+  @override
+  String toString() => 'No project found matching "$idOrPrefix".';
+}
+
+/// Thrown when multiple projects match a prefix.
+class AmbiguousProjectIdException implements Exception {
+  final String prefix;
+  final List<String> matchingIds;
+  AmbiguousProjectIdException(this.prefix, this.matchingIds);
+
+  @override
+  String toString() =>
+      'Multiple projects match "$prefix": ${matchingIds.map((id) => id.substring(0, 8)).join(', ')}. '
+      'Use a longer prefix.';
+}

--- a/mcp/test/services/project_service_test.dart
+++ b/mcp/test/services/project_service_test.dart
@@ -1,0 +1,178 @@
+import 'package:avodah_core/avodah_core.dart';
+import 'package:avodah_mcp/services/project_service.dart';
+import 'package:avodah_mcp/services/task_service.dart';
+import 'package:avodah_mcp/storage/database_opener.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late AppDatabase db;
+  late HybridLogicalClock clock;
+  late ProjectService service;
+  late TaskService taskService;
+
+  setUp(() {
+    db = openMemoryDatabase();
+    clock = HybridLogicalClock(nodeId: 'test-node');
+    service = ProjectService(db: db, clock: clock);
+    taskService = TaskService(db: db, clock: clock);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('add', () {
+    test('creates project with title and returns it', () async {
+      final project = await service.add(title: 'Backend API');
+
+      expect(project.id, isNotEmpty);
+      expect(project.title, equals('Backend API'));
+      expect(project.isArchived, isFalse);
+      expect(project.createdTimestamp, isNotNull);
+    });
+
+    test('creates project with icon', () async {
+      final project = await service.add(title: 'Frontend', icon: 'web');
+
+      expect(project.icon, equals('web'));
+    });
+
+    test('persists project to database', () async {
+      final project = await service.add(title: 'Persist me');
+
+      final fetched = await service.show(project.id);
+      expect(fetched.title, equals('Persist me'));
+    });
+  });
+
+  group('list', () {
+    test('returns active projects by default', () async {
+      await service.add(title: 'Project 1');
+      await service.add(title: 'Project 2');
+
+      final projects = await service.list();
+
+      expect(projects, hasLength(2));
+    });
+
+    test('excludes archived projects by default', () async {
+      final project = await service.add(title: 'Will be archived');
+      await service.add(title: 'Still active');
+
+      // Archive the project
+      project.isArchived = true;
+      await db
+          .into(db.projects)
+          .insertOnConflictUpdate(project.toDriftCompanion());
+
+      final projects = await service.list();
+
+      expect(projects, hasLength(1));
+      expect(projects.first.title, equals('Still active'));
+    });
+
+    test('includes archived projects with includeArchived', () async {
+      final project = await service.add(title: 'Will be archived');
+      await service.add(title: 'Still active');
+
+      project.isArchived = true;
+      await db
+          .into(db.projects)
+          .insertOnConflictUpdate(project.toDriftCompanion());
+
+      final projects = await service.list(includeArchived: true);
+
+      expect(projects, hasLength(2));
+    });
+
+    test('excludes deleted projects', () async {
+      final project = await service.add(title: 'Will be deleted');
+      await service.add(title: 'Still active');
+
+      project.delete();
+      await db
+          .into(db.projects)
+          .insertOnConflictUpdate(project.toDriftCompanion());
+
+      final projects = await service.list(includeArchived: true);
+
+      expect(projects, hasLength(1));
+      expect(projects.first.title, equals('Still active'));
+    });
+
+    test('returns empty list when no projects', () async {
+      final projects = await service.list();
+
+      expect(projects, isEmpty);
+    });
+  });
+
+  group('show', () {
+    test('finds project by exact ID', () async {
+      final created = await service.add(title: 'Find me');
+
+      final found = await service.show(created.id);
+
+      expect(found.id, equals(created.id));
+      expect(found.title, equals('Find me'));
+    });
+
+    test('finds project by prefix', () async {
+      final created = await service.add(title: 'Find by prefix');
+
+      final found = await service.show(created.id.substring(0, 8));
+
+      expect(found.id, equals(created.id));
+    });
+
+    test('throws ProjectNotFoundException for unknown ID', () async {
+      expect(
+        () => service.show('nonexistent-id'),
+        throwsA(isA<ProjectNotFoundException>()),
+      );
+    });
+
+    test('throws AmbiguousProjectIdException for ambiguous prefix', () async {
+      await service.add(title: 'Project A');
+      await service.add(title: 'Project B');
+
+      // Empty prefix matches all
+      expect(
+        () => service.show(''),
+        throwsA(isA<AmbiguousProjectIdException>()),
+      );
+    });
+  });
+
+  group('taskCount', () {
+    test('returns count of active tasks for project', () async {
+      final project = await service.add(title: 'My Project');
+      await taskService.add(title: 'Task 1', projectId: project.id);
+      await taskService.add(title: 'Task 2', projectId: project.id);
+
+      final count = await service.taskCount(project.id);
+
+      expect(count, equals(2));
+    });
+
+    test('excludes done tasks', () async {
+      final project = await service.add(title: 'My Project');
+      final task = await taskService.add(
+          title: 'Will be done', projectId: project.id);
+      await taskService.add(title: 'Still active', projectId: project.id);
+      await taskService.done(task.id);
+
+      final count = await service.taskCount(project.id);
+
+      expect(count, equals(1));
+    });
+
+    test('returns 0 for project with no tasks', () async {
+      final project = await service.add(title: 'Empty Project');
+
+      final count = await service.taskCount(project.id);
+
+      expect(count, equals(0));
+    });
+  });
+}

--- a/packages/avodah_core/lib/avodah_core.dart
+++ b/packages/avodah_core/lib/avodah_core.dart
@@ -19,6 +19,7 @@ export 'storage/tables/jira_integrations.dart';
 export 'storage/tables/timer.dart';
 
 // CRDT Document types
+export 'documents/project_document.dart';
 export 'documents/task_document.dart';
 export 'documents/timer_document.dart';
 export 'documents/worklog_document.dart';

--- a/packages/avodah_core/lib/documents/project_document.dart
+++ b/packages/avodah_core/lib/documents/project_document.dart
@@ -9,8 +9,8 @@ import 'dart:convert';
 import 'package:drift/drift.dart';
 import 'package:uuid/uuid.dart';
 
-import 'package:avodah_core/crdt/crdt.dart';
-import 'package:avodah_core/storage/database.dart';
+import '../crdt/crdt.dart';
+import '../storage/database.dart';
 
 /// Field keys for ProjectDocument.
 class ProjectFields {


### PR DESCRIPTION
## Summary
- Move `ProjectDocument` from Flutter app (`lib/features/`) to `avodah_core` shared package
- Add `ProjectService` with `add()`, `list()`, `show()`, and `taskCount()` methods
- Wire `ProjectCommand` group (`avo project add/list/show`) into CLI runner
- Add 15 unit tests covering all ProjectService methods

## Test plan
- [x] `dart test` — all 42 tests pass (27 existing + 15 new)
- [ ] Manual: `avo project add "Backend API"` creates project
- [ ] Manual: `avo project list` shows projects with task counts
- [ ] Manual: `avo project show <id>` shows project details

🤖 Generated with [Claude Code](https://claude.com/claude-code)