### PR TITLE
fix: auto-sync worklog to Jira on manual log

### DIFF
--- a/mcp/bin/avo.dart
+++ b/mcp/bin/avo.dart
@@ -85,7 +85,8 @@ Future<void> main(List<String> args) async {
       ..addCommand(CancelCommand(timerService))
       ..addCommand(TaskCommand(taskService, worklogService, projectService, jiraService))
       ..addCommand(ProjectCommand(projectService))
-      ..addCommand(WorklogCommand(worklogService, taskService))
+      ..addCommand(WorklogCommand(worklogService, taskService,
+          jiraService: jiraService))
       ..addCommand(TodayCommand(
           worklogService: worklogService, taskService: taskService))
       ..addCommand(WeekCommand(


### PR DESCRIPTION
## Summary
- `avo worklog add` now auto-pushes worklogs to Jira, matching existing `avo stop` behavior
- Previously manual worklogs required a separate `avo jira sync` to push

## Changes
- Thread `jiraService` through `WorklogCommand` → `WorklogSubcommand` → `WorklogAddCommand`
- Call `pushWorklog()` after worklog creation in `WorklogAddCommand`
- Wire `jiraService` in `avo.dart` entry point

## Test plan
- [x] 183 tests passing
- [x] Manual: `avo worklog add -t <jira-linked-task> -d 30m` → should print `Jira: worklog synced`
- [x] Manual: `avo worklog add -t <local-only-task> -d 30m` → no Jira output (graceful skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)