### PR TITLE
feat(jira): timezone fix and sync error reporting

### DIFF
--- a/mcp/lib/cli/commands.dart
+++ b/mcp/lib/cli/commands.dart
@@ -3127,6 +3127,11 @@ class JiraSyncCommand extends JiraSubcommand {
       if (result.titlesPushed > 0) print(kvRow('Titles pushed:', '${result.titlesPushed}', labelWidth: 18));
       if (result.titlesPulled > 0) print(kvRow('Titles pulled:', '${result.titlesPulled}', labelWidth: 18));
       if (result.failed > 0) print(kvRow('Failed:', '${result.failed}', labelWidth: 18));
+      for (final f in result.failures) {
+        final worklogPart = f.worklogId != null ? ' worklog #${f.worklogId}' : '';
+        final statusPart = f.httpStatus != null ? ' HTTP ${f.httpStatus} -' : '';
+        print('  → [${f.issueKey}]$worklogPart FAILED:$statusPart ${f.errorMessage}');
+      }
       if (result.tasksCreated == 0 && result.worklogsPushed == 0 &&
           result.worklogsPulled == 0 && result.mismatchesPushed == 0 &&
           result.mismatchesPulled == 0 && result.titlesPushed == 0 &&

--- a/mcp/lib/cli/commands.dart
+++ b/mcp/lib/cli/commands.dart
@@ -3160,7 +3160,7 @@ class JiraSyncCommand extends JiraSubcommand {
         final localDur = formatDuration(Duration(milliseconds: m.local.durationMs));
         final remoteDur = formatDuration(Duration(milliseconds: m.remote.durationMs));
         final localStart = formatDateTime(m.local.startTime);
-        final remoteStart = formatDateTime(m.remote.started);
+        final remoteStart = formatDateTime(m.remote.started.toLocal());
         print('  [${m.remote.issueKey}] worklog #${m.remote.jiraWorklogId}');
         print('    Local:   $localStart  $localDur  "${m.local.comment ?? ''}"');
         print('    Remote:  $remoteStart  $remoteDur  "${m.remote.comment ?? ''}"');
@@ -3191,7 +3191,7 @@ class JiraSyncCommand extends JiraSubcommand {
         final localDur = formatDuration(Duration(milliseconds: m.local.durationMs));
         final remoteDur = formatDuration(Duration(milliseconds: m.remote.durationMs));
         final localStart = formatDateTime(m.local.startTime);
-        final remoteStart = formatDateTime(m.remote.started);
+        final remoteStart = formatDateTime(m.remote.started.toLocal());
         print('  [${m.remote.issueKey}] worklog #${m.remote.jiraWorklogId}');
         print('    Local:   $localStart  $localDur  "${m.local.comment ?? ''}"');
         print('    Remote:  $remoteStart  $remoteDur  "${m.remote.comment ?? ''}"');

--- a/mcp/lib/services/jira_service.dart
+++ b/mcp/lib/services/jira_service.dart
@@ -181,6 +181,23 @@ class SyncContext {
   });
 }
 
+/// Detail of a single failed sync operation.
+class SyncFailure {
+  final String issueKey;
+  final String? worklogId;
+  final String operationType;
+  final int? httpStatus;
+  final String errorMessage;
+
+  SyncFailure({
+    required this.issueKey,
+    this.worklogId,
+    required this.operationType,
+    this.httpStatus,
+    required this.errorMessage,
+  });
+}
+
 /// Result of executing a sync plan.
 class SyncExecutionResult {
   final int tasksCreated;
@@ -192,8 +209,9 @@ class SyncExecutionResult {
   final int titlesPushed;
   final int titlesPulled;
   final int failed;
+  final List<SyncFailure> failures;
 
-  const SyncExecutionResult({
+  SyncExecutionResult({
     this.tasksCreated = 0,
     this.tasksUpdated = 0,
     this.worklogsPushed = 0,
@@ -203,7 +221,8 @@ class SyncExecutionResult {
     this.titlesPushed = 0,
     this.titlesPulled = 0,
     this.failed = 0,
-  });
+    List<SyncFailure>? failures,
+  }) : failures = List.unmodifiable(failures ?? const []);
 }
 
 /// Wraps all Jira integration operations.
@@ -586,8 +605,8 @@ class JiraService {
           if (existingJiraIds.contains(jiraId)) continue;
 
           final timeSpentSeconds = wl['timeSpentSeconds'] as int;
-          final started = DateTime.parse(wl['started'] as String);
-          final jiraCreated = DateTime.parse(wl['created'] as String);
+          final started = _parseJiraDateTime(wl['started'] as String);
+          final jiraCreated = _parseJiraDateTime(wl['created'] as String);
           final durationMs = timeSpentSeconds * 1000;
           final comment = _extractPlainText(wl['comment']);
 
@@ -926,8 +945,8 @@ class JiraService {
         if (authorId != accountId) continue;
 
         final timeSpentSeconds = wl['timeSpentSeconds'] as int;
-        final started = DateTime.parse(wl['started'] as String);
-        final wlCreated = DateTime.parse(wl['created'] as String);
+        final started = _parseJiraDateTime(wl['started'] as String);
+        final wlCreated = _parseJiraDateTime(wl['created'] as String);
         final comment = _extractPlainText(wl['comment']);
 
         final info = JiraWorklogInfo(
@@ -1013,6 +1032,7 @@ class JiraService {
     var titlesPushed = 0;
     var titlesPulled = 0;
     var failed = 0;
+    final failures = <SyncFailure>[];
 
     // Compute total operations for progress tracking
     final preview = context.preview;
@@ -1065,9 +1085,22 @@ class JiraService {
           worklogsPushed++;
         } else {
           failed++;
+          failures.add(SyncFailure(
+            issueKey: issueKey,
+            worklogId: worklog.jiraWorklogId,
+            operationType: 'push-new',
+            httpStatus: response.statusCode,
+            errorMessage: response.body,
+          ));
         }
-      } catch (_) {
+      } catch (e) {
         failed++;
+        failures.add(SyncFailure(
+          issueKey: issueKey,
+          worklogId: worklog.jiraWorklogId,
+          operationType: 'push-new',
+          errorMessage: e.toString(),
+        ));
       }
       completedOps++;
       onProgress?.call('Applying changes', completedOps, totalOps);
@@ -1111,9 +1144,22 @@ class JiraService {
               mismatchesPushed++;
             } else {
               failed++;
+              failures.add(SyncFailure(
+                issueKey: issueKey,
+                worklogId: m.remote.jiraWorklogId,
+                operationType: 'push-mismatch',
+                httpStatus: response.statusCode,
+                errorMessage: response.body,
+              ));
             }
-          } catch (_) {
+          } catch (e) {
             failed++;
+            failures.add(SyncFailure(
+              issueKey: issueKey,
+              worklogId: m.remote.jiraWorklogId,
+              operationType: 'push-mismatch',
+              errorMessage: e.toString(),
+            ));
           }
         case SyncDirection.pull:
           m.local.startMs = m.remote.started.millisecondsSinceEpoch;
@@ -1145,9 +1191,20 @@ class JiraService {
               titlesPushed++;
             } else {
               failed++;
+              failures.add(SyncFailure(
+                issueKey: m.issueKey,
+                operationType: 'push-title',
+                httpStatus: response.statusCode,
+                errorMessage: response.body,
+              ));
             }
-          } catch (_) {
+          } catch (e) {
             failed++;
+            failures.add(SyncFailure(
+              issueKey: m.issueKey,
+              operationType: 'push-title',
+              errorMessage: e.toString(),
+            ));
           }
         case SyncDirection.pull:
           m.localTask.title = m.remoteTitle;
@@ -1174,6 +1231,7 @@ class JiraService {
       titlesPushed: titlesPushed,
       titlesPulled: titlesPulled,
       failed: failed,
+      failures: failures,
     );
   }
 
@@ -1346,6 +1404,21 @@ class JiraService {
   static String _formatJiraDateTime(DateTime dt) {
     final utc = dt.toUtc();
     return '${utc.toIso8601String().split('.').first}.000+0000';
+  }
+
+  /// Parses a Jira Cloud timestamp string to UTC DateTime.
+  ///
+  /// Jira Cloud returns timestamps in "+HHMM" format (no colon separator),
+  /// e.g. "2024-01-15T14:30:00.000+0700". Dart's [DateTime.parse] requires
+  /// "+HH:MM" with a colon. This helper normalizes both forms and always
+  /// returns a UTC [DateTime].
+  static DateTime _parseJiraDateTime(String s) {
+    // Normalize "+HHMM" or "-HHMM" trailing offset to "+HH:MM" / "-HH:MM".
+    final normalized = s.replaceAllMapped(
+      RegExp(r'([+-])(\d{2})(\d{2})$'),
+      (m) => '${m[1]}${m[2]}:${m[3]}',
+    );
+    return DateTime.parse(normalized).toUtc();
   }
 }
 

--- a/mcp/lib/services/jira_service.dart
+++ b/mcp/lib/services/jira_service.dart
@@ -947,7 +947,10 @@ class JiraService {
           final localWl = localByJiraId[jiraId]!;
           final durationDiffers = localWl.durationMs ~/ 1000 != timeSpentSeconds;
           final commentDiffers = (localWl.comment ?? '') != (comment ?? '');
-          final startTimeDiffers = localWl.startMs != started.millisecondsSinceEpoch;
+          // Compare at second precision: _formatJiraDateTime strips ms (sends .000),
+          // so startMs and Jira's returned time can differ by up to 999ms spuriously.
+          final startTimeDiffers =
+              localWl.startMs ~/ 1000 != started.millisecondsSinceEpoch ~/ 1000;
           if (durationDiffers || commentDiffers || startTimeDiffers) {
             worklogMismatches.add(WorklogMismatch(
               local: localWl,

--- a/mcp/test/services/jira_service_test.dart
+++ b/mcp/test/services/jira_service_test.dart
@@ -1562,6 +1562,134 @@ void main() {
       expect(capturedJql, contains("updated >= '-14d'"));
       expect(capturedJql, contains('project in (AG, ABDE)'));
     });
+
+    test('no false mismatch when Jira returns +HHMM timezone offset', () async {
+      // Regression: Jira Cloud returns "started" with "+0700" (no colon).
+      // DateTime.parse requires "+HH:MM". Without the fix, epoch is wrong → false mismatch.
+      await writeProfileConfig();
+
+      // Local worklog starts at 2026-02-10 09:00 UTC (epoch = X).
+      final startUtcMs = DateTime.utc(2026, 2, 10, 9).millisecondsSinceEpoch;
+      final task = await taskService.add(title: 'Timezone task');
+      task.issueId = 'AG-1';
+      task.issueType = IssueType.jira;
+      await db.into(db.tasks).insertOnConflictUpdate(task.toDriftCompanion());
+
+      final worklog = WorklogDocument.create(
+        clock: clock,
+        taskId: task.id,
+        start: startUtcMs,
+        end: startUtcMs + 3600000,
+      );
+      worklog.linkToJira('8001');
+      await db.into(db.worklogEntries).insertOnConflictUpdate(worklog.toDriftCompanion());
+
+      // Jira returns same epoch as "2026-02-10T16:00:00.000+0700" (UTC+7 local = 09:00 UTC)
+      final client = buildPreviewClient(
+        issues: [
+          {'key': 'AG-1', 'fields': {'summary': 'Timezone task'}},
+        ],
+        worklogsByIssue: {
+          'AG-1': [
+            {
+              'id': '8001',
+              'author': {'accountId': 'user-123'},
+              'timeSpentSeconds': 3600,
+              'started': '2026-02-10T16:00:00.000+0700',  // same UTC epoch, +HHMM format
+              'created': '2026-02-10T16:00:00.000+0700',
+            },
+          ],
+        },
+      );
+      final service = createService(httpClient: client);
+      await service.setup(profileName: 'work');
+
+      final ctx = await service.computeSyncPreview();
+      // Should be no mismatches — same epoch, just different timezone representation
+      expect(ctx.preview.worklogMismatches, isEmpty);
+    });
+
+    test('no false mismatch when Jira returns +HH:MM timezone offset', () async {
+      await writeProfileConfig();
+
+      final startUtcMs = DateTime.utc(2026, 2, 10, 9).millisecondsSinceEpoch;
+      final task = await taskService.add(title: 'Colon tz task');
+      task.issueId = 'AG-2';
+      task.issueType = IssueType.jira;
+      await db.into(db.tasks).insertOnConflictUpdate(task.toDriftCompanion());
+
+      final worklog = WorklogDocument.create(
+        clock: clock,
+        taskId: task.id,
+        start: startUtcMs,
+        end: startUtcMs + 3600000,
+      );
+      worklog.linkToJira('8002');
+      await db.into(db.worklogEntries).insertOnConflictUpdate(worklog.toDriftCompanion());
+
+      final client = buildPreviewClient(
+        issues: [
+          {'key': 'AG-2', 'fields': {'summary': 'Colon tz task'}},
+        ],
+        worklogsByIssue: {
+          'AG-2': [
+            {
+              'id': '8002',
+              'author': {'accountId': 'user-123'},
+              'timeSpentSeconds': 3600,
+              'started': '2026-02-10T16:00:00.000+07:00',  // same UTC epoch, +HH:MM format
+              'created': '2026-02-10T16:00:00.000+07:00',
+            },
+          ],
+        },
+      );
+      final service = createService(httpClient: client);
+      await service.setup(profileName: 'work');
+
+      final ctx = await service.computeSyncPreview();
+      expect(ctx.preview.worklogMismatches, isEmpty);
+    });
+
+    test('no false mismatch when Jira returns Z timezone suffix', () async {
+      await writeProfileConfig();
+
+      final startUtcMs = DateTime.utc(2026, 2, 10, 9).millisecondsSinceEpoch;
+      final task = await taskService.add(title: 'Z tz task');
+      task.issueId = 'AG-3';
+      task.issueType = IssueType.jira;
+      await db.into(db.tasks).insertOnConflictUpdate(task.toDriftCompanion());
+
+      final worklog = WorklogDocument.create(
+        clock: clock,
+        taskId: task.id,
+        start: startUtcMs,
+        end: startUtcMs + 3600000,
+      );
+      worklog.linkToJira('8003');
+      await db.into(db.worklogEntries).insertOnConflictUpdate(worklog.toDriftCompanion());
+
+      final client = buildPreviewClient(
+        issues: [
+          {'key': 'AG-3', 'fields': {'summary': 'Z tz task'}},
+        ],
+        worklogsByIssue: {
+          'AG-3': [
+            {
+              'id': '8003',
+              'author': {'accountId': 'user-123'},
+              'timeSpentSeconds': 3600,
+              'started': '2026-02-10T09:00:00.000Z',  // UTC with Z suffix
+              'created': '2026-02-10T09:00:00.000Z',
+            },
+          ],
+        },
+      );
+      final service = createService(httpClient: client);
+      await service.setup(profileName: 'work');
+
+      final ctx = await service.computeSyncPreview();
+      expect(ctx.preview.worklogMismatches, isEmpty);
+    });
   });
 
   // ============================================================
@@ -2164,6 +2292,105 @@ void main() {
       final worklogs = await db.select(db.worklogEntries).get();
       final reconciled = worklogs.firstWhere((w) => w.jiraWorklogId == '14001');
       expect(reconciled.duration, equals(5432000)); // 5432 * 1000
+    });
+
+    test('captures failure detail when push-new returns non-201', () async {
+      final task = await taskService.add(title: 'Push fail task');
+      task.issueId = 'AG-99';
+      task.issueType = IssueType.jira;
+      await db.into(db.tasks).insertOnConflictUpdate(task.toDriftCompanion());
+      await worklogService.manualLog(taskId: task.id, durationMinutes: 30);
+
+      final client = MockClient((request) async {
+        if (request.url.path.contains('/search/jql')) {
+          return http.Response(jsonEncode({
+            'issues': [{'key': 'AG-99', 'fields': {'summary': 'Push fail task'}}],
+          }), 200);
+        }
+        if (request.url.path.contains('/myself')) {
+          return http.Response(jsonEncode({'accountId': 'user-123'}), 200);
+        }
+        if (request.url.path.contains('/worklog')) {
+          if (request.method == 'GET') {
+            return http.Response(jsonEncode({'worklogs': []}), 200);
+          }
+          if (request.method == 'POST') {
+            return http.Response('{"errorMessages":["Permission denied"]}', 403);
+          }
+        }
+        return http.Response('Not found', 404);
+      });
+      final service = await setupService(client);
+
+      final ctx = await service.computeSyncPreview();
+      expect(ctx.preview.newLocalWorklogs, hasLength(1));
+
+      final result = await service.executeSyncPlan(ctx);
+      expect(result.failed, equals(1));
+      expect(result.failures, hasLength(1));
+      expect(result.failures.first.issueKey, equals('AG-99'));
+      expect(result.failures.first.operationType, equals('push-new'));
+      expect(result.failures.first.httpStatus, equals(403));
+    });
+
+    test('captures failure detail when push-mismatch returns non-200', () async {
+      final task = await taskService.add(title: 'Mismatch fail task');
+      task.issueId = 'AG-98';
+      task.issueType = IssueType.jira;
+      await db.into(db.tasks).insertOnConflictUpdate(task.toDriftCompanion());
+
+      final startMs = DateTime.utc(2026, 2, 10, 9).millisecondsSinceEpoch;
+      final worklog = WorklogDocument.create(
+        clock: clock,
+        taskId: task.id,
+        start: startMs,
+        end: startMs + 3600000,
+      );
+      worklog.linkToJira('9901');
+      await db.into(db.worklogEntries).insertOnConflictUpdate(worklog.toDriftCompanion());
+
+      final client = MockClient((request) async {
+        if (request.url.path.contains('/search/jql')) {
+          return http.Response(jsonEncode({
+            'issues': [{'key': 'AG-98', 'fields': {'summary': 'Mismatch fail task'}}],
+          }), 200);
+        }
+        if (request.url.path.contains('/myself')) {
+          return http.Response(jsonEncode({'accountId': 'user-123'}), 200);
+        }
+        if (request.url.path.contains('/worklog')) {
+          if (request.method == 'GET') {
+            return http.Response(jsonEncode({
+              'worklogs': [
+                {
+                  'id': '9901',
+                  'author': {'accountId': 'user-123'},
+                  'timeSpentSeconds': 7200,  // different → mismatch
+                  'started': '2026-02-10T09:00:00.000+0000',
+                  'created': '2026-02-10T09:00:00.000+0000',
+                },
+              ],
+            }), 200);
+          }
+          if (request.method == 'PUT') {
+            return http.Response('{"errorMessages":["Not found"]}', 404);
+          }
+        }
+        return http.Response('Not found', 404);
+      });
+      final service = await setupService(client);
+
+      final ctx = await service.computeSyncPreview();
+      expect(ctx.preview.worklogMismatches, hasLength(1));
+      ctx.preview.worklogMismatches.first.resolution = SyncDirection.push;
+
+      final result = await service.executeSyncPlan(ctx);
+      expect(result.failed, equals(1));
+      expect(result.failures, hasLength(1));
+      expect(result.failures.first.issueKey, equals('AG-98'));
+      expect(result.failures.first.worklogId, equals('9901'));
+      expect(result.failures.first.operationType, equals('push-mismatch'));
+      expect(result.failures.first.httpStatus, equals(404));
     });
   });
 }


### PR DESCRIPTION
## Summary
- Implement `_parseJiraDateTime` helper that normalizes Jira Cloud's `+HHMM` offset format (no colon) to Dart-compatible `+HH:MM` before parsing — fixes root cause of 52 false start-time mismatches
- Replace all 4 bare `DateTime.parse` calls with the new timezone-aware helper
- Add `SyncFailure` class and extend `SyncExecutionResult` with per-failure detail (issueKey, worklogId, operationType, httpStatus, errorMessage)
- Fix all 6 failure points in `executeSyncPlan` (3 `catch` blocks + 3 `else` branches) — each now captures actionable error info instead of just `failed++`
- Print per-failure lines in CLI sync output: `→ [ISSUE-KEY] worklog #ID FAILED: HTTP N - message`
- 381 tests passing (5 new tests for timezone parsing + error capture)

## Test plan
- [x] All 381 tests pass (`cd mcp && dart test`)
- [ ] Manual: run `avo jira sync` against real Jira to verify 0 false mismatches
- [ ] Manual: trigger a sync failure to verify error detail output

Closes requirements from d-513fe0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)