### PR TITLE
chore(mcp): native avo binary + CLI default commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,8 @@ coverage/
 result
 result-*
 
+# Compiled CLI binary
+mcp/bin/avo
+
 # Direnv
 .direnv/

--- a/mcp/bin/avo.dart
+++ b/mcp/bin/avo.dart
@@ -77,7 +77,20 @@ Future<void> main(List<String> args) async {
       ..addCommand(WeekCommand(worklogService: worklogService))
       ..addCommand(JiraCommand(jiraService, paths));
 
-    await runner.run(args);
+    // No args → run status + hint
+    if (args.isEmpty) {
+      await runner.run(['status']);
+      print('');
+      print('  -> avo --help              for all commands');
+    }
+    // `avo jira` with no subcommand → run jira status + hint
+    else if (args.length == 1 && args.first == 'jira') {
+      await runner.run(['jira', 'status']);
+      print('');
+      print('  -> avo jira --help         for all subcommands');
+    } else {
+      await runner.run(args);
+    }
   } on UsageException catch (e) {
     print(e);
     exit(64);


### PR DESCRIPTION
## Summary

- **Native binary** (#19): Wire `dart compile exe` into nix flake `avo` script with auto-recompile when source changes (~9ms startup vs ~5s JIT). Add `av-build-cli` for manual compilation.
- **Default status** (#20): `avo` with no args runs the status dashboard + prints `avo --help` hint
- **Default jira status** (#21): `avo jira` with no subcommand runs `jira status` + prints `avo jira --help` hint

Closes #19, closes #20, closes #21

## Test plan

- [x] `dart compile exe mcp/bin/avo.dart` produces working binary (11ms startup)
- [x] `avo` (no args) shows status dashboard + help hint
- [x] `avo --help` works unchanged
- [x] `avo jira` shows jira status + help hint
- [x] `avo jira --help` works unchanged
- [x] `avo jira status` works unchanged
- [x] 92 tests pass (`cd mcp && dart test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)