### PR TITLE
feat: worklog guards, undone/undelete, --deleted list (#72, #73)

### DIFF
--- a/mcp/lib/services/worklog_service.dart
+++ b/mcp/lib/services/worklog_service.dart
@@ -236,6 +236,25 @@ class WorklogService {
     return docs.take(limit).toList();
   }
 
+  /// Returns worklog count and total duration for a task (excludes deleted).
+  Future<({int count, Duration total})> worklogInfoForTask(
+      String taskId) async {
+    final rows = await (db.select(db.worklogEntries)
+          ..where((w) => w.taskId.equals(taskId)))
+        .get();
+
+    var count = 0;
+    var totalMs = 0;
+    for (final row in rows) {
+      final doc = WorklogDocument.fromDrift(worklog: row, clock: clock);
+      if (doc.isDeleted) continue;
+      count++;
+      totalMs += doc.durationMs;
+    }
+
+    return (count: count, total: Duration(milliseconds: totalMs));
+  }
+
   /// Returns all non-deleted worklogs for a specific task.
   Future<List<WorklogDocument>> listForTask(String taskId) async {
     final rows = await (db.select(db.worklogEntries)


### PR DESCRIPTION
## Summary

- **Worklog guard on task deletion (#72)**: `avo task delete` now warns when a task has logged worklogs (showing count + total time) and requires confirmation. `--force` skips all checks. MCP returns a structured error with worklog info unless `force: true`.
- **Undone/Undelete commands (#73)**: `avo task undone <id>` reverses a done task. `avo task undelete <id>` restores a soft-deleted task. `avo task list --deleted` shows only deleted tasks. All three are also available via MCP (`undone`, `undelete` actions, `includeDeleted` param).
- 19 new tests (220 total), all passing.

## Test plan

- [x] `cd mcp && dart test` — 220 tests pass
- [ ] Manual: `avo task delete <id>` warns on worklogs, `--force` bypasses
- [ ] Manual: `avo task done <id>` then `avo task undone <id>` round-trips
- [ ] Manual: `avo task delete <id>` then `avo task list --deleted` then `avo task undelete <id>` round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)