### PR TITLE
fix: devshell avo wrapper watches avodah_core for recompilation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -125,8 +125,10 @@
             MCP_DIR="$(git rev-parse --show-toplevel)/mcp"
             BIN="$MCP_DIR/bin/avo"
 
+            ROOT="$(git rev-parse --show-toplevel)"
+
             # Recompile if binary is missing or any dart source is newer
-            if [ ! -f "$BIN" ] || [ -n "$(find "$MCP_DIR/lib" "$MCP_DIR/bin/avo.dart" -newer "$BIN" 2>/dev/null | head -1)" ]; then
+            if [ ! -f "$BIN" ] || [ -n "$(find "$MCP_DIR/lib" "$MCP_DIR/bin/avo.dart" "$ROOT/packages/avodah_core/lib" -newer "$BIN" 2>/dev/null | head -1)" ]; then
               echo "Compiling avo..." >&2
               (cd "$MCP_DIR" && dart compile exe bin/avo.dart -o bin/avo) >&2
             fi


### PR DESCRIPTION
## Summary
- The devshell `avo` wrapper only checked `mcp/lib` for source changes when deciding to recompile
- `packages/avodah_core/lib` (where `version.dart` lives) was not watched, causing stale binaries after version bumps
- Now includes `packages/avodah_core/lib` in the staleness check

## Test plan
- [ ] Enter devshell, `rm mcp/bin/avo`, run `avo --version` — recompiles and shows `0.3.0-beta.N`
- [ ] Edit `packages/avodah_core/lib/version.dart`, run `avo --version` — triggers recompile

🤖 Generated with [Claude Code](https://claude.com/claude-code)