### PR TITLE
feat(cli): avo daily command and avo week enhancements

### DIFF
--- a/mcp/bin/avo.dart
+++ b/mcp/bin/avo.dart
@@ -16,7 +16,7 @@
 ///
 ///   avo today                 Today's summary
 ///   avo daily [YYYY-MM-DD]    Daily report for any date
-///   avo week                  Weekly report with categories
+///   avo week [FROM] [TO]       Weekly/range report with categories
 ///
 ///   avo jira sync             Sync with Jira
 ///   avo jira status           Show Jira sync status

--- a/mcp/lib/services/worklog_service.dart
+++ b/mcp/lib/services/worklog_service.dart
@@ -69,27 +69,41 @@ class WorklogService {
     return _buildDaySummary(date, rows);
   }
 
-  /// Returns this week's summary (Mon-Sun), one DaySummary per day.
-  Future<List<DaySummary>> weekSummary() async {
-    final now = DateTime.now();
-    // Monday of current week
-    final monday = now.subtract(Duration(days: now.weekday - 1));
-
+  /// Returns summaries for a date range, one DaySummary per day.
+  ///
+  /// This is the core primitive — [weekSummary] derives from this.
+  Future<List<DaySummary>> rangeSummary({
+    required DateTime from,
+    required DateTime to,
+  }) async {
     final days = <String>[];
-    for (var i = 0; i < 7; i++) {
-      days.add(_formatDate(monday.add(Duration(days: i))));
+    var current = DateTime(from.year, from.month, from.day);
+    final end = DateTime(to.year, to.month, to.day);
+    while (!current.isAfter(end)) {
+      days.add(_formatDate(current));
+      current = current.add(const Duration(days: 1));
     }
 
     final rows = await db.select(db.worklogEntries).get();
-    final weekRows = rows.where((r) => days.contains(r.date)).toList();
+    final rangeRows = rows.where((r) => days.contains(r.date)).toList();
 
     final summaries = <DaySummary>[];
     for (final day in days) {
-      final dayRows = weekRows.where((r) => r.date == day).toList();
+      final dayRows = rangeRows.where((r) => r.date == day).toList();
       summaries.add(_buildDaySummary(day, dayRows));
     }
 
     return summaries;
+  }
+
+  /// Returns this week's summary (Mon-Sun), one DaySummary per day.
+  ///
+  /// Convenience wrapper around [rangeSummary].
+  Future<List<DaySummary>> weekSummary({DateTime? anchor}) async {
+    final now = anchor ?? DateTime.now();
+    final monday = now.subtract(Duration(days: now.weekday - 1));
+    final sunday = monday.add(const Duration(days: 6));
+    return rangeSummary(from: monday, to: sunday);
   }
 
   /// Creates a manual worklog entry.


### PR DESCRIPTION
## Summary
- **`avo daily [YYYY-MM-DD]`** — new command showing the same dashboard as `avo status` (worklog, tasks, plan-vs-actual) but for any date, defaulting to today
- **`avo week`** — enhanced with CATEGORIES section (plan vs actual aggregated across Mon-Sun) and TASKS section (all tasks worked on with done/not-done status, sorted by time)

### New service methods
- `WorklogService.daySummary(date)` — generalizes `todaySummary()` to accept any date string
- `PlanService.weekSummary({anchor})` — aggregates plan-vs-actual across a full week

## Test plan
- [x] 179 tests passing (up from 136), including new tests for `daySummary`, `weekSummary`
- [x] `avo daily` shows today's dashboard
- [x] `avo daily 2026-02-17` shows a past date's dashboard
- [x] `avo week` shows bar chart + categories breakdown + task list
- [x] `dart analyze` clean (no new warnings)

Closes #51, closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)