### PR TITLE
ci: add auto version bump workflows

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,62 @@
+name: Beta
+
+on:
+  push:
+    branches: [develop]
+
+concurrency:
+  group: beta-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  beta:
+    # Skip bot commits to prevent infinite loops
+    if: "!startsWith(github.event.head_commit.message, 'chore(ci):')"
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run MCP tests
+        run: |
+          cd mcp
+          dart pub get
+          dart test
+
+      - name: Bump build number
+        id: bump
+        run: |
+          dart run tool/bump_build.dart
+          BUILD=$(grep -oP 'version:\s*\d+\.\d+\.\d+\+\K\d+' pubspec.yaml)
+          VERSION=$(grep -oP 'version:\s*\K\d+\.\d+\.\d+' pubspec.yaml)
+          echo "build=$BUILD" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Commit build bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pubspec.yaml
+          git commit -m "chore(ci): bump build to +${{ steps.bump.outputs.build }}"
+          git push
+
+      - name: Create beta tag
+        run: |
+          TAG="v${{ steps.bump.outputs.version }}-beta.${{ steps.bump.outputs.build }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Created tag: $TAG"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   build:
+    if: "!startsWith(github.event.head_commit.message, 'chore(ci):')"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    # Skip version bump commits and bot commits
+    if: >-
+      !startsWith(github.event.head_commit.message, 'chore: bump version') &&
+      !startsWith(github.event.head_commit.message, 'chore(ci):')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run MCP tests
+        run: |
+          cd mcp
+          dart pub get
+          dart test
+
+      - name: Detect bump type
+        id: detect
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            RANGE="HEAD"
+          else
+            RANGE="${LAST_TAG}..HEAD"
+          fi
+
+          COMMITS=$(git log "$RANGE" --pretty=format:"%s")
+
+          if echo "$COMMITS" | grep -qiE "BREAKING[ -]CHANGE|^[a-z]+(\([^)]*\))?!:"; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif echo "$COMMITS" | grep -qE "^feat(\([^)]*\))?:"; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "Detected bump type: $(grep type "$GITHUB_OUTPUT" | cut -d= -f2)"
+
+      - name: Bump version
+        id: version
+        run: |
+          dart run tool/bump_version.dart ${{ steps.detect.outputs.type }}
+
+          # Reset build number to +1
+          sed -i -E 's/(version:\s*[0-9]+\.[0-9]+\.[0-9]+)\+[0-9]+/\1+1/' pubspec.yaml
+
+          VERSION=$(grep -oP "avodahVersion\s*=\s*'\K[^']+" packages/avodah_core/lib/version.dart)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
+          git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
+          git push
+          git push origin "v${{ steps.version.outputs.version }}"
+
+      - name: Extract changelog
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Extract the section for this version from CHANGELOG.md
+          BODY=$(sed -n "/^## \[$VERSION\]/,/^## \[/{ /^## \[$VERSION\]/d; /^## \[/d; p; }" CHANGELOG.md)
+          # Use a delimiter for multiline output
+          echo "body<<CHANGELOG_EOF" >> "$GITHUB_OUTPUT"
+          echo "$BODY" >> "$GITHUB_OUTPUT"
+          echo "CHANGELOG_EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --notes "${{ steps.changelog.outputs.body }}"

--- a/tool/bump_build.dart
+++ b/tool/bump_build.dart
@@ -1,0 +1,52 @@
+#!/usr/bin/env dart
+
+/// Increments the Flutter build number (+N) in root pubspec.yaml.
+///
+/// Usage:
+///   dart run tool/bump_build.dart
+///
+/// Reads `version: X.Y.Z+N`, increments N by 1, writes back.
+/// Only touches root pubspec.yaml (build suffix is Flutter-specific).
+import 'dart:io';
+
+void main() {
+  final rootDir = _findRoot();
+  final pubspecFile = File('$rootDir/pubspec.yaml');
+  final content = pubspecFile.readAsStringSync();
+
+  final pattern = RegExp(r'version:\s*(\d+\.\d+\.\d+)\+(\d+)');
+  final match = pattern.firstMatch(content);
+
+  if (match == null) {
+    print('Error: Could not find version+build in pubspec.yaml');
+    exit(1);
+  }
+
+  final version = match.group(1)!;
+  final currentBuild = int.parse(match.group(2)!);
+  final newBuild = currentBuild + 1;
+
+  final updated = content.replaceFirst(
+    match.group(0)!,
+    'version: $version+$newBuild',
+  );
+
+  pubspecFile.writeAsStringSync(updated);
+  print('Bumped build: $version+$currentBuild → $version+$newBuild');
+}
+
+String _findRoot() {
+  var dir = Directory.current;
+  while (true) {
+    if (File('${dir.path}/pubspec.yaml').existsSync() &&
+        Directory('${dir.path}/packages').existsSync()) {
+      return dir.path;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      print('Error: Could not find project root.');
+      exit(1);
+    }
+    dir = parent;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `tool/bump_build.dart` to increment Flutter build number (`+N`) in root pubspec
- Adds **beta.yml** workflow on `develop`: runs MCP tests, bumps build, commits, creates `v*-beta.N` tag
- Adds **release.yml** workflow on `main`: runs MCP tests, auto-detects bump type from conventional commits (`feat:` → minor, `fix:` → patch, `BREAKING` → major), bumps version, resets build to `+1`, tags, creates GitHub Release with changelog
- Updates **ci.yml** with `develop` triggers and bot-commit skip condition

Closes #56

## Test plan
- [x] Run `dart run tool/bump_build.dart` locally — verified `0.3.0+1 → 0.3.0+2`
- [ ] Merge to develop → verify beta workflow runs, `v*-beta.N` tag created
- [ ] Merge to main → verify release workflow runs, version bumped, GitHub Release created

🤖 Generated with [Claude Code](https://claude.com/claude-code)