### PR TITLE
feat(phone): deployment display improvements — activity timeline, auto-refresh, error details

### DIFF
--- a/mcp/lib/services/agent_api_service.dart
+++ b/mcp/lib/services/agent_api_service.dart
@@ -118,6 +118,10 @@ class AgentApiService {
         await _handleGetFeedbackChips(request);
       } else if (path == '/api/deployments' && method == 'GET') {
         await _handleListDeployments(request);
+      } else if (path.startsWith('/api/deployments/') &&
+          path.endsWith('/activity') &&
+          method == 'GET') {
+        await _handleGetDeploymentActivity(request);
       } else if (path == '/api/teams' && method == 'GET') {
         await _handleListTeams(request);
       } else if (path.startsWith('/api/teams/') && method == 'GET') {
@@ -774,6 +778,67 @@ class AgentApiService {
     _jsonResponse(request, HttpStatus.ok, {
       'deployments': deployments.map((d) => d.toJson()).toList(),
     });
+  }
+
+  /// GET /api/deployments/{id}/activity — Return activity.jsonl events.
+  ///
+  /// Query params:
+  ///   ?since=<ISO timestamp> — return only events after this timestamp
+  ///
+  /// Returns a JSON object with an `events` array. Each event has:
+  ///   ts, deploy_id, agent, event, data
+  Future<void> _handleGetDeploymentActivity(HttpRequest request) async {
+    final segments = request.uri.pathSegments;
+    // Path: /api/deployments/{id}/activity → segments: [api, deployments, {id}, activity]
+    if (segments.length < 4) {
+      _jsonResponse(
+          request, HttpStatus.badRequest, {'error': 'Missing deployment id'});
+      return;
+    }
+    final deployId = segments[2];
+
+    // Validate deployment id — must be alphanumeric with hyphens, no path traversal
+    if (!RegExp(r'^[a-zA-Z0-9\-]+$').hasMatch(deployId)) {
+      _jsonResponse(
+          request, HttpStatus.badRequest, {'error': 'Invalid deployment id'});
+      return;
+    }
+
+    final activityPath = p.join(
+        p.dirname(registryPath), // deployments/
+        deployId,
+        'activity.jsonl');
+    final file = File(activityPath);
+
+    if (!file.existsSync()) {
+      _jsonResponse(request, HttpStatus.ok, {'events': []});
+      return;
+    }
+
+    final sinceParam = request.uri.queryParameters['since'];
+    String? sinceTs;
+    if (sinceParam != null && sinceParam.isNotEmpty) {
+      sinceTs = sinceParam;
+    }
+
+    final events = <Map<String, dynamic>>[];
+    for (final line in file.readAsLinesSync()) {
+      final trimmed = line.trim();
+      if (trimmed.isEmpty) continue;
+      try {
+        final json = jsonDecode(trimmed) as Map<String, dynamic>;
+        // Filter by since timestamp if provided (string comparison works for ISO 8601)
+        if (sinceTs != null) {
+          final ts = json['ts'] as String?;
+          if (ts == null || ts.compareTo(sinceTs) <= 0) continue;
+        }
+        events.add(json);
+      } catch (e) {
+        stderr.writeln('Skipping malformed activity line: $e');
+      }
+    }
+
+    _jsonResponse(request, HttpStatus.ok, {'events': events});
   }
 
   /// GET /api/teams — List agent teams.

--- a/mcp/lib/services/registry_parser.dart
+++ b/mcp/lib/services/registry_parser.dart
@@ -18,6 +18,9 @@ class RegistryEvent {
   final String? summary;
   final List<String>? agents;
   final int? exitCode;
+  final Map<String, String>? models; // agent name → model id
+  final String? error;
+  final String? logFile;
 
   RegistryEvent({
     required this.deploymentId,
@@ -29,9 +32,17 @@ class RegistryEvent {
     this.summary,
     this.agents,
     this.exitCode,
+    this.models,
+    this.error,
+    this.logFile,
   });
 
   factory RegistryEvent.fromJson(Map<String, dynamic> json) {
+    Map<String, String>? models;
+    final rawModels = json['models'];
+    if (rawModels is Map) {
+      models = rawModels.map((k, v) => MapEntry(k.toString(), v.toString()));
+    }
     return RegistryEvent(
       deploymentId: json['deployment_id'] as String,
       team: json['team'] as String,
@@ -42,6 +53,9 @@ class RegistryEvent {
       summary: json['summary'] as String?,
       agents: (json['agents'] as List?)?.cast<String>(),
       exitCode: json['exit_code'] as int?,
+      models: models,
+      error: json['error'] as String?,
+      logFile: json['log_file'] as String?,
     );
   }
 
@@ -55,6 +69,9 @@ class RegistryEvent {
         if (summary != null) 'summary': summary,
         if (agents != null) 'agents': agents,
         if (exitCode != null) 'exit_code': exitCode,
+        if (models != null) 'models': models,
+        if (error != null) 'error': error,
+        if (logFile != null) 'log_file': logFile,
       };
 }
 
@@ -67,6 +84,10 @@ class DeploymentStatus {
   final String? completedAt;
   final String? summary;
   final List<String> agents;
+  final Map<String, String>? models; // agent name → model id
+  final String? error;
+  final int? exitCode;
+  final String? logFile;
 
   DeploymentStatus({
     required this.deploymentId,
@@ -76,6 +97,10 @@ class DeploymentStatus {
     this.completedAt,
     this.summary,
     this.agents = const [],
+    this.models,
+    this.error,
+    this.exitCode,
+    this.logFile,
   });
 
   Map<String, dynamic> toJson() => {
@@ -86,6 +111,10 @@ class DeploymentStatus {
         if (completedAt != null) 'completed_at': completedAt,
         if (summary != null) 'summary': summary,
         if (agents.isNotEmpty) 'agents': agents,
+        if (models != null) 'models': models,
+        if (error != null) 'error': error,
+        if (exitCode != null) 'exit_code': exitCode,
+        if (logFile != null) 'log_file': logFile,
       };
 }
 
@@ -133,14 +162,23 @@ List<DeploymentStatus> computeDeploymentStatuses(List<RegistryEvent> events) {
     String? completedAt;
     String? summary;
 
+    String? error;
+    int? exitCode;
+    String? logFile;
+
     if (crashed != null) {
       status = 'crashed';
       completedAt = crashed.timestamp;
       summary = crashed.summary;
+      error = crashed.error;
+      exitCode = crashed.exitCode;
+      logFile = crashed.logFile;
     } else if (completed != null) {
       status = completed.status ?? 'success';
       completedAt = completed.timestamp;
       summary = completed.summary;
+      exitCode = completed.exitCode;
+      logFile = completed.logFile;
     } else {
       status = 'running';
     }
@@ -153,6 +191,10 @@ List<DeploymentStatus> computeDeploymentStatuses(List<RegistryEvent> events) {
       completedAt: completedAt,
       summary: summary,
       agents: started?.agents ?? [],
+      models: started?.models,
+      error: error,
+      exitCode: exitCode,
+      logFile: logFile,
     ));
   }
 

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -263,7 +263,9 @@ class _HomeShellState extends State<_HomeShell> {
               ],
             ),
             body: DeploymentScreen(
-                deploymentProvider: widget.deploymentProvider),
+              deploymentProvider: widget.deploymentProvider,
+              apiClient: widget.apiClient,
+            ),
           ),
           Scaffold(
             appBar: AppBar(

--- a/phone/lib/models/activity_event.dart
+++ b/phone/lib/models/activity_event.dart
@@ -1,0 +1,63 @@
+/// A single event from a deployment's activity.jsonl timeline.
+class ActivityEvent {
+  final String ts;
+  final String deployId;
+  final String agent;
+  final String event;
+  final Map<String, dynamic> data;
+
+  const ActivityEvent({
+    required this.ts,
+    required this.deployId,
+    required this.agent,
+    required this.event,
+    this.data = const {},
+  });
+
+  factory ActivityEvent.fromJson(Map<String, dynamic> json) {
+    return ActivityEvent(
+      ts: json['ts'] as String? ?? '',
+      deployId: json['deploy_id'] as String? ?? '',
+      agent: json['agent'] as String? ?? '',
+      event: json['event'] as String? ?? '',
+      data: json['data'] as Map<String, dynamic>? ?? const {},
+    );
+  }
+
+  DateTime? get timestamp => DateTime.tryParse(ts);
+
+  /// Short label suitable for compact timeline display.
+  String get eventLabel {
+    switch (event) {
+      case 'agent_spawned':
+        return 'Agent spawned';
+      case 'agent_stopped':
+        return 'Agent stopped';
+      case 'task_completed':
+        return 'Task completed';
+      case 'task_failed':
+        return 'Task failed';
+      case 'tool_call':
+        final tool = data['tool'] as String?;
+        return tool != null ? 'Tool: $tool' : 'Tool call';
+      case 'deployment_started':
+        return 'Deployment started';
+      case 'deployment_completed':
+        return 'Deployment completed';
+      default:
+        return event;
+    }
+  }
+
+  bool get isMilestone {
+    const milestones = {
+      'agent_spawned',
+      'agent_stopped',
+      'task_completed',
+      'task_failed',
+      'deployment_started',
+      'deployment_completed',
+    };
+    return milestones.contains(event);
+  }
+}

--- a/phone/lib/models/deployment.dart
+++ b/phone/lib/models/deployment.dart
@@ -7,6 +7,10 @@ class Deployment {
   final String? completedAt;
   final String? summary;
   final List<String> agents;
+  final Map<String, String> models;
+  final String? error;
+  final int? exitCode;
+  final String? logFile;
 
   const Deployment({
     required this.deploymentId,
@@ -16,9 +20,14 @@ class Deployment {
     this.completedAt,
     this.summary,
     this.agents = const [],
+    this.models = const {},
+    this.error,
+    this.exitCode,
+    this.logFile,
   });
 
   factory Deployment.fromJson(Map<String, dynamic> json) {
+    final rawModels = json['models'] as Map<String, dynamic>?;
     return Deployment(
       deploymentId: json['deployment_id'] as String,
       team: json['team'] as String,
@@ -27,10 +36,32 @@ class Deployment {
       completedAt: json['completed_at'] as String?,
       summary: json['summary'] as String?,
       agents: (json['agents'] as List?)?.cast<String>() ?? const [],
+      models: rawModels?.map((k, v) => MapEntry(k, v as String)) ?? const {},
+      error: json['error'] as String?,
+      exitCode: json['exit_code'] as int?,
+      logFile: json['log_file'] as String?,
     );
   }
 
   bool get isRunning => status == 'running';
   bool get isSuccess => status == 'success';
   bool get isFailed => status == 'failed' || status == 'crashed';
+
+  /// Elapsed duration as a human-readable string.
+  ///
+  /// Uses [completedAt] if available, otherwise computes against now.
+  String get elapsedDuration {
+    final start = DateTime.tryParse(startedAt);
+    if (start == null) return '';
+    final end =
+        completedAt != null ? DateTime.tryParse(completedAt!) : DateTime.now();
+    if (end == null) return '';
+    final diff = end.difference(start);
+    final h = diff.inHours;
+    final m = diff.inMinutes.remainder(60);
+    final s = diff.inSeconds.remainder(60);
+    if (h > 0) return '${h}h ${m}m';
+    if (m > 0) return '${m}m ${s}s';
+    return '${s}s';
+  }
 }

--- a/phone/lib/screens/activity_timeline_screen.dart
+++ b/phone/lib/screens/activity_timeline_screen.dart
@@ -1,0 +1,425 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../models/activity_event.dart';
+import '../models/deployment.dart';
+import '../services/agent_api_client.dart';
+import '../widgets/activity_event_tile.dart';
+
+/// Full-screen activity timeline for a single deployment.
+///
+/// Shows a chronological event list with auto-refresh (every 4s) when the
+/// deployment is running. Has a compact/expanded toggle for event detail level.
+class ActivityTimelineScreen extends StatefulWidget {
+  final Deployment deployment;
+  final AgentApiClient client;
+
+  const ActivityTimelineScreen({
+    super.key,
+    required this.deployment,
+    required this.client,
+  });
+
+  @override
+  State<ActivityTimelineScreen> createState() => _ActivityTimelineScreenState();
+}
+
+class _ActivityTimelineScreenState extends State<ActivityTimelineScreen> {
+  List<ActivityEvent> _events = [];
+  bool _loading = true;
+  String? _error;
+  bool _expanded = false;
+  Timer? _refreshTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadEvents();
+    if (widget.deployment.isRunning) {
+      _scheduleRefresh();
+    }
+  }
+
+  @override
+  void dispose() {
+    _refreshTimer?.cancel();
+    super.dispose();
+  }
+
+  void _scheduleRefresh() {
+    _refreshTimer?.cancel();
+    _refreshTimer = Timer(const Duration(seconds: 4), () async {
+      await _loadEvents(background: true);
+      if (mounted && widget.deployment.isRunning) {
+        _scheduleRefresh();
+      }
+    });
+  }
+
+  Future<void> _loadEvents({bool background = false}) async {
+    if (!background) {
+      setState(() {
+        _loading = true;
+        _error = null;
+      });
+    }
+    try {
+      final events = await widget.client
+          .getDeploymentActivity(widget.deployment.deploymentId);
+      if (mounted) {
+        setState(() {
+          _events = events;
+          _loading = false;
+          _error = null;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = e.toString();
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final deployment = widget.deployment;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          deployment.deploymentId,
+          style: const TextStyle(fontFamily: 'monospace', fontSize: 16),
+        ),
+        actions: [
+          IconButton(
+            tooltip: _expanded ? 'Compact view' : 'Expanded view',
+            icon: Icon(_expanded ? Icons.unfold_less : Icons.unfold_more),
+            onPressed: () => setState(() => _expanded = !_expanded),
+          ),
+          IconButton(
+            tooltip: 'Refresh',
+            icon: const Icon(Icons.refresh),
+            onPressed: () => _loadEvents(),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          _DeploymentHeader(deployment: deployment),
+          if (_loading && _events.isEmpty)
+            const Expanded(
+              child: Center(child: CircularProgressIndicator()),
+            )
+          else if (_error != null && _events.isEmpty)
+            Expanded(child: _buildError())
+          else if (_events.isEmpty)
+            Expanded(child: _buildEmpty())
+          else
+            Expanded(
+              child: ListView.builder(
+                padding: const EdgeInsets.only(top: 8, bottom: 32),
+                itemCount: _events.length,
+                itemBuilder: (context, index) => ActivityEventTile(
+                  event: _events[index],
+                  expanded: _expanded,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildError() {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
+          const SizedBox(height: 12),
+          Text(
+            'Failed to load activity',
+            style:
+                theme.textTheme.bodyLarge?.copyWith(color: theme.colorScheme.error),
+          ),
+          const SizedBox(height: 8),
+          OutlinedButton.icon(
+            onPressed: _loadEvents,
+            icon: const Icon(Icons.refresh),
+            label: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmpty() {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.timeline, size: 48, color: theme.colorScheme.outline),
+          const SizedBox(height: 12),
+          Text(
+            'No events yet',
+            style: theme.textTheme.bodyLarge
+                ?.copyWith(color: theme.colorScheme.outline),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Header card with deployment metadata: status, duration, model badges,
+/// and error details section for failed/crashed deployments.
+class _DeploymentHeader extends StatelessWidget {
+  final Deployment deployment;
+
+  const _DeploymentHeader({required this.deployment});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = _statusColor(context, deployment.status);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerLow,
+        border: Border(
+          bottom: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Status + team + duration row
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(_statusIcon(deployment.status), color: color, size: 16),
+                  const SizedBox(width: 4),
+                  Text(
+                    deployment.status,
+                    style:
+                        theme.textTheme.bodyMedium?.copyWith(color: color),
+                  ),
+                ],
+              ),
+              Text('·',
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(color: theme.colorScheme.outline)),
+              Text(
+                deployment.team,
+                style: theme.textTheme.bodyMedium,
+              ),
+              if (deployment.elapsedDuration.isNotEmpty) ...[
+                Text('·',
+                    style: theme.textTheme.bodyMedium
+                        ?.copyWith(color: theme.colorScheme.outline)),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.access_time,
+                        size: 14, color: theme.colorScheme.outline),
+                    const SizedBox(width: 4),
+                    Text(
+                      deployment.elapsedDuration,
+                      style: theme.textTheme.bodyMedium
+                          ?.copyWith(color: theme.colorScheme.outline),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+          // Running indicator
+          if (deployment.isRunning) ...[
+            const SizedBox(height: 8),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(2),
+              child: LinearProgressIndicator(
+                minHeight: 3,
+                backgroundColor: theme.colorScheme.outlineVariant,
+              ),
+            ),
+          ],
+          // Model badges per agent
+          if (deployment.models.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: deployment.models.entries
+                  .map((e) => _ModelBadge(agent: e.key, model: e.value))
+                  .toList(),
+            ),
+          ],
+          // Task progress: completed/failed counts from deployment.agents
+          if (deployment.agents.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            Text(
+              '${deployment.agents.length} agent${deployment.agents.length == 1 ? '' : 's'}: '
+              '${deployment.agents.join(', ')}',
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.outline),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+          // Error details for failed/crashed
+          if (deployment.isFailed &&
+              (deployment.error != null || deployment.exitCode != null)) ...[
+            const SizedBox(height: 10),
+            _ErrorDetailsSection(deployment: deployment),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ModelBadge extends StatelessWidget {
+  final String agent;
+  final String model;
+
+  const _ModelBadge({required this.agent, required this.model});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        '$agent: $model',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSecondaryContainer,
+        ),
+      ),
+    );
+  }
+}
+
+/// Visually emphasized error details box for failed/crashed deployments.
+class _ErrorDetailsSection extends StatelessWidget {
+  final Deployment deployment;
+
+  const _ErrorDetailsSection({required this.deployment});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: theme.colorScheme.error.withValues(alpha: 0.4),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.error_outline,
+                  size: 16, color: theme.colorScheme.onErrorContainer),
+              const SizedBox(width: 6),
+              Text(
+                'Error Details',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.onErrorContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              if (deployment.exitCode != null) ...[
+                const Spacer(),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.error,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    'exit ${deployment.exitCode}',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onError,
+                      fontFamily: 'monospace',
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+          if (deployment.error != null) ...[
+            const SizedBox(height: 6),
+            Text(
+              deployment.error!,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onErrorContainer,
+                fontFamily: 'monospace',
+              ),
+              maxLines: 5,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+// --- Shared helpers ---
+
+Color _statusColor(BuildContext context, String status) {
+  switch (status.toLowerCase()) {
+    case 'running':
+      return Colors.blue;
+    case 'success':
+    case 'completed':
+      return Colors.green;
+    case 'partial':
+      return Colors.orange;
+    case 'failed':
+    case 'crashed':
+      return Colors.red;
+    default:
+      return Theme.of(context).colorScheme.outline;
+  }
+}
+
+IconData _statusIcon(String status) {
+  switch (status.toLowerCase()) {
+    case 'running':
+      return Icons.play_circle_outline;
+    case 'success':
+    case 'completed':
+      return Icons.check_circle_outline;
+    case 'partial':
+      return Icons.warning_amber_outlined;
+    case 'failed':
+    case 'crashed':
+      return Icons.error_outline;
+    default:
+      return Icons.help_outline;
+  }
+}

--- a/phone/lib/screens/deployment_screen.dart
+++ b/phone/lib/screens/deployment_screen.dart
@@ -1,15 +1,23 @@
 import 'package:flutter/material.dart';
 
 import '../models/deployment.dart';
+import '../services/agent_api_client.dart';
 import '../services/deployment_provider.dart';
+import 'activity_timeline_screen.dart';
 
 /// Shows deployment status with filtering by team and status.
 ///
-/// Supports pull-to-refresh, filter chips, and a detail bottom sheet.
+/// Supports pull-to-refresh, filter chips, and tap-to-navigate to the
+/// activity timeline for each deployment.
 class DeploymentScreen extends StatefulWidget {
   final DeploymentProvider deploymentProvider;
+  final AgentApiClient apiClient;
 
-  const DeploymentScreen({super.key, required this.deploymentProvider});
+  const DeploymentScreen({
+    super.key,
+    required this.deploymentProvider,
+    required this.apiClient,
+  });
 
   @override
   State<DeploymentScreen> createState() => _DeploymentScreenState();
@@ -64,13 +72,25 @@ class _DeploymentScreenState extends State<DeploymentScreen> {
                     itemBuilder: (context, index) {
                       return _DeploymentTile(
                         deployment: provider.deployments[index],
-                        onTap: () =>
-                            _showDetail(context, provider.deployments[index]),
+                        onTap: () => _navigateToTimeline(
+                            context, provider.deployments[index]),
                       );
                     },
                   ),
           ),
         ],
+      ),
+    );
+  }
+
+  void _navigateToTimeline(BuildContext context, Deployment deployment) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ActivityTimelineScreen(
+          deployment: deployment,
+          client: widget.apiClient,
+        ),
       ),
     );
   }
@@ -158,15 +178,6 @@ class _DeploymentScreenState extends State<DeploymentScreen> {
       ),
     );
   }
-
-  void _showDetail(BuildContext context, Deployment deployment) {
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      builder: (_) => _DeploymentDetail(deployment: deployment),
-    );
-  }
 }
 
 /// Filter chips row for team and status.
@@ -239,22 +250,64 @@ class _DeploymentTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final color = _statusColor(context, deployment.status);
+    final isCrashed = deployment.isFailed;
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      child: ListTile(
-        onTap: onTap,
-        leading: CircleAvatar(
-          backgroundColor: color.withValues(alpha: 0.15),
-          child: Icon(_statusIcon(deployment.status), color: color, size: 20),
-        ),
-        title: Text(
-          deployment.deploymentId,
-          style: theme.textTheme.bodyMedium
-              ?.copyWith(fontFamily: 'monospace', fontWeight: FontWeight.w600),
-        ),
-        subtitle: _buildSubtitle(theme, color),
-        trailing: const Icon(Icons.chevron_right),
+      // Visual emphasis for failed/crashed: red border
+      shape: isCrashed
+          ? RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+              side: BorderSide(
+                  color: theme.colorScheme.error.withValues(alpha: 0.5),
+                  width: 1.5),
+            )
+          : null,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            onTap: onTap,
+            leading: CircleAvatar(
+              backgroundColor: color.withValues(alpha: 0.15),
+              child:
+                  Icon(_statusIcon(deployment.status), color: color, size: 20),
+            ),
+            title: Text(
+              deployment.deploymentId,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                  fontFamily: 'monospace', fontWeight: FontWeight.w600),
+            ),
+            subtitle: _buildSubtitle(theme, color),
+            trailing: const Icon(Icons.chevron_right),
+          ),
+          // Model badges if available
+          if (deployment.models.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 10),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Wrap(
+                  spacing: 5,
+                  runSpacing: 4,
+                  children: deployment.models.entries
+                      .map((e) => _CompactModelBadge(
+                          agent: e.key, model: e.value, theme: theme))
+                      .toList(),
+                ),
+              ),
+            ),
+          // Running progress indicator
+          if (deployment.isRunning)
+            ClipRRect(
+              borderRadius:
+                  const BorderRadius.vertical(bottom: Radius.circular(12)),
+              child: LinearProgressIndicator(
+                minHeight: 3,
+                backgroundColor: theme.colorScheme.outlineVariant,
+              ),
+            ),
+        ],
       ),
     );
   }
