### PR TITLE
feat: centralized version management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Version Roadmap
+
+| Version | Scope |
+|---------|-------|
+| **0.x.y** | Pre-stable — key features being built and tested |
+| **0.2.0** | Next capability milestone (e.g., full Jira coverage, GitHub integration) |
+| **1.0.0** | Fully functional CLI + MCP integration for AI usage |
+| **2.0.0** | Flutter UI with Linux & Android |
+
+## [0.1.0] - 2026-02-13
+
+First tagged release — CLI-first time tracking with Jira integration.
+
+### Added
+
+**Timer & Time Tracking**
+- Timer with start, stop, pause, resume, and cancel
+- Automatic worklog creation on timer stop
+- Manual time entry via `avo log <task> <duration>` (e.g., `1h30m`)
+- Today's work summary by task (`avo today`)
+- Weekly work summary with bar chart (`avo week`)
+- Recent worklogs view (`avo recent`)
+- Worklog deletion (`avo worklog delete`)
+
+**Task Management**
+- Task CRUD: add, list, show, done, delete
+- Task ID prefix matching (type first few chars instead of full UUID)
+- Interactive task picker for `avo start` with no arguments
+- Due dates with overdue tracking (`avo task due`)
+- Task categories: Learning, Working, Side-project, Family & Friends, Personal (`avo task cat`)
+- Filter tasks by source, project, Jira profile, or local-only
+- Task descriptions and time estimates
+
+**Project Management**
+- Project CRUD: add, list, show, delete
+- Project icons
+- Task count per project
+
+**Daily Planning**
+- Plan time by category (`avo plan add`)
+- Plan-vs-actual comparison with progress indicators (`avo plan list`)
+- Configurable categories via `~/.config/avodah/config.json`
+
+**Jira Integration**
+- 2-way sync: pull issues from Jira, push worklogs to Jira
+- Multi-profile support (e.g., work, personal Jira instances)
+- Interactive setup wizard (`avo jira setup`)
+- Credentials template generator (`avo jira init`)
+- Conflict resolution for title/duration mismatches
+- Sync preview with dry-run mode (`--dry-run`)
+- Auto-push worklogs on timer stop
+- Sync progress indicators
+- Per-profile default category for auto-categorization
+- Done-status sync between Jira and local tasks
+
+**Dashboard**
+- `avo status` dashboard: active timer, today's summary, open tasks, daily plan
+- `avo` with no arguments runs status + help hint
+- Smart defaults: `avo jira` → status, `avo plan` → list
+
+**MCP Server**
+- JSON-RPC 2.0 over stdio (MCP protocol 2024-11-05)
+- Tools: timer, tasks, today, jira
+- Resources: `avodah://status` (current state as JSON)
+
+**Architecture**
+- CRDT-based documents for future P2P sync (Task, Worklog, Timer, Project, DailyPlan, JiraIntegration)
+- Hybrid logical clocks with persistent node IDs
+- Drift (SQLite) database with 8 tables (schema v7)
+- Shared `avodah_core` package between Flutter app and CLI
+- Service layer with dependency injection (db + clock)
+
+**Infrastructure**
+- Nix flake: devShell with Flutter + Dart + Android SDK
+- Nix package: `buildDartApplication` for native `avo` binary
+- Fish shell completions for all commands and subcommands
+- Auto-compiling `avo` wrapper in devShell (recompiles on source changes)
+
+**Flutter App (scaffold)**
+- App shell with bottom navigation
+- Screens: Tasks, Timer, Projects, Settings
+- Material Design theming
+
+[0.1.0]: https://github.com/sinh-x/avodah/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ See `.kiro/specs/sp-flutter-migration/` for detailed:
 
 **Avodah** (עבודה) is a Hebrew word meaning "work," "service," and "worship." In Jewish tradition, it represents the idea that work itself can be a form of divine service—transforming everyday tasks into something meaningful.
 
+## Versioning
+
+Avodah follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for release notes.
+
+| Version | Milestone |
+|---------|-----------|
+| **0.x.y** | Pre-stable — core features being built and tested |
+| **0.1.0** | CLI time tracking, task management, Jira 2-way sync, daily planning, MCP server |
+| **0.2.0** | Next capability area (e.g., full Jira coverage, GitHub integration) |
+| **1.0.0** | Fully functional CLI + MCP integration for AI-assisted usage |
+| **2.0.0** | Flutter UI with Linux & Android |
+
+**Pre-1.0 convention:** minor bumps (0.x.0) for new capability areas or breaking changes; patch bumps (0.x.y) for bug fixes and polish within a capability.
+
 ## License
 
 MIT

