### PR TITLE
feat(mcp): wire services into MCP server protocol (#8)

### DIFF
--- a/mcp/lib/tools/mcp_server.dart
+++ b/mcp/lib/tools/mcp_server.dart
@@ -1,28 +1,39 @@
 /// MCP Server implementation for Avodah.
+///
+/// Implements the Model Context Protocol (MCP) over JSON-RPC 2.0 for stdio.
 library;
 
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:avodah_core/avodah_core.dart';
 import 'package:avodah_mcp/config/paths.dart';
+import 'package:avodah_mcp/services/project_service.dart';
+import 'package:avodah_mcp/services/task_service.dart';
+import 'package:avodah_mcp/services/timer_service.dart';
+import 'package:avodah_mcp/services/worklog_service.dart';
 
 /// MCP Server that exposes worklog tracking tools.
 class McpServer {
-  final AppDatabase db;
+  final TimerService timerService;
+  final TaskService taskService;
+  final WorklogService worklogService;
+  final ProjectService projectService;
   final AvodahPaths paths;
 
+  static const String serverName = 'avodah';
+  static const String serverVersion = '0.1.0';
+
   McpServer({
-    required this.db,
+    required this.timerService,
+    required this.taskService,
+    required this.worklogService,
+    required this.projectService,
     required this.paths,
   });
 
   /// Starts serving MCP over stdio.
   Future<void> serve(Stream<List<int>> input, IOSink output) async {
-    // TODO: Implement MCP protocol
-    // For now, just a placeholder that reads JSON-RPC requests
-
     final lines = input.transform(utf8.decoder).transform(const LineSplitter());
 
     await for (final line in lines) {
@@ -45,7 +56,8 @@ class McpServer {
     }
   }
 
-  Future<Map<String, dynamic>> _handleRequest(Map<String, dynamic> request) async {
+  Future<Map<String, dynamic>> _handleRequest(
+      Map<String, dynamic> request) async {
     final method = request['method'] as String?;
     final params = request['params'] as Map<String, dynamic>? ?? {};
     final id = request['id'];
@@ -71,6 +83,19 @@ class McpServer {
 
   Future<dynamic> _dispatch(String? method, Map<String, dynamic> params) async {
     switch (method) {
+      // MCP Protocol methods
+      case 'initialize':
+        return _handleInitialize(params);
+      case 'tools/list':
+        return _handleToolsList();
+      case 'tools/call':
+        return _handleToolsCall(params);
+      case 'resources/list':
+        return _handleResourcesList();
+      case 'resources/read':
+        return _handleResourcesRead(params);
+
+      // Legacy methods (for backwards compatibility)
       case 'timer':
         return _handleTimer(params);
       case 'tasks':
@@ -79,36 +104,297 @@ class McpServer {
         return _handleToday(params);
       case 'jira':
         return _handleJira(params);
+
       default:
         throw Exception('Unknown method: $method');
     }
   }
+
+  // ── MCP Protocol Methods ──────────────────────────────────────────────────
+
+  Map<String, dynamic> _handleInitialize(Map<String, dynamic> params) {
+    return {
+      'protocolVersion': '2024-11-05',
+      'capabilities': {
+        'tools': {},
+        'resources': {},
+      },
+      'serverInfo': {
+        'name': serverName,
+        'version': serverVersion,
+      },
+    };
+  }
+
+  Map<String, dynamic> _handleToolsList() {
+    return {
+      'tools': [
+        {
+          'name': 'timer',
+          'description':
+              'Control the worklog timer - start, stop, pause, resume, or get status',
+          'inputSchema': {
+            'type': 'object',
+            'properties': {
+              'action': {
+                'type': 'string',
+                'enum': ['start', 'stop', 'pause', 'resume', 'status', 'cancel'],
+                'description': 'Timer action to perform',
+              },
+              'task': {
+                'type': 'string',
+                'description': 'Task title (required for start)',
+              },
+              'taskId': {
+                'type': 'string',
+                'description': 'Optional task ID to link the timer to',
+              },
+              'note': {
+                'type': 'string',
+                'description': 'Optional note for the timer',
+              },
+            },
+            'required': ['action'],
+          },
+        },
+        {
+          'name': 'tasks',
+          'description': 'Manage tasks - list, add, show details, or mark done',
+          'inputSchema': {
+            'type': 'object',
+            'properties': {
+              'action': {
+                'type': 'string',
+                'enum': ['list', 'add', 'show', 'done'],
+                'description': 'Task action to perform',
+              },
+              'title': {
+                'type': 'string',
+                'description': 'Task title (required for add)',
+              },
+              'id': {
+                'type': 'string',
+                'description': 'Task ID or prefix (required for show/done)',
+              },
+              'projectId': {
+                'type': 'string',
+                'description': 'Optional project ID for add',
+              },
+              'includeCompleted': {
+                'type': 'boolean',
+                'description': 'Include completed tasks in list',
+              },
+            },
+            'required': ['action'],
+          },
+        },
+        {
+          'name': 'today',
+          'description': "Get today's worklog summary",
+          'inputSchema': {
+            'type': 'object',
+            'properties': {},
+          },
+        },
+        {
+          'name': 'jira',
+          'description': 'Jira integration - sync, status, pull, push',
+          'inputSchema': {
+            'type': 'object',
+            'properties': {
+              'action': {
+                'type': 'string',
+                'enum': ['sync', 'status', 'pull', 'push'],
+                'description': 'Jira action to perform',
+              },
+            },
+            'required': ['action'],
+          },
+        },
+      ],
+    };
+  }
+
+  Future<Map<String, dynamic>> _handleToolsCall(
+      Map<String, dynamic> params) async {
+    final name = params['name'] as String?;
+    final arguments = params['arguments'] as Map<String, dynamic>? ?? {};
+
+    switch (name) {
+      case 'timer':
+        return _handleTimer(arguments);
+      case 'tasks':
+        return _handleTasks(arguments);
+      case 'today':
+        return _handleToday(arguments);
+      case 'jira':
+        return _handleJira(arguments);
+      default:
+        throw Exception('Unknown tool: $name');
+    }
+  }
+
+  Map<String, dynamic> _handleResourcesList() {
+    return {
+      'resources': [
+        {
+          'uri': 'avodah://status',
+          'name': 'Avodah Status',
+          'description': 'Current timer status and today\'s summary',
+          'mimeType': 'application/json',
+        },
+      ],
+    };
+  }
+
+  Future<Map<String, dynamic>> _handleResourcesRead(
+      Map<String, dynamic> params) async {
+    final uri = params['uri'] as String?;
+
+    switch (uri) {
+      case 'avodah://status':
+        final timer = await timerService.status();
+        final today = await worklogService.todaySummary();
+
+        return {
+          'contents': [
+            {
+              'uri': 'avodah://status',
+              'mimeType': 'application/json',
+              'text': jsonEncode({
+                'timer': timer != null
+                    ? {
+                        'running': timer.isRunning,
+                        'paused': timer.isPaused,
+                        'task': timer.taskTitle,
+                        'taskId': timer.taskId,
+                        'elapsed': _formatDuration(timer.elapsed),
+                      }
+                    : null,
+                'today': {
+                  'date': today.date,
+                  'total': today.formattedDuration,
+                  'tasks': today.tasks
+                      .map((t) => {
+                            'taskId': t.taskId,
+                            'total': t.formattedDuration,
+                          })
+                      .toList(),
+                },
+              }),
+            },
+          ],
+        };
+      default:
+        throw Exception('Unknown resource: $uri');
+    }
+  }
+
+  // ── Tool Handlers ─────────────────────────────────────────────────────────
 
   Future<Map<String, dynamic>> _handleTimer(Map<String, dynamic> params) async {
     final action = params['action'] as String?;
 
     switch (action) {
       case 'start':
-        // TODO: Implement start timer
-        return {
-          'ok': true,
-          'running': true,
-          'task': params['task'] ?? 'Untitled',
-          'elapsed': '0m',
-        };
+        final task = params['task'] as String? ?? 'Untitled';
+        final taskId = params['taskId'] as String?;
+        final note = params['note'] as String?;
+
+        try {
+          final timer = await timerService.start(
+            taskTitle: task,
+            taskId: taskId,
+            note: note,
+          );
+          return {
+            'ok': true,
+            'running': true,
+            'task': timer.taskTitle,
+            'taskId': timer.taskId,
+            'startedAt': timer.startedAt?.toIso8601String(),
+          };
+        } on TimerAlreadyRunningException catch (e) {
+          return {
+            'ok': false,
+            'error': e.toString(),
+            'running': true,
+            'task': e.timer.taskTitle,
+          };
+        }
+
       case 'stop':
-        // TODO: Implement stop timer
-        return {
-          'ok': true,
-          'running': false,
-          'logged': '0m → Task',
-        };
+        try {
+          final result = await timerService.stop();
+          return {
+            'ok': true,
+            'running': false,
+            'logged': '${result.elapsedFormatted} → ${result.taskTitle}',
+            'worklogId': result.worklogId,
+            'elapsed': result.elapsedFormatted,
+            'task': result.taskTitle,
+          };
+        } on NoTimerRunningException {
+          return {
+            'ok': false,
+            'error': 'No timer is currently running.',
+            'running': false,
+          };
+        }
+
+      case 'pause':
+        try {
+          final timer = await timerService.pause();
+          return {
+            'ok': true,
+            'paused': true,
+            'task': timer.taskTitle,
+            'elapsed': _formatDuration(timer.elapsed),
+          };
+        } on NoTimerRunningException {
+          return {'ok': false, 'error': 'No timer is currently running.'};
+        } on TimerAlreadyPausedException {
+          return {'ok': false, 'error': 'Timer is already paused.'};
+        }
+
+      case 'resume':
+        try {
+          final timer = await timerService.resume();
+          return {
+            'ok': true,
+            'running': true,
+            'task': timer.taskTitle,
+            'elapsed': _formatDuration(timer.elapsed),
+          };
+        } on NoTimerRunningException {
+          return {'ok': false, 'error': 'No timer is currently running.'};
+        } on TimerNotPausedException {
+          return {'ok': false, 'error': 'Timer is not paused.'};
+        }
+
+      case 'cancel':
+        try {
+          await timerService.cancel();
+          return {'ok': true, 'cancelled': true};
+        } on NoTimerRunningException {
+          return {'ok': false, 'error': 'No timer is currently running.'};
+        }
+
       case 'status':
-        // TODO: Implement status
+        final timer = await timerService.status();
+        if (timer == null) {
+          return {'ok': true, 'running': false};
+        }
         return {
           'ok': true,
-          'running': false,
+          'running': timer.isRunning,
+          'paused': timer.isPaused,
+          'task': timer.taskTitle,
+          'taskId': timer.taskId,
+          'elapsed': _formatDuration(timer.elapsed),
+          'startedAt': timer.startedAt?.toIso8601String(),
         };
+
       default:
         throw Exception('Unknown timer action: $action');
     }
@@ -119,54 +405,114 @@ class McpServer {
 
     switch (action) {
       case 'list':
-        // TODO: Implement list tasks
+        final includeCompleted = params['includeCompleted'] as bool? ?? false;
+        final tasks = await taskService.list(includeCompleted: includeCompleted);
         return {
           'ok': true,
-          'tasks': <Map<String, dynamic>>[],
+          'tasks': tasks
+              .map((t) => {
+                    'id': t.id,
+                    'title': t.title,
+                    'isDone': t.isDone,
+                    'projectId': t.projectId,
+                  })
+              .toList(),
         };
+
       case 'add':
-        // TODO: Implement add task
+        final title = params['title'] as String?;
+        if (title == null || title.isEmpty) {
+          return {'ok': false, 'error': 'Title is required'};
+        }
+        final projectId = params['projectId'] as String?;
+        final task = await taskService.add(title: title, projectId: projectId);
         return {
           'ok': true,
           'created': {
-            'id': 'placeholder',
-            'title': params['title'],
+            'id': task.id,
+            'title': task.title,
+            'projectId': task.projectId,
           },
         };
+
+      case 'show':
+        final id = params['id'] as String?;
+        if (id == null || id.isEmpty) {
+          return {'ok': false, 'error': 'Task ID is required'};
+        }
+        try {
+          final task = await taskService.show(id);
+          return {
+            'ok': true,
+            'task': {
+              'id': task.id,
+              'title': task.title,
+              'isDone': task.isDone,
+              'projectId': task.projectId,
+            },
+          };
+        } on TaskNotFoundException catch (e) {
+          return {'ok': false, 'error': e.toString()};
+        } on AmbiguousTaskIdException catch (e) {
+          return {'ok': false, 'error': e.toString()};
+        }
+
+      case 'done':
+        final id = params['id'] as String?;
+        if (id == null || id.isEmpty) {
+          return {'ok': false, 'error': 'Task ID is required'};
+        }
+        try {
+          final task = await taskService.done(id);
+          return {
+            'ok': true,
+            'completed': {
+              'id': task.id,
+              'title': task.title,
+            },
+          };
+        } on TaskNotFoundException catch (e) {
+          return {'ok': false, 'error': e.toString()};
+        } on AmbiguousTaskIdException catch (e) {
+          return {'ok': false, 'error': e.toString()};
+        } on TaskAlreadyDoneException catch (e) {
+          return {'ok': false, 'error': e.toString()};
+        }
+
       default:
         throw Exception('Unknown tasks action: $action');
     }
   }
 
   Future<Map<String, dynamic>> _handleToday(Map<String, dynamic> params) async {
-    // TODO: Implement today summary
-    final now = DateTime.now();
+    final summary = await worklogService.todaySummary();
     return {
-      'date': '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}',
-      'total': '0m',
-      'tasks': <Map<String, dynamic>>[],
+      'date': summary.date,
+      'total': summary.formattedDuration,
+      'tasks': summary.tasks
+          .map((t) => {
+                'taskId': t.taskId,
+                'taskTitle': t.taskTitle,
+                'total': t.formattedDuration,
+              })
+          .toList(),
     };
   }
 
   Future<Map<String, dynamic>> _handleJira(Map<String, dynamic> params) async {
-    final action = params['action'] as String?;
+    // Placeholder until Session 4 (Jira Integration)
+    return {
+      'ok': false,
+      'error': 'Jira integration not configured. Run `avo jira setup` first.',
+    };
+  }
 
-    switch (action) {
-      case 'sync':
-        // TODO: Implement Jira sync
-        return {
-          'ok': true,
-          'pulled': 0,
-          'pushed': 0,
-        };
-      case 'status':
-        // TODO: Implement Jira status
-        return {
-          'ok': true,
-          'configured': false,
-        };
-      default:
-        throw Exception('Unknown jira action: $action');
-    }
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  String _formatDuration(Duration d) {
+    final hours = d.inHours;
+    final minutes = d.inMinutes % 60;
+    if (hours > 0) return '${hours}h ${minutes}m';
+    return '${minutes}m';
   }
 }


### PR DESCRIPTION
## Summary
- Inject all services (TimerService, TaskService, WorklogService, ProjectService) into MCP server
- Implement proper MCP protocol: `initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read`
- Wire handlers to real service implementations
- Expose `avodah://status` resource for timer + today summary

## Test plan
- [x] All 42 mcp tests pass (`dart test`)
- [x] `initialize` returns server info and capabilities
- [x] `tools/list` returns 4 tools with schemas
- [x] `tools/call` dispatches to handlers correctly
- [x] `resources/list` shows avodah://status
- [x] `resources/read` returns timer + today data
- [x] CLI and MCP use same database (verified with `avo status`)

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/code)