@@ -275,7 +328,13 @@ class _DeploymentTile extends StatelessWidget {
       ),
     ];
 
-    if (deployment.startedAt.isNotEmpty) {
+    if (deployment.elapsedDuration.isNotEmpty) {
+      parts.add(TextSpan(
+        text: ' \u00b7 ${deployment.elapsedDuration}',
+        style:
+            theme.textTheme.bodySmall?.copyWith(color: deployment.isFailed ? statusColor : null),
+      ));
+    } else if (deployment.startedAt.isNotEmpty) {
       parts.add(TextSpan(
         text: ' \u00b7 ${_formatTimestamp(deployment.startedAt)}',
         style: theme.textTheme.bodySmall,
@@ -290,148 +349,28 @@ class _DeploymentTile extends StatelessWidget {
   }
 }
 
-/// Bottom sheet with full deployment details.
-class _DeploymentDetail extends StatelessWidget {
-  final Deployment deployment;
+class _CompactModelBadge extends StatelessWidget {
+  final String agent;
+  final String model;
+  final ThemeData theme;
 
-  const _DeploymentDetail({required this.deployment});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final color = _statusColor(context, deployment.status);
-
-    return DraggableScrollableSheet(
-      initialChildSize: 0.6,
-      minChildSize: 0.4,
-      maxChildSize: 0.9,
-      expand: false,
-      builder: (context, scrollController) {
-        return Column(
-          children: [
-            // Handle bar
-            Container(
-              margin: const EdgeInsets.only(top: 12, bottom: 8),
-              width: 40,
-              height: 4,
-              decoration: BoxDecoration(
-                color: theme.colorScheme.outlineVariant,
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-            Expanded(
-              child: ListView(
-                controller: scrollController,
-                padding: const EdgeInsets.fromLTRB(20, 4, 20, 32),
-                children: [
-                  // Header
-                  Row(
-                    children: [
-                      CircleAvatar(
-                        backgroundColor: color.withValues(alpha: 0.15),
-                        child: Icon(_statusIcon(deployment.status),
-                            color: color, size: 22),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              deployment.deploymentId,
-                              style: theme.textTheme.titleMedium?.copyWith(
-                                fontFamily: 'monospace',
-                                fontWeight: FontWeight.w700,
-                              ),
-                            ),
-                            Text(
-                              deployment.status,
-                              style: theme.textTheme.bodySmall
-                                  ?.copyWith(color: color),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 20),
-                  // Info rows
-                  _InfoRow(label: 'Team', value: deployment.team),
-                  _InfoRow(
-                    label: 'Status',
-                    value: deployment.status,
-                    valueColor: color,
-                  ),
-                  if (deployment.startedAt.isNotEmpty)
-                    _InfoRow(label: 'Started', value: deployment.startedAt),
-                  if (deployment.completedAt != null)
-                    _InfoRow(
-                        label: 'Completed', value: deployment.completedAt!),
-                  if (deployment.agents.isNotEmpty)
-                    _InfoRow(
-                      label: 'Agents',
-                      value: deployment.agents.join(', '),
-                    ),
-                  if (deployment.summary != null) ...[
-                    const SizedBox(height: 16),
-                    Text(
-                      'Summary',
-                      style: theme.textTheme.labelMedium
-                          ?.copyWith(color: theme.colorScheme.outline),
-                    ),
-                    const SizedBox(height: 6),
-                    Container(
-                      padding: const EdgeInsets.all(12),
-                      decoration: BoxDecoration(
-                        color: theme.colorScheme.surfaceContainerHighest,
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Text(
-                        deployment.summary!,
-                        style: theme.textTheme.bodyMedium,
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-          ],
-        );
-      },
-    );
-  }
-}
-
-class _InfoRow extends StatelessWidget {
-  final String label;
-  final String value;
-  final Color? valueColor;
-
-  const _InfoRow({required this.label, required this.value, this.valueColor});
+  const _CompactModelBadge(
+      {required this.agent, required this.model, required this.theme});
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 6),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: 90,
-            child: Text(
-              label,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.outline),
-            ),
-          ),
-          Expanded(
-            child: Text(
-              value,
-              style: theme.textTheme.bodyMedium?.copyWith(color: valueColor),
-            ),
-          ),
-        ],
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondaryContainer.withValues(alpha: 0.7),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Text(
+        '$agent: $model',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSecondaryContainer,
+          fontSize: 10,
+        ),
       ),
     );
   }
@@ -478,8 +417,19 @@ String _formatTimestamp(String iso) {
   try {
     final dt = DateTime.parse(iso).toLocal();
     final months = [
-      '', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+      '',
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
     ];
     final h = dt.hour.toString().padLeft(2, '0');
     final m = dt.minute.toString().padLeft(2, '0');

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+import '../models/activity_event.dart';
 import '../models/agent_team.dart';
 import '../models/create_idea_payload.dart';
 import '../models/deploy_result.dart';
@@ -147,6 +148,22 @@ class AgentApiClient {
     final deployments = response['deployments'] as List;
     return deployments
         .map((e) => Deployment.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Fetch activity events for a deployment.
+  ///
+  /// Pass [since] (ISO-8601 timestamp) to fetch only events after that time.
+  /// Returns events in chronological order.
+  Future<List<ActivityEvent>> getDeploymentActivity(
+    String id, {
+    String? since,
+  }) async {
+    final params = since != null ? '?since=${Uri.encodeComponent(since)}' : '';
+    final response = await _get('/api/deployments/$id/activity$params');
+    final events = response['events'] as List;
+    return events
+        .map((e) => ActivityEvent.fromJson(e as Map<String, dynamic>))
         .toList();
   }
 

--- a/phone/lib/services/deployment_provider.dart
+++ b/phone/lib/services/deployment_provider.dart
@@ -5,7 +5,10 @@ import 'package:flutter/foundation.dart';
 import '../models/deployment.dart';
 import 'agent_api_client.dart';
 
-/// Provides deployment status data with filtering.
+/// Provides deployment status data with filtering and auto-refresh.
+///
+/// Auto-refresh polls every 7 seconds when any deployment is running,
+/// and stops automatically when no running deployments remain.
 class DeploymentProvider extends ChangeNotifier {
   final AgentApiClient _client;
 
@@ -14,6 +17,7 @@ class DeploymentProvider extends ChangeNotifier {
   String? _error;
   String? _filterTeam;
   String? _filterStatus;
+  Timer? _refreshTimer;
 
   DeploymentProvider(this._client);
 
@@ -33,6 +37,8 @@ class DeploymentProvider extends ChangeNotifier {
   String? get error => _error;
   String? get filterTeam => _filterTeam;
   String? get filterStatus => _filterStatus;
+
+  bool get hasRunning => _deployments.any((d) => d.isRunning);
 
   /// Get unique team names from all deployments.
   List<String> get availableTeams {
@@ -58,10 +64,32 @@ class DeploymentProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Fetch deployments from the API.
+  /// Start auto-refresh. Fetches immediately, then polls every 7s while
+  /// running deployments exist. Call once after construction.
+  void startAutoRefresh() {
+    refresh();
+    _scheduleRefresh();
+  }
+
+  void _scheduleRefresh() {
+    _refreshTimer?.cancel();
+    _refreshTimer = Timer(const Duration(seconds: 7), () async {
+      await refresh();
+      // Continue polling only if deployments are running.
+      if (hasRunning) {
+        _scheduleRefresh();
+      }
+    });
+  }
+
+  /// Fetch deployments from the API and restart auto-refresh if needed.
   Future<void> refresh() async {
-    _loading = true;
-    notifyListeners();
+    // Avoid loading flicker on background refreshes.
+    final wasEmpty = _deployments.isEmpty;
+    if (wasEmpty) {
+      _loading = true;
+      notifyListeners();
+    }
 
     try {
       _deployments = await _client.listDeployments();
@@ -73,5 +101,16 @@ class DeploymentProvider extends ChangeNotifier {
       _loading = false;
       notifyListeners();
     }
+
+    // Resume auto-refresh if running deployments appeared.
+    if (hasRunning && _refreshTimer == null) {
+      _scheduleRefresh();
+    }
+  }
+
+  @override
+  void dispose() {
+    _refreshTimer?.cancel();
+    super.dispose();
   }
 }

--- a/phone/lib/widgets/activity_event_tile.dart
+++ b/phone/lib/widgets/activity_event_tile.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+
+import '../models/activity_event.dart';
+
+/// Renders a single activity event in a timeline style.
+///
+/// Supports [expanded] mode to show event data fields below the label.
+class ActivityEventTile extends StatelessWidget {
+  final ActivityEvent event;
+  final bool expanded;
+
+  const ActivityEventTile({
+    super.key,
+    required this.event,
+    this.expanded = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = _eventColor(context, event.event);
+    final icon = _eventIcon(event.event);
+    final time =
+        event.timestamp != null ? _formatTime(event.timestamp!) : event.ts;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Timeline dot
+          Container(
+            width: 28,
+            height: 28,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: color.withValues(alpha: 0.15),
+            ),
+            child: Icon(icon, size: 14, color: color),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        _buildLabel(),
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: event.isMilestone
+                              ? FontWeight.w600
+                              : FontWeight.normal,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      time,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.outline,
+                        fontFamily: 'monospace',
+                      ),
+                    ),
+                  ],
+                ),
+                if (event.agent.isNotEmpty)
+                  Text(
+                    event.agent,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
+                  ),
+                if (expanded && event.data.isNotEmpty) ...[
+                  const SizedBox(height: 4),
+                  _buildDataSection(theme),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _buildLabel() {
+    switch (event.event) {
+      case 'tool_call':
+        final tool = event.data['tool'] as String?;
+        final status = event.data['status'] as String?;
+        if (tool != null && status != null) return 'Tool: $tool ($status)';
+        if (tool != null) return 'Tool: $tool';
+        return 'Tool call';
+      case 'agent_spawned':
+        final name = event.data['name'] as String? ?? event.data['agent'] as String?;
+        return name != null ? 'Agent spawned: $name' : 'Agent spawned';
+      case 'agent_stopped':
+        return 'Agent stopped';
+      case 'task_completed':
+        final taskId = event.data['task_id'] as String?;
+        return taskId != null ? 'Task completed: $taskId' : 'Task completed';
+      case 'task_failed':
+        final taskId = event.data['task_id'] as String?;
+        return taskId != null ? 'Task failed: $taskId' : 'Task failed';
+      case 'child_deploy_started':
+        final deployId = event.data['deploy_id'] as String?;
+        return deployId != null
+            ? 'Child deploy: $deployId'
+            : 'Child deploy started';
+      case 'deployment_started':
+        return 'Deployment started';
+      case 'deployment_completed':
+        final status = event.data['status'] as String?;
+        return status != null
+            ? 'Deployment completed ($status)'
+            : 'Deployment completed';
+      default:
+        return event.eventLabel;
+    }
+  }
+
+  Widget _buildDataSection(ThemeData theme) {
+    final entries = event.data.entries
+        .where((e) => e.value != null && e.value.toString().isNotEmpty)
+        .toList();
+    if (entries.isEmpty) return const SizedBox.shrink();
+
+    return Container(
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: entries
+            .map((e) => Text(
+                  '${e.key}: ${e.value}',
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(fontFamily: 'monospace'),
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                ))
+            .toList(),
+      ),
+    );
+  }
+}
+
+Color _eventColor(BuildContext context, String eventType) {
+  switch (eventType) {
+    case 'deployment_started':
+    case 'agent_spawned':
+      return Colors.blue;
+    case 'deployment_completed':
+    case 'task_completed':
+    case 'agent_stopped':
+      return Colors.green;
+    case 'task_failed':
+      return Colors.red;
+    case 'tool_call':
+      return Colors.purple;
+    case 'child_deploy_started':
+      return Colors.teal;
+    default:
+      return Theme.of(context).colorScheme.outline;
+  }
+}
+
+IconData _eventIcon(String eventType) {
+  switch (eventType) {
+    case 'deployment_started':
+      return Icons.rocket_launch;
+    case 'deployment_completed':
+      return Icons.check_circle;
+    case 'agent_spawned':
+      return Icons.person_add;
+    case 'agent_stopped':
+      return Icons.person_off;
+    case 'task_completed':
+      return Icons.task_alt;
+    case 'task_failed':
+      return Icons.cancel;
+    case 'tool_call':
+      return Icons.build;
+    case 'child_deploy_started':
+      return Icons.fork_right;
+    default:
+      return Icons.circle_outlined;
+  }
+}
+
+String _formatTime(DateTime dt) {
+  final local = dt.toLocal();
+  final h = local.hour.toString().padLeft(2, '0');
+  final m = local.minute.toString().padLeft(2, '0');
+  final s = local.second.toString().padLeft(2, '0');
+  return '$h:$m:$s';
+}


### PR DESCRIPTION
## Summary
- **Phase 1 (backend):** Extended `registry_parser.dart` to parse `models`, `error`, `exitCode`, `logFile` fields. Added `GET /api/deployments/{id}/activity` endpoint with `?since=` incremental polling support.
- **Phase 2 (data layer):** Extended phone `Deployment` model with new fields + computed `elapsedDuration`. Created `ActivityEvent` model. Added `getDeploymentActivity()` to API client. Implemented auto-refresh timer (7s) in `DeploymentProvider` that activates only when running deployments exist.
- **Phase 3+4 (UI + polish):** Created `ActivityTimelineScreen` with chronological events, auto-refresh, compact/expanded toggle. Created `ActivityEventTile` with type-specific icons/colors. Updated `DeploymentScreen` with duration display, model badges, error emphasis, and tap-to-timeline navigation.

Closes requirements from deployment d-729bd7.

## Test plan
- [ ] Start a deployment from CLI → open phone → verify deployment appears within 10s with running status and live duration
- [ ] Tap running deployment → verify activity timeline updates every 3-5s with agent spawns, tool calls, task completions
- [ ] Wait for deployment to complete → verify final status, total duration, and summary appear
- [ ] Find a crashed deployment → tap → verify error message and exit code displayed
- [ ] Verify auto-refresh stops when no deployments are running (check battery impact)
- [ ] `dart analyze` clean on phone/ directory
- [ ] All existing tests pass (`cd mcp && dart test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)