### PR TITLE
fix(cli): support task ID prefix matching in start command

### DIFF
--- a/mcp/bin/avo.dart
+++ b/mcp/bin/avo.dart
@@ -58,7 +58,7 @@ Future<void> main(List<String> args) async {
       'avo',
       'Avodah - Worklog tracking from the command line',
     )
-      ..addCommand(StartCommand(timerService))
+      ..addCommand(StartCommand(timerService, taskService))
       ..addCommand(StopCommand(timerService))
       ..addCommand(StatusCommand(
         timerService: timerService,


### PR DESCRIPTION
## Summary
- `avo start <id-prefix>` now resolves an existing task by ID prefix instead of creating a new task titled with the ID string
- Handles ambiguous prefix matches with user-friendly error message
- Falls back to title-based lookup/creation when input doesn't match any task ID

## Test plan
- [x] All 92 existing tests pass
- [x] Verified `StartCommand` wiring in `avo.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)