--- a/completions/avo.fish
+++ b/completions/avo.fish
@@ -3,6 +3,9 @@
 # Disable file completions by default
 complete -c avo -f
 
+# Global options
+complete -c avo -n __fish_use_subcommand -l version -d 'Show version'
+
 # Top-level commands
 complete -c avo -n __fish_use_subcommand -a start -d 'Start timer on a task'
 complete -c avo -n __fish_use_subcommand -a stop -d 'Stop timer and log time'

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:avodah_core/avodah_core.dart' show avodahVersion;
 import 'package:flutter/material.dart';
 
 class SettingsScreen extends StatelessWidget {
@@ -48,7 +49,7 @@ class SettingsScreen extends StatelessWidget {
           ListTile(
             leading: const Icon(Icons.info_outline),
             title: const Text('About'),
-            subtitle: const Text('Avodah v0.1.0'),
+            subtitle: Text('Avodah v$avodahVersion'),
             onTap: () {
               // TODO: About dialog
             },

--- a/mcp/bin/avo.dart
+++ b/mcp/bin/avo.dart
@@ -27,7 +27,7 @@ library;
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:avodah_core/avodah_core.dart';
+import 'package:avodah_core/avodah_core.dart' show HybridLogicalClock, avodahVersion;
 import 'package:avodah_mcp/cli/commands.dart';
 import 'package:avodah_mcp/config/avo_config.dart';
 import 'package:avodah_mcp/config/paths.dart';
@@ -40,6 +40,12 @@ import 'package:avodah_mcp/services/worklog_service.dart';
 import 'package:avodah_mcp/storage/database_opener.dart';
 
 Future<void> main(List<String> args) async {
+  // Handle --version / -v before any initialization
+  if (args.contains('--version') || args.contains('-v')) {
+    print('avodah (עבודה) $avodahVersion');
+    return;
+  }
+
   // Initialize paths and database
   final paths = AvodahPaths();
   await paths.ensureDirectories();

--- a/mcp/lib/tools/mcp_server.dart
+++ b/mcp/lib/tools/mcp_server.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:avodah_core/avodah_core.dart' show avodahVersion;
 import 'package:avodah_mcp/config/paths.dart';
 import 'package:avodah_mcp/services/jira_service.dart';
 import 'package:avodah_mcp/services/project_service.dart';
@@ -24,7 +25,7 @@ class McpServer {
   final AvodahPaths paths;
 
   static const String serverName = 'avodah';
-  static const String serverVersion = '0.1.0';
+  static String get serverVersion => avodahVersion;
 
   McpServer({
     required this.timerService,

--- a/packages/avodah_core/lib/avodah_core.dart
+++ b/packages/avodah_core/lib/avodah_core.dart
@@ -26,3 +26,6 @@ export 'documents/project_document.dart';
 export 'documents/task_document.dart';
 export 'documents/timer_document.dart';
 export 'documents/worklog_document.dart';
+
+// Version
+export 'version.dart';

--- a/packages/avodah_core/lib/version.dart
+++ b/packages/avodah_core/lib/version.dart
@@ -1,0 +1,3 @@
+/// Single source of truth for the Avodah version.
+/// Updated by tool/bump_version.dart — do not edit manually.
+const String avodahVersion = '0.1.0';

--- a/tool/bump_version.dart
+++ b/tool/bump_version.dart
@@ -1,0 +1,264 @@
+#!/usr/bin/env dart
+
+/// Bumps the Avodah version across all files.
+///
+/// Usage:
+///   dart run tool/bump_version.dart <version>
+///   dart run tool/bump_version.dart patch|minor|major
+///
+/// Updates:
+///   - packages/avodah_core/lib/version.dart  (source of truth)
+///   - packages/avodah_core/pubspec.yaml
+///   - mcp/pubspec.yaml
+///   - pubspec.yaml                           (root Flutter app)
+///   - flake.nix
+///   - CHANGELOG.md                           (adds new section from git log)
+import 'dart:io';
+
+void main(List<String> args) {
+  if (args.isEmpty || args.first == '--help' || args.first == '-h') {
+    print('Usage: dart run tool/bump_version.dart <version|patch|minor|major>');
+    exit(0);
+  }
+
+  final rootDir = _findRoot();
+  final currentVersion = _readCurrentVersion(rootDir);
+  final newVersion = _resolveVersion(currentVersion, args.first);
+
+  if (newVersion == currentVersion) {
+    print('Already at version $currentVersion — nothing to do.');
+    exit(0);
+  }
+
+  print('Bumping $currentVersion → $newVersion\n');
+
+  // 1. version.dart (source of truth)
+  _replaceInFile(
+    File('$rootDir/packages/avodah_core/lib/version.dart'),
+    "const String avodahVersion = '$currentVersion';",
+    "const String avodahVersion = '$newVersion';",
+  );
+
+  // 2. packages/avodah_core/pubspec.yaml
+  _replacePubspecVersion(
+    File('$rootDir/packages/avodah_core/pubspec.yaml'),
+    currentVersion,
+    newVersion,
+  );
+
+  // 3. mcp/pubspec.yaml
+  _replacePubspecVersion(
+    File('$rootDir/mcp/pubspec.yaml'),
+    currentVersion,
+    newVersion,
+  );
+
+  // 4. Root pubspec.yaml (Flutter — version: X.Y.Z+build)
+  final rootPubspec = File('$rootDir/pubspec.yaml');
+  final rootContent = rootPubspec.readAsStringSync();
+  final rootPattern = RegExp(r'version:\s*' + RegExp.escape(currentVersion) + r'(\+\d+)?');
+  final rootMatch = rootPattern.firstMatch(rootContent);
+  if (rootMatch != null) {
+    final buildSuffix = rootMatch.group(1) ?? '+1';
+    final updated = rootContent.replaceFirst(
+      rootMatch.group(0)!,
+      'version: $newVersion$buildSuffix',
+    );
+    rootPubspec.writeAsStringSync(updated);
+    print('  Updated pubspec.yaml');
+  } else {
+    print('  WARNING: Could not find version in pubspec.yaml');
+  }
+
+  // 5. flake.nix
+  _replaceInFile(
+    File('$rootDir/flake.nix'),
+    'version = "$currentVersion"',
+    'version = "$newVersion"',
+  );
+
+  // 6. CHANGELOG.md — prepend new section
+  _updateChangelog(rootDir, currentVersion, newVersion);
+
+  // Summary
+  print('');
+  print('Done! Updated 6 files to $newVersion.');
+  print('');
+  print('Next steps:');
+  print('  git add -A && git commit -m "chore: bump version to $newVersion"');
+  print('  git tag v$newVersion');
+  print('  git push origin main --tags');
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+String _findRoot() {
+  var dir = Directory.current;
+  while (true) {
+    if (File('${dir.path}/pubspec.yaml').existsSync() &&
+        Directory('${dir.path}/packages').existsSync()) {
+      return dir.path;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      print('Error: Could not find project root.');
+      exit(1);
+    }
+    dir = parent;
+  }
+}
+
+String _readCurrentVersion(String rootDir) {
+  final file = File('$rootDir/packages/avodah_core/lib/version.dart');
+  final content = file.readAsStringSync();
+  final match = RegExp(r"avodahVersion\s*=\s*'([^']+)'").firstMatch(content);
+  if (match == null) {
+    print('Error: Could not read current version from version.dart');
+    exit(1);
+  }
+  return match.group(1)!;
+}
+
+String _resolveVersion(String current, String arg) {
+  final parts = current.split('.').map(int.parse).toList();
+  if (parts.length != 3) {
+    print('Error: Current version "$current" is not semver.');
+    exit(1);
+  }
+
+  switch (arg) {
+    case 'major':
+      return '${parts[0] + 1}.0.0';
+    case 'minor':
+      return '${parts[0]}.${parts[1] + 1}.0';
+    case 'patch':
+      return '${parts[0]}.${parts[1]}.${parts[2] + 1}';
+    default:
+      // Validate explicit version
+      if (!RegExp(r'^\d+\.\d+\.\d+$').hasMatch(arg)) {
+        print('Error: "$arg" is not a valid semver version or bump keyword.');
+        exit(1);
+      }
+      return arg;
+  }
+}
+
+void _replaceInFile(File file, String from, String to) {
+  final content = file.readAsStringSync();
+  if (!content.contains(from)) {
+    print('  WARNING: Pattern not found in ${file.path}');
+    return;
+  }
+  file.writeAsStringSync(content.replaceFirst(from, to));
+  print('  Updated ${file.uri.pathSegments.last}');
+}
+
+void _replacePubspecVersion(File file, String from, String to) {
+  final content = file.readAsStringSync();
+  final pattern = RegExp(r'version:\s*' + RegExp.escape(from));
+  if (!pattern.hasMatch(content)) {
+    print('  WARNING: Could not find version in ${file.path}');
+    return;
+  }
+  file.writeAsStringSync(content.replaceFirst(pattern, 'version: $to'));
+  print('  Updated ${file.uri.pathSegments.last}');
+}
+
+void _updateChangelog(String rootDir, String oldVersion, String newVersion) {
+  final changelog = File('$rootDir/CHANGELOG.md');
+  if (!changelog.existsSync()) {
+    print('  WARNING: CHANGELOG.md not found, skipping.');
+    return;
+  }
+
+  // Get commits since last tag
+  final tag = 'v$oldVersion';
+  final result = Process.runSync('git', ['log', '$tag..HEAD', '--oneline']);
+  final commits = (result.stdout as String)
+      .split('\n')
+      .where((l) => l.trim().isNotEmpty)
+      .toList();
+
+  // Categorize commits
+  final added = <String>[];
+  final fixed = <String>[];
+  final changed = <String>[];
+
+  for (final commit in commits) {
+    // Strip hash prefix
+    final msg = commit.replaceFirst(RegExp(r'^[a-f0-9]+\s+'), '');
+    // Strip conventional commit prefix for display
+    final display = msg.replaceFirst(RegExp(r'^(feat|fix|chore|refactor|docs|test|ci)(\([^)]*\))?:\s*'), '');
+    final capitalised = display[0].toUpperCase() + display.substring(1);
+
+    if (msg.startsWith('feat')) {
+      added.add(capitalised);
+    } else if (msg.startsWith('fix')) {
+      fixed.add(capitalised);
+    } else {
+      changed.add(capitalised);
+    }
+  }
+
+  // Build new section
+  final today = DateTime.now().toIso8601String().substring(0, 10);
+  final buf = StringBuffer();
+  buf.writeln('## [$newVersion] - $today');
+  buf.writeln('');
+  if (added.isNotEmpty) {
+    buf.writeln('### Added');
+    for (final a in added) {
+      buf.writeln('- $a');
+    }
+    buf.writeln('');
+  }
+  if (fixed.isNotEmpty) {
+    buf.writeln('### Fixed');
+    for (final f in fixed) {
+      buf.writeln('- $f');
+    }
+    buf.writeln('');
+  }
+  if (changed.isNotEmpty) {
+    buf.writeln('### Changed');
+    for (final c in changed) {
+      buf.writeln('- $c');
+    }
+    buf.writeln('');
+  }
+  if (commits.isEmpty) {
+    buf.writeln('_No conventional commits since $oldVersion._');
+    buf.writeln('');
+  }
+
+  // Insert after the header line "## [old..."
+  var content = changelog.readAsStringSync();
+  final insertPoint = content.indexOf('\n## [');
+  if (insertPoint >= 0) {
+    content = content.substring(0, insertPoint + 1) +
+        buf.toString() +
+        content.substring(insertPoint + 1);
+  } else {
+    // No existing section — append before EOF
+    content += '\n${buf.toString()}';
+  }
+
+  // Update link references at bottom
+  final linkLine =
+      '[$newVersion]: https://github.com/sinh-x/avodah/compare/v$oldVersion...v$newVersion';
+  if (!content.contains('[$newVersion]')) {
+    // Insert new link before the old version link
+    final oldLink = '[$oldVersion]:';
+    final linkPos = content.indexOf(oldLink);
+    if (linkPos >= 0) {
+      content = content.substring(0, linkPos) +
+          '$linkLine\n' +
+          content.substring(linkPos);
+    } else {
+      content += '\n$linkLine\n';
+    }
+  }
+
+  changelog.writeAsStringSync(content);
+  print('  Updated CHANGELOG.md');
+}


### PR DESCRIPTION
## Summary
- Add `packages/avodah_core/lib/version.dart` as single source of truth for version
- Wire shared constant to MCP server, CLI `--version`/`-v` flag, and Flutter settings screen
- Create `tool/bump_version.dart` that updates all 6 locations (version.dart, 3 pubspec.yaml, flake.nix, CHANGELOG.md)
- Seed `CHANGELOG.md` with comprehensive 0.1.0 release notes covering all features built so far
- Add version roadmap to README.md (0.x → 1.0.0 CLI+MCP → 2.0.0 Flutter UI)
- Add `--version` fish completion

## Test plan
- [x] `cd mcp && dart test` — 139 tests pass
- [x] `avo --version` → `avodah (עבודה) 0.1.0` (exits immediately, no DB hang)
- [x] `avo -v` → same output
- [x] `avo` with no args → still shows status (no regression)
- [x] `dart run tool/bump_version.dart patch` → updates all 6 files to 0.1.1 (verified, reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)