### PR TITLE
feat(phone): deploy enhancements - repos endpoint, mode fix, repo picker

### DIFF
--- a/mcp/lib/services/agent_api_service.dart
+++ b/mcp/lib/services/agent_api_service.dart
@@ -128,6 +128,8 @@ class AgentApiService {
         await _handleTeamBrowse(request);
       } else if (path == '/api/pa-teams' && method == 'GET') {
         await _handleListPaTeams(request);
+      } else if (path == '/api/repos' && method == 'GET') {
+        await _handleListRepos(request);
       } else if (path == '/api/agent-teams' && method == 'GET') {
         await _handleListAgentTeams(request);
       } else if (path == '/api/deploy' && method == 'POST') {
@@ -1732,16 +1734,28 @@ class AgentApiService {
         {'teams': teams.map((t) => t.toJson()).toList()});
   }
 
+  /// GET /api/repos — List available repos from repos.yaml.
+  ///
+  /// Reads repos.yaml from PA_CONFIG then PA_HOME.
+  /// Returns: `{"repos": [{"name": ..., "path": ..., "description": ...}]}`
+  Future<void> _handleListRepos(HttpRequest request) async {
+    final repos = await _loadRepos();
+    _jsonResponse(request, HttpStatus.ok,
+        {'repos': repos.map((r) => r.toJson()).toList()});
+  }
+
   /// POST /api/deploy — Trigger a PA team deployment.
   ///
-  /// Body (JSON): `{"team": "builder", "mode": "background", "objective": "..."}`
+  /// Body (JSON): `{"team": "builder", "mode": "background", "objective": "...", "repo": "avodah"}`
   /// Validates team + mode against the YAML whitelist before executing.
   /// Runs the `pa` command as a detached subprocess and returns immediately
   /// with the deployment ID parsed from the primer path in pa's output.
   /// Optional `objective` field: passed as `--objective <value>` to `pa`.
   /// Validated: max 500 chars, safe ASCII characters only.
+  /// Optional `repo` field: passed as `--repo <name>` to `pa deploy`.
+  /// Validated against repos.yaml whitelist.
   ///
