### PR TITLE
feat(phone): stop timer sheet with worklog message prompt

### DIFF
--- a/phone/lib/screens/dashboard_screen.dart
+++ b/phone/lib/screens/dashboard_screen.dart
@@ -9,6 +9,7 @@ import '../settings/settings_screen.dart';
 import '../widgets/connection_indicator.dart';
 import '../widgets/plan_category_table.dart';
 import '../widgets/planned_task_list.dart';
+import '../widgets/stop_timer_sheet.dart';
 import '../widgets/timer_status_bar.dart';
 import '../widgets/worklog_summary.dart';
 import 'edit_plan_screen.dart';
@@ -53,24 +54,44 @@ class _DashboardScreenState extends State<DashboardScreen> {
     if (mounted) setState(() {});
   }
 
-  Future<void> _stopTimer() async {
-    final result = await widget.writeService.stopTimerAndLog();
+  Future<void> _showStopTimerSheet(TimerSnapshot timer) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => StopTimerSheet(
+        initialMessage: timer.note,
+        taskId: timer.taskId,
+        onSave: (message, markDone) async {
+          final result =
+              await widget.writeService.stopTimerAndLog(comment: message);
 
-    // Push deltas to desktop (fire-and-forget)
-    final timerDelta = await widget.writeService.getTimerDelta();
-    final worklogDelta = result.worklogId != null
-        ? await widget.writeService.getWorklogDelta(result.worklogId!)
-        : null;
-    final deltas = [?timerDelta, ?worklogDelta];
-    if (deltas.isNotEmpty) widget.onPushDeltas?.call(deltas);
+          // Push deltas to desktop (fire-and-forget)
+          final timerDelta = await widget.writeService.getTimerDelta();
+          final worklogDelta = result.worklogId != null
+              ? await widget.writeService.getWorklogDelta(result.worklogId!)
+              : null;
+          final deltas = [?timerDelta, ?worklogDelta];
 
-    await widget.dashboardProvider.refresh();
-    if (!mounted) return;
-    final msg = result.worklogId != null
-        ? 'Timer stopped. Worklog created.'
-        : 'Timer stopped.';
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(msg), duration: const Duration(seconds: 2)),
+          if (markDone && timer.taskId != null) {
+            await widget.writeService.toggleTaskDone(timer.taskId!);
+            final taskDelta =
+                await widget.writeService.getTaskDelta(timer.taskId!);
+            if (taskDelta != null) deltas.add(taskDelta);
+          }
+
+          if (deltas.isNotEmpty) widget.onPushDeltas?.call(deltas);
+
+          await widget.dashboardProvider.refresh();
+          if (!mounted) return;
+          Navigator.of(context).pop();
+          final msg = result.worklogId != null
+              ? 'Timer stopped. Worklog created.'
+              : 'Timer stopped.';
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(msg), duration: const Duration(seconds: 2)),
+          );
+        },
+      ),
     );
   }
 
@@ -274,7 +295,9 @@ class _DashboardScreenState extends State<DashboardScreen> {
           // Timer
           TimerStatusBar(
             timer: s.timer,
-            onStop: s.timer != null ? _stopTimer : null,
+            onStop: s.timer != null
+                ? () => _showStopTimerSheet(s.timer!)
+                : null,
           ),
           const SizedBox(height: 8),
 

--- a/phone/lib/widgets/stop_timer_sheet.dart
+++ b/phone/lib/widgets/stop_timer_sheet.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+
+/// A bottom sheet that prompts the user for a worklog message before stopping
+/// the active timer.
+///
+/// The message field is pre-filled from the timer note and is required —
+/// the Save button is disabled until the field is non-empty.
+///
+/// Usage:
+/// ```dart
+/// showModalBottomSheet(
+///   context: context,
+///   isScrollControlled: true,
+///   builder: (_) => StopTimerSheet(
+///     initialMessage: timer.note,
+///     taskId: timer.taskId,
+///     onSave: (message, markDone) async { ... },
+///   ),
+/// );
+/// ```
+class StopTimerSheet extends StatefulWidget {
+  /// Pre-filled message text (from timer note). User can edit before saving.
+  final String? initialMessage;
+
+  /// Task ID for the mark-as-done toggle. If null, the toggle is hidden.
+  final String? taskId;
+
+  /// Called when user taps Save with a non-empty message.
+  final Future<void> Function(String message, bool markDone) onSave;
+
+  const StopTimerSheet({
+    super.key,
+    this.initialMessage,
+    this.taskId,
+    required this.onSave,
+  });
+
+  @override
+  State<StopTimerSheet> createState() => _StopTimerSheetState();
+}
+
+class _StopTimerSheetState extends State<StopTimerSheet> {
+  late final TextEditingController _messageController;
+  bool _markDone = false;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _messageController =
+        TextEditingController(text: widget.initialMessage ?? '');
+    _messageController.addListener(_onMessageChanged);
+  }
+
+  @override
+  void dispose() {
+    _messageController.dispose();
+    super.dispose();
+  }
+
+  void _onMessageChanged() => setState(() {});
+
+  bool get _canSave =>
+      _messageController.text.trim().isNotEmpty && !_saving;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Handle bar
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  margin: const EdgeInsets.only(bottom: 16),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.outlineVariant,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+
+              Text('Stop Timer', style: theme.textTheme.titleLarge),
+              const SizedBox(height: 16),
+
+              Text('Worklog message', style: theme.textTheme.labelMedium),
+              const SizedBox(height: 6),
+              TextField(
+                controller: _messageController,
+                enabled: !_saving,
+                minLines: 2,
+                maxLines: 5,
+                autofocus: true,
+                decoration: const InputDecoration(
+                  hintText: 'What did you work on?',
+                  border: OutlineInputBorder(),
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 10,
+                  ),
+                ),
+              ),
+
+              if (widget.taskId != null) ...[
+                const SizedBox(height: 12),
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: Text(
+                    'Mark task as done',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  value: _markDone,
+                  onChanged:
+                      _saving ? null : (v) => setState(() => _markDone = v),
+                ),
+              ],
+
+              const SizedBox(height: 20),
+
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: _canSave ? _save : null,
+                  icon: _saving
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.stop_circle_outlined),
+                  label: const Text('Save'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _save() async {
+    if (!_canSave) return;
+    setState(() => _saving = true);
+    try {
+      await widget.onSave(_messageController.text.trim(), _markDone);
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `StopTimerSheet` bottom sheet widget that appears when tapping Stop on a running timer
- Captures worklog message (required), pre-fills from timer note if available
- Includes "Mark as done" toggle to optionally complete the task on stop
- Save button disabled until message is non-empty
- Follows existing `DeploySheet` pattern for keyboard handling and Material 3 UX

## Files Changed
- `phone/lib/widgets/stop_timer_sheet.dart` (new) — StopTimerSheet widget
- `phone/lib/screens/dashboard_screen.dart` (modified) — Wire stop button to show sheet

## Requirements
Implements approved requirements from `2026-03-19-review-phone-timer-stop-message-prompt`

## Test plan
- [ ] Tap Stop on running timer → bottom sheet appears
- [ ] Message field pre-fills with timer note (if set)
- [ ] Save disabled when message empty
- [ ] Save stops timer, creates worklog with message
- [ ] Mark-as-done toggle marks task done when enabled
- [ ] Dismiss sheet without saving → timer keeps running
- [ ] Delta push to desktop works after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)