### PR TITLE
feat: fix phone deploy logging — mode flag, repo picker

### DIFF
--- a/mcp/lib/services/agent_api_service.dart
+++ b/mcp/lib/services/agent_api_service.dart
@@ -1770,6 +1770,7 @@ class AgentApiService {
     final team = json['team'] as String?;
     final mode = json['mode'] as String?;
     final objective = json['objective'] as String?;
+    final repo = json['repo'] as String?;
 
     if (team == null || team.isEmpty) {
       _jsonResponse(
@@ -1787,6 +1788,15 @@ class AgentApiService {
       _jsonResponse(
           request, HttpStatus.badRequest, {'error': 'Invalid team name'});
       return;
+    }
+
+    // Validate repo if provided (alphanumeric + hyphens only — no shell injection)
+    if (repo != null && repo.isNotEmpty) {
+      if (!RegExp(r'^[a-zA-Z0-9_-]+$').hasMatch(repo)) {
+        _jsonResponse(
+            request, HttpStatus.badRequest, {'error': 'Invalid repo name'});
+        return;
+      }
     }
 
     // Validate team + mode against YAML whitelist
@@ -1810,6 +1820,13 @@ class AgentApiService {
       return;
     }
 
+    // Reject interactive modes — cannot be launched headlessly from phone
+    if (deployMode.modeType == 'interactive') {
+      _jsonResponse(request, HttpStatus.badRequest,
+          {'error': 'Interactive modes cannot be launched from phone'});
+      return;
+    }
+
     // Validate objective (optional field)
     if (objective != null && objective.isNotEmpty) {
       if (objective.length > 500) {
@@ -1826,15 +1843,17 @@ class AgentApiService {
     }
 
     // Build pa command
-    // daily team: `pa daily <mode>` — all other teams: `pa deploy <team> [--flag]`
+    // daily team: `pa daily <mode>` — all other teams: `pa deploy <team> --mode <mode> --background`
     final List<String> args;
     if (team == 'daily') {
       args = ['daily', mode];
     } else {
-      args = ['deploy', team];
-      if (mode == 'background') args.add('--background');
-      if (mode == 'interactive') args.add('--interactive');
-      // foreground: no extra flag
+      args = ['deploy', team, '--mode', mode];
+      // All phone deploys run in background (interactive modes already rejected above)
+      args.add('--background');
+      if (repo != null && repo.isNotEmpty) {
+        args.addAll(['--repo', repo]);
+      }
     }
 
     // Append --objective flag if provided
@@ -2287,11 +2306,13 @@ class _DeployMode {
   final String id;
   final String label;
   final bool phoneVisible;
+  final String? modeType;
 
   const _DeployMode({
     required this.id,
     required this.label,
     required this.phoneVisible,
+    this.modeType,
   });
 
   /// Parse a deploy mode from a map of YAML key-value pairs.
@@ -2300,7 +2321,9 @@ class _DeployMode {
     final label = map['label'];
     if (id == null || id.isEmpty || label == null || label.isEmpty) return null;
     final phoneVisible = map['phone_visible']?.toLowerCase() == 'true';
-    return _DeployMode(id: id, label: label, phoneVisible: phoneVisible);
+    final modeType = map['mode_type'];
+    return _DeployMode(
+        id: id, label: label, phoneVisible: phoneVisible, modeType: modeType);
   }
 
   Map<String, dynamic> toJson() => {'id': id, 'label': label};

--- a/mcp/lib/services/agent_api_service.dart
+++ b/mcp/lib/services/agent_api_service.dart
@@ -128,6 +128,8 @@ class AgentApiService {
         await _handleTeamBrowse(request);
       } else if (path == '/api/pa-teams' && method == 'GET') {
         await _handleListPaTeams(request);
+      } else if (path == '/api/pa-repos' && method == 'GET') {
+        await _handleListPaRepos(request);
       } else if (path == '/api/agent-teams' && method == 'GET') {
         await _handleListAgentTeams(request);
       } else if (path == '/api/deploy' && method == 'POST') {
@@ -1732,6 +1734,117 @@ class AgentApiService {
         {'teams': teams.map((t) => t.toJson()).toList()});
   }
 
+  /// GET /api/pa-repos — List available PA repos from repos.yaml.
+  ///
+  /// Searches for repos.yaml in:
+  ///   1. PA_CONFIG/repos.yaml (if PA_CONFIG is set)
+  ///   2. ~/.config/sinh-x/personal-assistant/repos.yaml
+  ///   3. PA_HOME/repos.yaml
+  ///
+  /// Returns: `{"repos": [{"name": "...", "path": "...", "description": "..."}]}`
+  /// Returns empty list if no repos.yaml found — not an error.
+  Future<void> _handleListPaRepos(HttpRequest request) async {
+    final repos = _loadPaRepos();
+    _jsonResponse(request, HttpStatus.ok,
+        {'repos': repos.map((r) => r.toJson()).toList()});
+  }
+
+  /// Load repos from repos.yaml, searching config dir → user config dir → PA_HOME.
+  List<_PaRepo> _loadPaRepos() {
+    final home = Platform.environment['HOME'] ?? '/home';
+    final searchPaths = <String>[];
+    if (paConfigDir != null) {
+      searchPaths.add(p.join(paConfigDir!, 'repos.yaml'));
+    }
+    searchPaths
+        .add(p.join(home, '.config', 'sinh-x', 'personal-assistant', 'repos.yaml'));
+    searchPaths.add(p.join(paHome, 'repos.yaml'));
+
+    for (final path in searchPaths) {
+      final file = File(path);
+      if (!file.existsSync()) continue;
+      try {
+        return _parseReposYaml(file.readAsStringSync());
+      } catch (e) {
+        stderr.writeln('Error parsing repos.yaml at $path: $e');
+      }
+    }
+    return [];
+  }
+
+  /// Parse repos.yaml content into a list of [_PaRepo].
+  ///
+  /// Expected format:
+  /// ```yaml
+  /// repos:
+  ///   personal-assistant:
+  ///     path: ~/git-repos/.../personal-assistant
+  ///     description: Optional description
+  /// ```
+  List<_PaRepo> _parseReposYaml(String content) {
+    final repos = <_PaRepo>[];
+    final home = Platform.environment['HOME'] ?? '/home';
+
+    bool inRepos = false;
+    String? currentName;
+    String? currentPath;
+    String? currentDescription;
+
+    void flushCurrent() {
+      if (currentName != null && currentPath != null) {
+        final expandedPath = currentPath!.startsWith('~/')
+            ? p.join(home, currentPath!.substring(2))
+            : currentPath!;
+        repos.add(_PaRepo(
+          name: currentName!,
+          path: expandedPath,
+          description: currentDescription,
+        ));
+      }
+      currentName = null;
+      currentPath = null;
+      currentDescription = null;
+    }
+
+    for (final rawLine in content.split('\n')) {
+      final line = rawLine.trimRight();
+      if (line.isEmpty || line.trimLeft().startsWith('#')) continue;
+
+      // Top-level key (no indentation)
+      if (!line.startsWith(' ') && !line.startsWith('\t')) {
+        flushCurrent();
+        inRepos = line.trim() == 'repos:';
+        continue;
+      }
+
+      if (!inRepos) continue;
+
+      // 2-space indent: repo name (key only, no value)
+      final twoSpaceMatch = RegExp(r'^  ([a-zA-Z0-9_-]+):\s*$').firstMatch(line);
+      if (twoSpaceMatch != null) {
+        flushCurrent();
+        currentName = twoSpaceMatch.group(1);
+        continue;
+      }
+
+      // 4-space indent: key: value
+      if (currentName != null) {
+        final pathMatch = RegExp(r'^    path:\s*(.+)$').firstMatch(line);
+        if (pathMatch != null) {
+          currentPath = pathMatch.group(1)!.trim();
+          continue;
+        }
+        final descMatch = RegExp(r'^    description:\s*(.+)$').firstMatch(line);
+        if (descMatch != null) {
+          currentDescription = descMatch.group(1)!.trim();
+          continue;
+        }
+      }
+    }
+    flushCurrent();
+    return repos;
+  }
+
   /// POST /api/deploy — Trigger a PA team deployment.
   ///
   /// Body (JSON): `{"team": "builder", "mode": "background", "objective": "..."}`
@@ -2327,4 +2440,18 @@ class _DeployMode {
   }
 
   Map<String, dynamic> toJson() => {'id': id, 'label': label};
+}
+
+class _PaRepo {
+  final String name;
+  final String path;
+  final String? description;
+
+  const _PaRepo({required this.name, required this.path, this.description});
+
+  Map<String, dynamic> toJson() {
+    final m = <String, dynamic>{'name': name, 'path': path};
+    if (description != null) m['description'] = description;
+    return m;
+  }
 }

--- a/phone/lib/models/pa_team.dart
+++ b/phone/lib/models/pa_team.dart
@@ -30,12 +30,35 @@ class DeployMode {
   final String id;
   final String label;
 
-  const DeployMode({required this.id, required this.label});
+  /// Execution mode type from team YAML (`work`, `housekeeping`, `interactive`, etc.).
+  final String? modeType;
+
+  const DeployMode({required this.id, required this.label, this.modeType});
 
   factory DeployMode.fromJson(Map<String, dynamic> json) {
     return DeployMode(
       id: json['id'] as String,
       label: json['label'] as String,
+      modeType: json['mode_type'] as String?,
+    );
+  }
+}
+
+/// A repo entry from the PA repos registry.
+///
+/// Deserialized from GET /api/pa-repos response.
+class PaRepo {
+  final String name;
+  final String path;
+  final String? description;
+
+  const PaRepo({required this.name, required this.path, this.description});
+
+  factory PaRepo.fromJson(Map<String, dynamic> json) {
+    return PaRepo(
+      name: json['name'] as String,
+      path: json['path'] as String,
+      description: json['description'] as String?,
     );
   }
 }

--- a/phone/lib/screens/item_detail_screen.dart
+++ b/phone/lib/screens/item_detail_screen.dart
@@ -27,11 +27,15 @@ class ItemDetailScreen extends StatefulWidget {
   /// a deploy icon button appears in the AppBar.
   final List<PaTeam>? paTeams;
 
+  /// PA repos for the optional repo picker in the deploy sheet.
+  final List<PaRepo>? paRepos;
+
   const ItemDetailScreen({
     super.key,
     required this.item,
     required this.reviewProvider,
     this.paTeams,
+    this.paRepos,
   });
 
   @override
@@ -677,15 +681,17 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
       isScrollControlled: true,
       builder: (_) => DeploySheet(
         paTeams: widget.paTeams!,
+        paRepos: widget.paRepos ?? const [],
         initialTeam: team,
         initialObjective: widget.item.id,
-        onDeploy: (t, mode, objective) async {
+        onDeploy: (t, mode, objective, {repo}) async {
           Navigator.pop(context);
           try {
             final result = await widget.reviewProvider.client.triggerDeployment(
               t,
               mode,
               objective: objective.isNotEmpty ? objective : null,
+              repo: repo,
             );
             if (mounted) {
               messenger.showSnackBar(SnackBar(

--- a/phone/lib/screens/review_queue_screen.dart
+++ b/phone/lib/screens/review_queue_screen.dart
@@ -55,6 +55,7 @@ class ReviewQueueScreen extends StatelessWidget {
                 _InboxTabView(
                   reviewProvider: reviewProvider,
                   paTeams: teamBrowserProvider?.paTeams,
+                  paRepos: teamBrowserProvider?.paRepos,
                 ),
                 FolderListView(
                     folder: 'approved', client: reviewProvider.client),
@@ -283,8 +284,10 @@ class _IdeasTabViewState extends State<_IdeasTabView> {
 class _InboxTabView extends StatefulWidget {
   final ReviewProvider reviewProvider;
   final List<PaTeam>? paTeams;
+  final List<PaRepo>? paRepos;
 
-  const _InboxTabView({required this.reviewProvider, this.paTeams});
+  const _InboxTabView(
+      {required this.reviewProvider, this.paTeams, this.paRepos});
 
   @override
   State<_InboxTabView> createState() => _InboxTabViewState();
@@ -666,6 +669,7 @@ class _InboxTabViewState extends State<_InboxTabView> {
           item: item,
           reviewProvider: widget.reviewProvider,
           paTeams: widget.paTeams,
+          paRepos: widget.paRepos,
         ),
       ),
     );

--- a/phone/lib/screens/team_browser_screen.dart
+++ b/phone/lib/screens/team_browser_screen.dart
@@ -28,6 +28,9 @@ class _TeamBrowserScreenState extends State<TeamBrowserScreen> {
     if (widget.teamProvider.paTeams.isEmpty) {
       widget.teamProvider.loadPaTeams();
     }
+    if (widget.teamProvider.paRepos.isEmpty) {
+      widget.teamProvider.loadRepos();
+    }
   }
 
   @override
@@ -99,13 +102,15 @@ class _TeamBrowserScreenState extends State<TeamBrowserScreen> {
       isScrollControlled: true,
       builder: (_) => DeploySheet(
         paTeams: widget.teamProvider.paTeams,
-        onDeploy: (team, mode, objective) async {
+        paRepos: widget.teamProvider.paRepos,
+        onDeploy: (team, mode, objective, {repo}) async {
           Navigator.pop(context);
           try {
             final result = await widget.teamProvider.deploy(
               team,
               mode,
               objective: objective.isNotEmpty ? objective : null,
+              repo: repo,
             );
             if (mounted) {
               messenger.showSnackBar(
@@ -611,15 +616,17 @@ class _TeamFileViewScreenState extends State<_TeamFileViewScreen> {
       isScrollControlled: true,
       builder: (_) => DeploySheet(
         paTeams: widget.teamProvider.paTeams,
+        paRepos: widget.teamProvider.paRepos,
         initialTeam: widget.team,
         initialObjective: widget.file.name,
-        onDeploy: (team, mode, objective) async {
+        onDeploy: (team, mode, objective, {repo}) async {
           Navigator.pop(context);
           try {
             final result = await widget.teamProvider.deploy(
               team,
               mode,
               objective: objective.isNotEmpty ? objective : null,
+              repo: repo,
             );
             if (mounted) {
               messenger.showSnackBar(SnackBar(

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -315,18 +315,34 @@ class AgentApiClient {
         .toList();
   }
 
+  /// List available PA repos from the repos registry.
+  ///
+  /// Returns empty list if no repos.yaml configured — not an error.
+  Future<List<PaRepo>> listPaRepos() async {
+    final response = await _get('/api/pa-repos');
+    final repos = response['repos'] as List;
+    return repos
+        .map((e) => PaRepo.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
   /// Trigger a PA team deployment.
   ///
   /// Validates team + mode on the server before executing.
   /// Returns immediately after the subprocess is started.
+  /// Optional [repo] passes `--repo <name>` to PA (for codebase-aware modes).
   Future<DeployResult> triggerDeployment(
     String team,
     String mode, {
     String? objective,
+    String? repo,
   }) async {
     final body = <String, dynamic>{'team': team, 'mode': mode};
     if (objective != null && objective.isNotEmpty) {
       body['objective'] = objective;
+    }
+    if (repo != null && repo.isNotEmpty) {
+      body['repo'] = repo;
     }
     final response = await _post('/api/deploy', body: body);
     return DeployResult.fromJson(response);

--- a/phone/lib/services/team_browser_provider.dart
+++ b/phone/lib/services/team_browser_provider.dart
@@ -13,6 +13,7 @@ class TeamBrowserProvider extends ChangeNotifier {
   List<TeamFolder> _teams = [];
   List<TeamFile> _files = [];
   List<PaTeam> _paTeams = [];
+  List<PaRepo> _paRepos = [];
   bool _loading = false;
   String? _error;
 
@@ -21,6 +22,7 @@ class TeamBrowserProvider extends ChangeNotifier {
   List<TeamFolder> get teams => _teams;
   List<TeamFile> get files => _files;
   List<PaTeam> get paTeams => _paTeams;
+  List<PaRepo> get paRepos => _paRepos;
   bool get loading => _loading;
   String? get error => _error;
 
@@ -43,9 +45,23 @@ class TeamBrowserProvider extends ChangeNotifier {
     }
   }
 
+  /// Fetch PA repos from the repos registry.
+  Future<void> loadRepos() async {
+    try {
+      _paRepos = await _client.listPaRepos();
+      notifyListeners();
+    } catch (e) {
+      debugPrint('TeamBrowserProvider loadRepos error: $e');
+    }
+  }
+
   /// Trigger a PA team deployment.
-  Future<DeployResult> deploy(String team, String mode, {String? objective}) {
-    return _client.triggerDeployment(team, mode, objective: objective);
+  ///
+  /// Optional [repo] passes `--repo <name>` to PA for codebase-aware modes.
+  Future<DeployResult> deploy(String team, String mode,
+      {String? objective, String? repo}) {
+    return _client.triggerDeployment(team, mode,
+        objective: objective, repo: repo);
   }
 
   /// Fetch team list.

--- a/phone/lib/widgets/deploy_sheet.dart
+++ b/phone/lib/widgets/deploy_sheet.dart
@@ -25,6 +25,10 @@ class DeploySheet extends StatefulWidget {
   /// All PA teams with deploy modes.
   final List<PaTeam> paTeams;
 
+  /// Available PA repos for the optional repo picker.
+  /// When empty, the repo dropdown is hidden.
+  final List<PaRepo> paRepos;
+
   /// Pre-selected team name. If null, user must select from [paTeams].
   final String? initialTeam;
 
@@ -33,12 +37,14 @@ class DeploySheet extends StatefulWidget {
 
   /// Called when user taps Launch.
   /// [objective] may be empty string if user left the field blank.
-  final Future<void> Function(String team, String mode, String objective)
-      onDeploy;
+  /// [repo] is null when no repo was selected.
+  final Future<void> Function(String team, String mode, String objective,
+      {String? repo}) onDeploy;
 
   const DeploySheet({
     super.key,
     required this.paTeams,
+    this.paRepos = const [],
     this.initialTeam,
     this.initialObjective,
     required this.onDeploy,
@@ -51,6 +57,7 @@ class DeploySheet extends StatefulWidget {
 class _DeploySheetState extends State<DeploySheet> {
   String? _selectedTeam;
   String? _selectedMode;
+  String? _selectedRepo;
   bool _deploying = false;
   late final TextEditingController _objectiveController;
 
@@ -159,6 +166,19 @@ class _DeploySheetState extends State<DeploySheet> {
                   const SizedBox(height: 16),
                 ],
 
+                // Repo picker (hidden when no repos configured)
+                if (widget.paRepos.isNotEmpty) ...[
+                  Text('Repo (optional)', style: theme.textTheme.labelMedium),
+                  const SizedBox(height: 6),
+                  _RepoSelector(
+                    paRepos: widget.paRepos,
+                    selectedRepo: _selectedRepo,
+                    enabled: !_deploying,
+                    onChanged: (repo) => setState(() => _selectedRepo = repo),
+                  ),
+                  const SizedBox(height: 16),
+                ],
+
                 // Objective field
                 Text('Objective (optional)', style: theme.textTheme.labelMedium),
                 const SizedBox(height: 6),
@@ -245,10 +265,68 @@ class _DeploySheetState extends State<DeploySheet> {
         _selectedTeam!,
         _selectedMode!,
         _objectiveController.text.trim(),
+        repo: _selectedRepo,
       );
     } finally {
       if (mounted) setState(() => _deploying = false);
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Repo selector widget
+// ---------------------------------------------------------------------------
+
+class _RepoSelector extends StatelessWidget {
+  final List<PaRepo> paRepos;
+  final String? selectedRepo;
+  final bool enabled;
+  final void Function(String?) onChanged;
+
+  const _RepoSelector({
+    required this.paRepos,
+    required this.selectedRepo,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return InputDecorator(
+      decoration: const InputDecoration(
+        border: OutlineInputBorder(),
+        contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      ),
+      child: DropdownButton<String>(
+        value: selectedRepo,
+        isExpanded: true,
+        underline: const SizedBox.shrink(),
+        hint: Text(
+          'None (no repo context)',
+          style: theme.textTheme.bodyMedium
+              ?.copyWith(color: theme.colorScheme.outline),
+        ),
+        items: [
+          DropdownMenuItem<String>(
+            value: null,
+            child: Text(
+              'None',
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: theme.colorScheme.outline),
+            ),
+          ),
+          ...paRepos.map(
+            (r) => DropdownMenuItem(
+              value: r.name,
+              child: Text(r.name),
+            ),
+          ),
+        ],
+        onChanged: enabled ? onChanged : null,
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- **Phase 2**: Fix `_handleDeploy` to pass `--mode <mode_id>` to PA CLI, determine execution mode from `mode_type` (not id string matching), reject interactive modes with 400, pass `--repo` when provided. Fix YAML parser to read `mode_type`.
- **Phase 3**: Add `GET /api/pa-repos` endpoint, update phone models with `modeType` and `PaRepo`, add repo picker dropdown to deploy sheet.

## Context
Phone-triggered deploys failed silently: `--mode` flag was never passed, `--background` was only added by string-matching the id. This PR fixes the root cause and adds repo selection from phone.

## Requirements
See: `~/Documents/ai-usage/agent-teams/builder/inbox/2026-03-20-2026-03-20-review-fix-phone-deploy-logging.md`

## Test plan
- [ ] Phone deploy with mode=spike sends `--mode spike --background` to PA CLI
- [ ] Interactive modes rejected with 400 from phone
- [ ] Repo picker shows repos from `/api/pa-repos` (hidden when none configured)
- [ ] `--repo` flag passed when repo selected
- [ ] Existing CLI deploy behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)