-  /// Returns: `{"deployment_id": "d-abc123", "started": true, "team": ..., "mode": ...}`
+  /// Returns: `{"deployment_id": "d-abc123", "started": true, "team": ..., "mode": ..., "cwd": ...}`
   Future<void> _handleDeploy(HttpRequest request) async {
     String body;
     try {
@@ -1770,6 +1784,7 @@ class AgentApiService {
     final team = json['team'] as String?;
     final mode = json['mode'] as String?;
     final objective = json['objective'] as String?;
+    final repo = json['repo'] as String?;
 
     if (team == null || team.isEmpty) {
       _jsonResponse(
@@ -1787,6 +1802,24 @@ class AgentApiService {
       _jsonResponse(
           request, HttpStatus.badRequest, {'error': 'Invalid team name'});
       return;
+    }
+
+    // Validate repo if provided (alphanumeric + hyphens only — no shell injection)
+    String? repoCwd;
+    if (repo != null && repo.isNotEmpty) {
+      if (!RegExp(r'^[a-zA-Z0-9_-]+$').hasMatch(repo)) {
+        _jsonResponse(
+            request, HttpStatus.badRequest, {'error': 'Invalid repo name'});
+        return;
+      }
+      final repos = await _loadRepos();
+      final paRepo = repos.where((r) => r.name == repo).firstOrNull;
+      if (paRepo == null) {
+        _jsonResponse(request, HttpStatus.badRequest,
+            {'error': 'Unknown repo: $repo'});
+        return;
+      }
+      repoCwd = paRepo.path;
     }
 
     // Validate team + mode against YAML whitelist
@@ -1832,9 +1865,20 @@ class AgentApiService {
       args = ['daily', mode];
     } else {
       args = ['deploy', team];
-      if (mode == 'background') args.add('--background');
-      if (mode == 'interactive') args.add('--interactive');
-      // foreground: no extra flag
+      if (mode == 'background') {
+        args.add('--background');
+      } else if (mode == 'interactive') {
+        args.add('--interactive');
+      } else if (mode != 'foreground') {
+        // Custom mode: pass --mode flag to load mode-specific objective
+        args.addAll(['--mode', mode]);
+      }
+      // foreground: no extra flag (default)
+    }
+
+    // Append --repo flag if provided
+    if (repo != null && repo.isNotEmpty) {
+      args.addAll(['--repo', repo]);
     }
 
     // Append --objective flag if provided
@@ -1895,6 +1939,7 @@ class AgentApiService {
       'started': true,
       'team': team,
       'mode': mode,
+      if (repoCwd != null) 'cwd': repoCwd,
     });
   }
 
@@ -2033,6 +2078,102 @@ class AgentApiService {
       description: description ?? '',
       deployModes: filteredModes,
     );
+  }
+
+  // --- Repos YAML parsing ---
+
+  /// Load repos from repos.yaml (PA_CONFIG then PA_HOME).
+  ///
+  /// Expands `~` in paths using the HOME environment variable.
+  Future<List<_PaRepo>> _loadRepos() async {
+    final home = Platform.environment['HOME'] ?? '';
+    final repoPaths = <String>[];
+    if (paConfigDir != null) {
+      repoPaths.add(p.join(paConfigDir!, 'repos.yaml'));
+    }
+    repoPaths.add(p.join(paHome, 'repos.yaml'));
+
+    for (final repoPath in repoPaths) {
+      final file = File(repoPath);
+      if (!file.existsSync()) continue;
+      final repos = _parseReposYaml(file.readAsStringSync(), home);
+      if (repos.isNotEmpty) return repos;
+    }
+    return [];
+  }
+
+  /// Parse repos.yaml content into a list of [_PaRepo].
+  ///
+  /// Expected format:
+  /// ```yaml
+  /// repos:
+  ///   pa:
+  ///     path: ~/git-repos/...
+  ///     description: PA CLI tool
+  /// ```
+  List<_PaRepo> _parseReposYaml(String content, String home) {
+    final repos = <_PaRepo>[];
+    String? currentName;
+    String? currentPath;
+    String? currentDescription;
+
+    for (final rawLine in content.split('\n')) {
+      final line = rawLine.trimRight();
+      if (line.isEmpty || line.startsWith('#')) continue;
+
+      // Top-level `repos:` key — skip
+      if (line == 'repos:') continue;
+
+      final indent = line.length - line.trimLeft().length;
+      final trimmed = line.trimLeft();
+
+      if (indent == 2) {
+        // Flush previous repo
+        if (currentName != null && currentPath != null) {
+          repos.add(_PaRepo(
+            name: currentName,
+            path: currentPath,
+            description: currentDescription ?? '',
+          ));
+        }
+        // New repo: `  <name>:` (indent=2, ends with colon)
+        if (trimmed.endsWith(':')) {
+          currentName = trimmed.substring(0, trimmed.length - 1).trim();
+          currentPath = null;
+          currentDescription = null;
+        } else {
+          currentName = null;
+        }
+      } else if (indent == 4 && currentName != null) {
+        // Repo property: `    key: value`
+        final colonIdx = trimmed.indexOf(':');
+        if (colonIdx > 0) {
+          final key = trimmed.substring(0, colonIdx).trim();
+          var value = trimmed.substring(colonIdx + 1).trim();
+          // Strip surrounding quotes
+          if (value.length >= 2 &&
+              ((value.startsWith('"') && value.endsWith('"')) ||
+                  (value.startsWith("'") && value.endsWith("'")))) {
+            value = value.substring(1, value.length - 1);
+          }
+          // Expand ~ in path
+          if (value.startsWith('~/') || value == '~') {
+            value = home + value.substring(1);
+          }
+          if (key == 'path') currentPath = value;
+          if (key == 'description') currentDescription = value;
+        }
+      }
+    }
+    // Flush last repo
+    if (currentName != null && currentPath != null) {
+      repos.add(_PaRepo(
+        name: currentName,
+        path: currentPath,
+        description: currentDescription ?? '',
+      ));
+    }
+    return repos;
   }
 
   /// Extract a scalar value from a YAML line like `key: value` or `key: "value"`.
@@ -2264,6 +2405,24 @@ class AgentApiService {
 }
 
 // --- Private data classes for PA team support ---
+
+class _PaRepo {
+  final String name;
+  final String path;
+  final String description;
+
+  const _PaRepo({
+    required this.name,
+    required this.path,
+    required this.description,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'path': path,
+        'description': description,
+      };
+}
 
 class _PaTeam {
   final String name;

--- a/mcp/lib/services/registry_parser.dart
+++ b/mcp/lib/services/registry_parser.dart
@@ -21,6 +21,7 @@ class RegistryEvent {
   final Map<String, String>? models; // agent name → model id
   final String? error;
   final String? logFile;
+  final String? primer; // path to the primer file (from PA's started event)
 
   RegistryEvent({
     required this.deploymentId,
@@ -35,6 +36,7 @@ class RegistryEvent {
     this.models,
     this.error,
     this.logFile,
+    this.primer,
   });
 
   factory RegistryEvent.fromJson(Map<String, dynamic> json) {
@@ -56,6 +58,7 @@ class RegistryEvent {
       models: models,
       error: json['error'] as String?,
       logFile: json['log_file'] as String?,
+      primer: json['primer'] as String?,
     );
   }
 
@@ -72,6 +75,7 @@ class RegistryEvent {
         if (models != null) 'models': models,
         if (error != null) 'error': error,
         if (logFile != null) 'log_file': logFile,
+        if (primer != null) 'primer': primer,
       };
 }
 
@@ -88,6 +92,7 @@ class DeploymentStatus {
   final String? error;
   final int? exitCode;
   final String? logFile;
+  final String? cwd; // working directory the deployment was launched from
 
   DeploymentStatus({
     required this.deploymentId,
@@ -101,6 +106,7 @@ class DeploymentStatus {
     this.error,
     this.exitCode,
     this.logFile,
+    this.cwd,
   });
 
   Map<String, dynamic> toJson() => {
@@ -115,6 +121,7 @@ class DeploymentStatus {
         if (error != null) 'error': error,
         if (exitCode != null) 'exit_code': exitCode,
         if (logFile != null) 'log_file': logFile,
+        if (cwd != null) 'cwd': cwd,
       };
 }
 
@@ -183,6 +190,13 @@ List<DeploymentStatus> computeDeploymentStatuses(List<RegistryEvent> events) {
       status = 'running';
     }
 
+    // Extract cwd from primer file if available
+    String? cwd;
+    final primerPath = started?.primer;
+    if (primerPath != null) {
+      cwd = _extractCwdFromPrimer(primerPath);
+    }
+
     deployments.add(DeploymentStatus(
       deploymentId: entry.key,
       team: started?.team ?? deployEvents.first.team,
@@ -195,10 +209,30 @@ List<DeploymentStatus> computeDeploymentStatuses(List<RegistryEvent> events) {
       error: error,
       exitCode: exitCode,
       logFile: logFile,
+      cwd: cwd,
     ));
   }
 
   // Sort newest first
   deployments.sort((a, b) => b.startedAt.compareTo(a.startedAt));
   return deployments;
+}
+
+/// Extract the `cwd:` value from a deployment primer file.
+///
+/// Reads the deployment-context YAML block and returns the `cwd:` value.
+/// Returns null if the file does not exist or the field is not found.
+String? _extractCwdFromPrimer(String primerPath) {
+  try {
+    final file = File(primerPath);
+    if (!file.existsSync()) return null;
+    for (final line in file.readAsLinesSync()) {
+      final trimmed = line.trim();
+      if (trimmed.startsWith('cwd:')) {
+        final value = trimmed.substring(4).trim();
+        return value.isNotEmpty ? value : null;
+      }
+    }
+  } catch (_) {}
+  return null;
 }

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -81,6 +81,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
     final teamBrowserProvider = TeamBrowserProvider(apiClient);
     teamBrowserProvider.refreshTeams();
     teamBrowserProvider.loadPaTeams();
+    teamBrowserProvider.loadPaRepos();
 
     setState(() {
       _db = db;

--- a/phone/lib/models/deployment.dart
+++ b/phone/lib/models/deployment.dart
@@ -11,6 +11,7 @@ class Deployment {
   final String? error;
   final int? exitCode;
   final String? logFile;
+  final String? cwd; // working directory the deployment was launched from
 
   const Deployment({
     required this.deploymentId,
@@ -24,6 +25,7 @@ class Deployment {
     this.error,
     this.exitCode,
     this.logFile,
+    this.cwd,
   });
 
   factory Deployment.fromJson(Map<String, dynamic> json) {
@@ -40,6 +42,7 @@ class Deployment {
       error: json['error'] as String?,
       exitCode: json['exit_code'] as int?,
       logFile: json['log_file'] as String?,
+      cwd: json['cwd'] as String?,
     );
   }
 

--- a/phone/lib/models/pa_team.dart
+++ b/phone/lib/models/pa_team.dart
@@ -39,3 +39,26 @@ class DeployMode {
     );
   }
 }
+
+/// A repo entry from repos.yaml.
+///
+/// Deserialized from GET /api/repos response.
+class PaRepo {
+  final String name;
+  final String path;
+  final String description;
+
+  const PaRepo({
+    required this.name,
+    required this.path,
+    required this.description,
+  });
+
+  factory PaRepo.fromJson(Map<String, dynamic> json) {
+    return PaRepo(
+      name: json['name'] as String,
+      path: json['path'] as String? ?? '',
+      description: json['description'] as String? ?? '',
+    );
+  }
+}

--- a/phone/lib/screens/activity_timeline_screen.dart
+++ b/phone/lib/screens/activity_timeline_screen.dart
@@ -280,6 +280,29 @@ class _DeploymentHeader extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
             ),
           ],
+          // Working directory
+          if (deployment.cwd != null) ...[
+            const SizedBox(height: 6),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.folder_outlined,
+                    size: 14, color: theme.colorScheme.outline),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(
+                    deployment.cwd!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                      fontFamily: 'monospace',
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ],
           // Error details for failed/crashed
           if (deployment.isFailed &&
               (deployment.error != null || deployment.exitCode != null)) ...[

--- a/phone/lib/screens/item_detail_screen.dart
+++ b/phone/lib/screens/item_detail_screen.dart
@@ -27,11 +27,15 @@ class ItemDetailScreen extends StatefulWidget {
   /// a deploy icon button appears in the AppBar.
   final List<PaTeam>? paTeams;
 
+  /// Available repos for the repo picker in DeploySheet.
+  final List<PaRepo> paRepos;
+
   const ItemDetailScreen({
     super.key,
     required this.item,
     required this.reviewProvider,
     this.paTeams,
+    this.paRepos = const [],
   });
 
   @override
@@ -677,15 +681,17 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
       isScrollControlled: true,
       builder: (_) => DeploySheet(
         paTeams: widget.paTeams!,
+        repos: widget.paRepos,
         initialTeam: team,
         initialObjective: widget.item.id,
-        onDeploy: (t, mode, objective) async {
+        onDeploy: (t, mode, objective, repo) async {
           Navigator.pop(context);
           try {
             final result = await widget.reviewProvider.client.triggerDeployment(
               t,
               mode,
               objective: objective.isNotEmpty ? objective : null,
+              repo: repo,
             );
             if (mounted) {
               messenger.showSnackBar(SnackBar(

--- a/phone/lib/screens/review_queue_screen.dart
+++ b/phone/lib/screens/review_queue_screen.dart
@@ -55,6 +55,7 @@ class ReviewQueueScreen extends StatelessWidget {
                 _InboxTabView(
                   reviewProvider: reviewProvider,
                   paTeams: teamBrowserProvider?.paTeams,
+                  paRepos: teamBrowserProvider?.paRepos ?? const [],
                 ),
                 FolderListView(
                     folder: 'approved', client: reviewProvider.client),
@@ -283,8 +284,12 @@ class _IdeasTabViewState extends State<_IdeasTabView> {
 class _InboxTabView extends StatefulWidget {
   final ReviewProvider reviewProvider;
   final List<PaTeam>? paTeams;
+  final List<PaRepo> paRepos;
 
-  const _InboxTabView({required this.reviewProvider, this.paTeams});
+  const _InboxTabView(
+      {required this.reviewProvider,
+      this.paTeams,
+      this.paRepos = const []});
 
   @override
   State<_InboxTabView> createState() => _InboxTabViewState();
@@ -666,6 +671,7 @@ class _InboxTabViewState extends State<_InboxTabView> {
           item: item,
           reviewProvider: widget.reviewProvider,
           paTeams: widget.paTeams,
+          paRepos: widget.paRepos,
         ),
       ),
     );

--- a/phone/lib/screens/team_browser_screen.dart
+++ b/phone/lib/screens/team_browser_screen.dart
@@ -99,13 +99,15 @@ class _TeamBrowserScreenState extends State<TeamBrowserScreen> {
       isScrollControlled: true,
       builder: (_) => DeploySheet(
         paTeams: widget.teamProvider.paTeams,
-        onDeploy: (team, mode, objective) async {
+        repos: widget.teamProvider.paRepos,
+        onDeploy: (team, mode, objective, repo) async {
           Navigator.pop(context);
           try {
             final result = await widget.teamProvider.deploy(
               team,
               mode,
               objective: objective.isNotEmpty ? objective : null,
+              repo: repo,
             );
             if (mounted) {
               messenger.showSnackBar(
@@ -611,15 +613,17 @@ class _TeamFileViewScreenState extends State<_TeamFileViewScreen> {
       isScrollControlled: true,
       builder: (_) => DeploySheet(
         paTeams: widget.teamProvider.paTeams,
+        repos: widget.teamProvider.paRepos,
         initialTeam: widget.team,
         initialObjective: widget.file.name,
-        onDeploy: (team, mode, objective) async {
+        onDeploy: (team, mode, objective, repo) async {
           Navigator.pop(context);
           try {
             final result = await widget.teamProvider.deploy(
               team,
               mode,
               objective: objective.isNotEmpty ? objective : null,
+              repo: repo,
             );
             if (mounted) {
               messenger.showSnackBar(SnackBar(

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -315,18 +315,32 @@ class AgentApiClient {
         .toList();
   }
 
+  /// List available repos from repos.yaml.
+  Future<List<PaRepo>> listRepos() async {
+    final response = await _get('/api/repos');
+    final repos = response['repos'] as List;
+    return repos
+        .map((e) => PaRepo.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
   /// Trigger a PA team deployment.
   ///
   /// Validates team + mode on the server before executing.
   /// Returns immediately after the subprocess is started.
+  /// Optional [repo]: passed as `--repo <name>` to pa deploy.
   Future<DeployResult> triggerDeployment(
     String team,
     String mode, {
     String? objective,
+    String? repo,
   }) async {
     final body = <String, dynamic>{'team': team, 'mode': mode};
     if (objective != null && objective.isNotEmpty) {
       body['objective'] = objective;
+    }
+    if (repo != null && repo.isNotEmpty) {
+      body['repo'] = repo;
     }
     final response = await _post('/api/deploy', body: body);
     return DeployResult.fromJson(response);

--- a/phone/lib/services/team_browser_provider.dart
+++ b/phone/lib/services/team_browser_provider.dart
@@ -13,6 +13,7 @@ class TeamBrowserProvider extends ChangeNotifier {
   List<TeamFolder> _teams = [];
   List<TeamFile> _files = [];
   List<PaTeam> _paTeams = [];
+  List<PaRepo> _paRepos = [];
   bool _loading = false;
   String? _error;
 
@@ -21,6 +22,7 @@ class TeamBrowserProvider extends ChangeNotifier {
   List<TeamFolder> get teams => _teams;
   List<TeamFile> get files => _files;
   List<PaTeam> get paTeams => _paTeams;
+  List<PaRepo> get paRepos => _paRepos;
   bool get loading => _loading;
   String? get error => _error;
 
@@ -43,9 +45,21 @@ class TeamBrowserProvider extends ChangeNotifier {
     }
   }
 
+  /// Fetch available repos from repos.yaml.
+  Future<void> loadPaRepos() async {
+    try {
+      _paRepos = await _client.listRepos();
+      notifyListeners();
+    } catch (e) {
+      debugPrint('TeamBrowserProvider loadPaRepos error: $e');
+    }
+  }
+
   /// Trigger a PA team deployment.
-  Future<DeployResult> deploy(String team, String mode, {String? objective}) {
-    return _client.triggerDeployment(team, mode, objective: objective);
+  Future<DeployResult> deploy(String team, String mode,
+      {String? objective, String? repo}) {
+    return _client.triggerDeployment(team, mode,
+        objective: objective, repo: repo);
   }
 
   /// Fetch team list.

--- a/phone/lib/widgets/deploy_sheet.dart
+++ b/phone/lib/widgets/deploy_sheet.dart
@@ -15,15 +15,19 @@ import '../models/pa_team.dart';
 ///   isScrollControlled: true,
 ///   builder: (_) => DeploySheet(
 ///     paTeams: paTeams,
-///     initialTeam: 'requirements',         // optional
+///     repos: repos,                          // optional
+///     initialTeam: 'requirements',           // optional
 ///     initialObjective: '2026-03-16-foo.md', // optional
-///     onDeploy: (team, mode, objective) async { ... },
+///     onDeploy: (team, mode, objective, repo) async { ... },
 ///   ),
 /// );
 /// ```
 class DeploySheet extends StatefulWidget {
   /// All PA teams with deploy modes.
   final List<PaTeam> paTeams;
+
+  /// Available repos (optional — hides repo picker if empty).
+  final List<PaRepo> repos;
 
   /// Pre-selected team name. If null, user must select from [paTeams].
   final String? initialTeam;
@@ -33,12 +37,14 @@ class DeploySheet extends StatefulWidget {
 
   /// Called when user taps Launch.
   /// [objective] may be empty string if user left the field blank.
-  final Future<void> Function(String team, String mode, String objective)
-      onDeploy;
+  /// [repo] is null if no repo was selected.
+  final Future<void> Function(
+      String team, String mode, String objective, String? repo) onDeploy;
 
   const DeploySheet({
     super.key,
     required this.paTeams,
+    this.repos = const [],
     this.initialTeam,
     this.initialObjective,
     required this.onDeploy,
@@ -51,6 +57,7 @@ class DeploySheet extends StatefulWidget {
 class _DeploySheetState extends State<DeploySheet> {
   String? _selectedTeam;
   String? _selectedMode;
+  String? _selectedRepo;
   bool _deploying = false;
   late final TextEditingController _objectiveController;
 
@@ -159,6 +166,12 @@ class _DeploySheetState extends State<DeploySheet> {
                   const SizedBox(height: 16),
                 ],
 
+                // Repo picker (only shown if repos are available)
+                if (widget.repos.isNotEmpty) ...[
+                  _buildRepoSection(theme),
+                  const SizedBox(height: 16),
+                ],
+
                 // Objective field
                 Text('Objective (optional)', style: theme.textTheme.labelMedium),
                 const SizedBox(height: 6),
@@ -237,6 +250,51 @@ class _DeploySheetState extends State<DeploySheet> {
     );
   }
 
+  Widget _buildRepoSection(ThemeData theme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Repo (optional)', style: theme.textTheme.labelMedium),
+        const SizedBox(height: 6),
+        InputDecorator(
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+          ),
+          child: DropdownButton<String>(
+            value: _selectedRepo,
+            isExpanded: true,
+            underline: const SizedBox.shrink(),
+            hint: Text(
+              'Default (no override)',
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: theme.colorScheme.outline),
+            ),
+            items: [
+              DropdownMenuItem<String>(
+                value: null,
+                child: Text(
+                  'Default (no override)',
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(color: theme.colorScheme.outline),
+                ),
+              ),
+              ...widget.repos.map(
+                (r) => DropdownMenuItem(
+                  value: r.name,
+                  child: Text(r.name),
+                ),
+              ),
+            ],
+            onChanged: _deploying
+                ? null
+                : (value) => setState(() => _selectedRepo = value),
+          ),
+        ),
+      ],
+    );
+  }
+
   Future<void> _launch() async {
     if (!_canLaunch) return;
     setState(() => _deploying = true);
@@ -245,6 +303,7 @@ class _DeploySheetState extends State<DeploySheet> {
         _selectedTeam!,
         _selectedMode!,
         _objectiveController.text.trim(),
+        _selectedRepo,
       );
     } finally {
       if (mounted) setState(() => _deploying = false);


### PR DESCRIPTION
## Summary
- Fix mode passthrough in `_handleDeploy` — all deploy modes now pass through correctly (not just background/interactive)
- Add `GET /api/repos` endpoint to expose repos from PA's repos.yaml
- Accept `repo` field in `POST /api/deploy` body, validate against whitelist, pass `--repo` to PA
- Add `PaRepo` model and repo picker dropdown in phone DeploySheet
- Show deployment CWD (working directory) in activity timeline deploy details

## Context
Part 2 of Deploy Enhancements — Repo Roots Registry & Mode Passthrough.
PA-side changes (Part 1) in separate PR on personal-assistant repo.
Unblocks spike research mode and enables phone deployments to target specific repos.

## Test plan
- [x] `cd mcp && dart test` — 376 tests passing
- [x] Flutter build succeeds
- [ ] E2E: Phone deploy with mode=spike routes correctly
- [ ] E2E: Phone deploy with repo picker targets correct repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)