### PR TITLE
feat(phone): kanban board UI with ticket & bulletin API integration

### DIFF
--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -5,10 +5,12 @@ import 'package:flutter/material.dart';
 
 import 'screens/dashboard_screen.dart';
 import 'screens/deployment_screen.dart';
+import 'screens/kanban_board_screen.dart';
 import 'screens/review_queue_screen.dart';
 import 'screens/team_browser_screen.dart';
 import 'screens/timers_screen.dart';
 import 'services/agent_api_client.dart';
+import 'services/board_provider.dart';
 import 'services/crdt_sync_service.dart';
 import 'services/deployment_provider.dart';
 import 'services/local_dashboard_provider.dart';
@@ -38,6 +40,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
   ReviewProvider? _reviewProvider;
   DeploymentProvider? _deploymentProvider;
   TeamBrowserProvider? _teamBrowserProvider;
+  BoardProvider? _boardProvider;
   Timer? _syncTimer;
 
   @override
@@ -82,6 +85,10 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
     teamBrowserProvider.refreshTeams();
     teamBrowserProvider.loadPaTeams();
 
+    final boardProvider = BoardProvider(apiClient);
+    boardProvider.refresh();
+    boardProvider.startPolling();
+
     setState(() {
       _db = db;
       _dashboardProvider = dashboardProvider;
@@ -91,6 +98,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
       _reviewProvider = reviewProvider;
       _deploymentProvider = deploymentProvider;
       _teamBrowserProvider = teamBrowserProvider;
+      _boardProvider = boardProvider;
     });
 
     // Initial pull + dashboard render
@@ -134,6 +142,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
   @override
   void dispose() {
     _syncTimer?.cancel();
+    _boardProvider?.dispose();
     _teamBrowserProvider?.dispose();
     _deploymentProvider?.dispose();
     _reviewProvider?.dispose();
@@ -170,14 +179,14 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
               reviewProvider: _reviewProvider!,
               deploymentProvider: _deploymentProvider!,
               teamBrowserProvider: _teamBrowserProvider!,
+              boardProvider: _boardProvider!,
               onPushDeltas: _pushDeltas,
             ),
     );
   }
-
 }
 
-/// Shell with bottom navigation between Dashboard, Agent Review, Deployments, and Teams.
+/// Shell with bottom navigation between Kanban, Dashboard, Agent Review, Deployments, and Teams.
 class _HomeShell extends StatefulWidget {
   final LocalDashboardProvider dashboardProvider;
   final LocalWriteService writeService;
@@ -185,6 +194,7 @@ class _HomeShell extends StatefulWidget {
   final ReviewProvider reviewProvider;
   final DeploymentProvider deploymentProvider;
   final TeamBrowserProvider teamBrowserProvider;
+  final BoardProvider boardProvider;
   final Future<void> Function(List<Map<String, dynamic>>)? onPushDeltas;
 
   const _HomeShell({
@@ -194,6 +204,7 @@ class _HomeShell extends StatefulWidget {
     required this.reviewProvider,
     required this.deploymentProvider,
     required this.teamBrowserProvider,
+    required this.boardProvider,
     this.onPushDeltas,
   });
 
@@ -207,27 +218,31 @@ class _HomeShellState extends State<_HomeShell> {
   @override
   void initState() {
     super.initState();
-    widget.reviewProvider.addListener(_onReviewUpdate);
+    widget.reviewProvider.addListener(_onUpdate);
+    widget.boardProvider.addListener(_onUpdate);
   }
 
   @override
   void dispose() {
-    widget.reviewProvider.removeListener(_onReviewUpdate);
+    widget.reviewProvider.removeListener(_onUpdate);
+    widget.boardProvider.removeListener(_onUpdate);
     super.dispose();
   }
 
-  void _onReviewUpdate() {
+  void _onUpdate() {
     if (mounted) setState(() {});
   }
 
   @override
   Widget build(BuildContext context) {
     final pendingCount = widget.reviewProvider.pendingCount;
+    final actionableCount = widget.boardProvider.actionableCount;
 
     return Scaffold(
       body: IndexedStack(
         index: _currentIndex,
         children: [
+          KanbanBoardScreen(boardProvider: widget.boardProvider),
           DashboardScreen(
             dashboardProvider: widget.dashboardProvider,
             writeService: widget.writeService,
@@ -299,6 +314,21 @@ class _HomeShellState extends State<_HomeShell> {
         onDestinationSelected: (index) =>
             setState(() => _currentIndex = index),
         destinations: [
+          NavigationDestination(
+            icon: actionableCount > 0
+                ? Badge(
+                    label: Text('$actionableCount'),
+                    child: const Icon(Icons.view_kanban_outlined),
+                  )
+                : const Icon(Icons.view_kanban_outlined),
+            selectedIcon: actionableCount > 0
+                ? Badge(
+                    label: Text('$actionableCount'),
+                    child: const Icon(Icons.view_kanban),
+                  )
+                : const Icon(Icons.view_kanban),
+            label: 'Kanban',
+          ),
           const NavigationDestination(
             icon: Icon(Icons.dashboard_outlined),
             selectedIcon: Icon(Icons.dashboard),

--- a/phone/lib/models/bulletin.dart
+++ b/phone/lib/models/bulletin.dart
@@ -1,0 +1,52 @@
+// Data model for PA system bulletins.
+//
+// Matches the API response shape from pa serve /api/bulletin.
+// The [block] field is either the String "all" or a List of team name strings.
+
+class Bulletin {
+  final String id;
+  final String title;
+  final dynamic block; // String "all" or List<String>
+  final List<String> except;
+  final String? message;
+  final String status; // "active" or "resolved"
+  final DateTime created;
+
+  const Bulletin({
+    required this.id,
+    required this.title,
+    required this.block,
+    required this.except,
+    this.message,
+    required this.status,
+    required this.created,
+  });
+
+  /// Whether this bulletin is currently active.
+  bool get isActive => status == 'active';
+
+  /// Whether this bulletin blocks all teams.
+  bool get blocksAll => block == 'all';
+
+  /// Returns the list of blocked teams, or empty list if blocks all.
+  List<String> get blockedTeams {
+    if (block is List) {
+      return (block as List).map((e) => e as String).toList();
+    }
+    return [];
+  }
+
+  factory Bulletin.fromJson(Map<String, dynamic> json) {
+    final exceptList = json['except'] as List? ?? [];
+    return Bulletin(
+      id: json['id'] as String? ?? '',
+      title: json['title'] as String? ?? '',
+      block: json['block'] ?? 'all',
+      except: exceptList.map((e) => e as String).toList(),
+      message: json['message'] as String?,
+      status: json['status'] as String? ?? 'active',
+      created: DateTime.tryParse(json['created'] as String? ?? '') ??
+          DateTime.now(),
+    );
+  }
+}

--- a/phone/lib/models/ticket.dart
+++ b/phone/lib/models/ticket.dart
@@ -1,0 +1,156 @@
+// Data models for the PA ticket/kanban system.
+//
+// Matches the API response shapes from pa serve /api/tickets and /api/board.
+// JSON keys are camelCase as returned by the server.
+
+class TicketComment {
+  final String author;
+  final String content;
+  final DateTime timestamp;
+
+  const TicketComment({
+    required this.author,
+    required this.content,
+    required this.timestamp,
+  });
+
+  factory TicketComment.fromJson(Map<String, dynamic> json) {
+    return TicketComment(
+      author: json['author'] as String? ?? '',
+      content: json['content'] as String? ?? '',
+      timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+          DateTime.now(),
+    );
+  }
+}
+
+class Ticket {
+  final String id; // e.g. "PA-001"
+  final String project;
+  final String title;
+  final String? summary;
+  final String? description;
+  final String status; // idea|requirement-review|pending-approval|pending-implementation|implementing|review-uat|done|rejected|cancelled|on-hold
+  final String priority; // critical|high|medium|low|normal
+  final String? type; // feature|bug|task|review-request|work-report|fyi|idea|question
+  final String? team;
+  final String? assignee;
+  final String? estimate; // XS|S|M|L|XL
+  final String? from;
+  final String? to;
+  final List<String> tags;
+  final List<String> dependencies;
+  final String? docRef;
+  final List<TicketComment> comments;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? resolvedAt;
+
+  const Ticket({
+    required this.id,
+    required this.project,
+    required this.title,
+    this.summary,
+    this.description,
+    required this.status,
+    required this.priority,
+    this.type,
+    this.team,
+    this.assignee,
+    this.estimate,
+    this.from,
+    this.to,
+    required this.tags,
+    required this.dependencies,
+    this.docRef,
+    required this.comments,
+    required this.createdAt,
+    required this.updatedAt,
+    this.resolvedAt,
+  });
+
+  factory Ticket.fromJson(Map<String, dynamic> json) {
+    final tagsList = json['tags'] as List? ?? [];
+    final depsList = json['dependencies'] as List? ?? [];
+    final commentsList = json['comments'] as List? ?? [];
+
+    return Ticket(
+      id: json['id'] as String? ?? '',
+      project: json['project'] as String? ?? '',
+      title: json['title'] as String? ?? 'Untitled',
+      summary: json['summary'] as String?,
+      description: json['description'] as String?,
+      status: json['status'] as String? ?? 'idea',
+      priority: json['priority'] as String? ?? 'normal',
+      type: json['type'] as String?,
+      team: json['team'] as String?,
+      assignee: json['assignee'] as String?,
+      estimate: json['estimate'] as String?,
+      from: json['from'] as String?,
+      to: json['to'] as String?,
+      tags: tagsList.map((e) => e as String).toList(),
+      dependencies: depsList.map((e) => e as String).toList(),
+      docRef: json['docRef'] as String?,
+      comments: commentsList
+          .map((e) => TicketComment.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      createdAt: DateTime.tryParse(json['createdAt'] as String? ?? '') ??
+          DateTime.now(),
+      updatedAt: DateTime.tryParse(json['updatedAt'] as String? ?? '') ??
+          DateTime.now(),
+      resolvedAt: json['resolvedAt'] != null
+          ? DateTime.tryParse(json['resolvedAt'] as String)
+          : null,
+    );
+  }
+}
+
+class BoardColumn {
+  final String status;
+  final List<Ticket> tickets;
+  final int count;
+
+  const BoardColumn({
+    required this.status,
+    required this.tickets,
+    required this.count,
+  });
+
+  factory BoardColumn.fromJson(Map<String, dynamic> json) {
+    final ticketsList = json['tickets'] as List? ?? [];
+    return BoardColumn(
+      status: json['status'] as String? ?? '',
+      tickets: ticketsList
+          .map((e) => Ticket.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      count: json['count'] as int? ?? 0,
+    );
+  }
+}
+
+class BoardView {
+  final String project;
+  final List<BoardColumn> columns;
+  final int total;
+  final Map<String, int> teamCounts;
+
+  const BoardView({
+    required this.project,
+    required this.columns,
+    required this.total,
+    required this.teamCounts,
+  });
+
+  factory BoardView.fromJson(Map<String, dynamic> json) {
+    final columnsList = json['columns'] as List? ?? [];
+    final teamCountsRaw = json['teamCounts'] as Map<String, dynamic>? ?? {};
+    return BoardView(
+      project: json['project'] as String? ?? '',
+      columns: columnsList
+          .map((e) => BoardColumn.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      total: json['total'] as int? ?? 0,
+      teamCounts: teamCountsRaw.map((k, v) => MapEntry(k, v as int)),
+    );
+  }
+}

--- a/phone/lib/screens/create_bulletin_screen.dart
+++ b/phone/lib/screens/create_bulletin_screen.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+
+import '../services/board_provider.dart';
+
+/// Form for creating a new bulletin.
+///
+/// On save, calls [boardProvider.client.createBulletin] and pops back.
+/// The parent should trigger [boardProvider.refresh] after the screen closes.
+class CreateBulletinScreen extends StatefulWidget {
+  final BoardProvider boardProvider;
+
+  const CreateBulletinScreen({super.key, required this.boardProvider});
+
+  @override
+  State<CreateBulletinScreen> createState() => _CreateBulletinScreenState();
+}
+
+class _CreateBulletinScreenState extends State<CreateBulletinScreen> {
+  final _formKey = GlobalKey<FormState>();
+  bool _saving = false;
+
+  bool _blockAll = true; // true = all teams, false = specific teams
+
+  final _titleController = TextEditingController();
+  final _specificTeamsController = TextEditingController();
+  final _exceptController = TextEditingController();
+  final _messageController = TextEditingController();
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _specificTeamsController.dispose();
+    _exceptController.dispose();
+    _messageController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _saving = true);
+    try {
+      final dynamic block = _blockAll
+          ? 'all'
+          : _specificTeamsController.text
+              .split(',')
+              .map((s) => s.trim())
+              .where((s) => s.isNotEmpty)
+              .toList();
+
+      final exceptList = _exceptController.text
+          .split(',')
+          .map((s) => s.trim())
+          .where((s) => s.isNotEmpty)
+          .toList();
+
+      final body = <String, dynamic>{
+        'title': _titleController.text.trim(),
+        'block': block,
+        if (exceptList.isNotEmpty) 'except': exceptList,
+        if (_messageController.text.trim().isNotEmpty)
+          'message': _messageController.text.trim(),
+      };
+
+      await widget.boardProvider.client.createBulletin(body);
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _saving = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Create failed: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create Bulletin'),
+        actions: [
+          _saving
+              ? const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16),
+                  child: SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                )
+              : TextButton(
+                  onPressed: _save,
+                  child: const Text('Save'),
+                ),
+        ],
+      ),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            // Title
+            TextFormField(
+              controller: _titleController,
+              decoration: const InputDecoration(
+                labelText: 'Title *',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              validator: (v) =>
+                  (v == null || v.trim().isEmpty) ? 'Title is required' : null,
+              textCapitalization: TextCapitalization.sentences,
+            ),
+            const SizedBox(height: 20),
+
+            // Block scope
+            Text(
+              'Block scope',
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            SegmentedButton<bool>(
+              segments: const [
+                ButtonSegment<bool>(value: true, label: Text('All teams')),
+                ButtonSegment<bool>(
+                    value: false, label: Text('Specific teams')),
+              ],
+              selected: {_blockAll},
+              onSelectionChanged: (Set<bool> selection) {
+                setState(() => _blockAll = selection.first);
+              },
+            ),
+            if (!_blockAll) ...[
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _specificTeamsController,
+                decoration: const InputDecoration(
+                  labelText: 'Teams (comma-separated)',
+                  hintText: 'e.g. builder, orchestrator',
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+                validator: (v) => (!_blockAll &&
+                        (v == null || v.trim().isEmpty))
+                    ? 'Enter at least one team name'
+                    : null,
+              ),
+            ],
+            const SizedBox(height: 16),
+
+            // Except
+            TextFormField(
+              controller: _exceptController,
+              decoration: const InputDecoration(
+                labelText: 'Except (comma-separated, optional)',
+                hintText: 'e.g. sprint-master, daily',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // Message
+            TextFormField(
+              controller: _messageController,
+              decoration: const InputDecoration(
+                labelText: 'Message (optional)',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              maxLines: 3,
+              textCapitalization: TextCapitalization.sentences,
+            ),
+            const SizedBox(height: 24),
+
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _saving ? null : _save,
+                child: _saving
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Create Bulletin'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/phone/lib/screens/create_ticket_screen.dart
+++ b/phone/lib/screens/create_ticket_screen.dart
@@ -1,0 +1,244 @@
+import 'package:flutter/material.dart';
+
+import '../services/board_provider.dart';
+
+/// Form for creating a new ticket.
+///
+/// On save, calls [boardProvider.client.createTicket] and pops back.
+/// The parent should trigger [boardProvider.refresh] after the screen closes.
+class CreateTicketScreen extends StatefulWidget {
+  final BoardProvider boardProvider;
+
+  const CreateTicketScreen({super.key, required this.boardProvider});
+
+  @override
+  State<CreateTicketScreen> createState() => _CreateTicketScreenState();
+}
+
+class _CreateTicketScreenState extends State<CreateTicketScreen> {
+  final _formKey = GlobalKey<FormState>();
+  bool _saving = false;
+
+  String _selectedProject = 'personal-assistant';
+  String _selectedType = 'task';
+  String _selectedPriority = 'medium';
+  String? _selectedEstimate;
+
+  final _titleController = TextEditingController();
+  final _teamController = TextEditingController();
+  final _summaryController = TextEditingController();
+
+  static const _projects = ['personal-assistant', 'avodah'];
+  static const _types = [
+    'feature',
+    'bug',
+    'task',
+    'review-request',
+    'work-report',
+    'fyi',
+    'idea',
+    'question',
+  ];
+  static const _priorities = ['critical', 'high', 'medium', 'low'];
+  static const _estimates = ['XS', 'S', 'M', 'L', 'XL'];
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _teamController.dispose();
+    _summaryController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _saving = true);
+    try {
+      final body = <String, dynamic>{
+        'project': _selectedProject,
+        'title': _titleController.text.trim(),
+        'type': _selectedType,
+        'priority': _selectedPriority,
+        'estimate': _selectedEstimate!,
+      };
+      final team = _teamController.text.trim();
+      if (team.isNotEmpty) body['team'] = team;
+      final summary = _summaryController.text.trim();
+      if (summary.isNotEmpty) body['summary'] = summary;
+
+      await widget.boardProvider.client.createTicket(body);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Ticket created')),
+        );
+        Navigator.of(context).pop();
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _saving = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Create failed: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create Ticket'),
+        actions: [
+          _saving
+              ? const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16),
+                  child: SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                )
+              : TextButton(
+                  onPressed: _save,
+                  child: const Text('Save'),
+                ),
+        ],
+      ),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            // Project
+            DropdownButtonFormField<String>(
+              initialValue: _selectedProject,
+              decoration: const InputDecoration(
+                labelText: 'Project',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              items: _projects
+                  .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                  .toList(),
+              onChanged: (p) {
+                if (p != null) setState(() => _selectedProject = p);
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // Title
+            TextFormField(
+              controller: _titleController,
+              decoration: const InputDecoration(
+                labelText: 'Title *',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              validator: (v) =>
+                  (v == null || v.trim().isEmpty) ? 'Title is required' : null,
+              textCapitalization: TextCapitalization.sentences,
+            ),
+            const SizedBox(height: 16),
+
+            // Type
+            DropdownButtonFormField<String>(
+              initialValue: _selectedType,
+              decoration: const InputDecoration(
+                labelText: 'Type',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              items: _types
+                  .map((t) => DropdownMenuItem(value: t, child: Text(t)))
+                  .toList(),
+              onChanged: (t) {
+                if (t != null) setState(() => _selectedType = t);
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // Team
+            TextField(
+              controller: _teamController,
+              decoration: const InputDecoration(
+                labelText: 'Team',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // Priority + Estimate row
+            Row(
+              children: [
+                Expanded(
+                  child: DropdownButtonFormField<String>(
+                    initialValue: _selectedPriority,
+                    decoration: const InputDecoration(
+                      labelText: 'Priority',
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                    items: _priorities
+                        .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                        .toList(),
+                    onChanged: (p) {
+                      if (p != null) setState(() => _selectedPriority = p);
+                    },
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: DropdownButtonFormField<String>(
+                    initialValue: _selectedEstimate,
+                    decoration: const InputDecoration(
+                      labelText: 'Estimate *',
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                    items: _estimates
+                        .map((e) => DropdownMenuItem(value: e, child: Text(e)))
+                        .toList(),
+                    validator: (v) =>
+                        v == null ? 'Estimate is required' : null,
+                    onChanged: (e) {
+                      setState(() => _selectedEstimate = e);
+                    },
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+
+            // Summary
+            TextFormField(
+              controller: _summaryController,
+              decoration: const InputDecoration(
+                labelText: 'Summary',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              maxLines: 3,
+              textCapitalization: TextCapitalization.sentences,
+            ),
+            const SizedBox(height: 24),
+
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _saving ? null : _save,
+                child: _saving
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Create Ticket'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/phone/lib/screens/kanban_board_screen.dart
+++ b/phone/lib/screens/kanban_board_screen.dart
@@ -3,18 +3,23 @@ import 'package:flutter/material.dart';
 import '../models/ticket.dart';
 import '../services/board_provider.dart';
 import '../widgets/board_column.dart';
+import '../widgets/bulletin_banner.dart';
 import '../widgets/ticket_card.dart';
+import 'create_bulletin_screen.dart';
+import 'create_ticket_screen.dart';
+import 'ticket_detail_screen.dart';
 
 /// Main Kanban board screen.
 ///
 /// Displays a horizontally scrollable board of [KanbanColumn] widgets,
 /// driven by [BoardProvider]. Features:
 /// - Project filter dropdown + team filter chips
-/// - Bulletin banner when active bulletins exist
+/// - [BulletinBanner] when active bulletins exist (with resolve action)
 /// - Toggle terminal columns (done/rejected/cancelled)
 /// - Collapsible on-hold section below the main board
 /// - Pull-to-refresh
-/// - FAB for ticket creation (placeholder — Phase 3)
+/// - FAB navigates to [CreateTicketScreen]
+/// - AppBar overflow menu includes "Create Bulletin" → [CreateBulletinScreen]
 class KanbanBoardScreen extends StatefulWidget {
   final BoardProvider boardProvider;
 
@@ -31,6 +36,40 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
     if (widget.boardProvider.board == null) {
       widget.boardProvider.refresh();
     }
+  }
+
+  void _openTicketDetail(BuildContext context, Ticket ticket) {
+    Navigator.of(context)
+        .push(MaterialPageRoute<void>(
+          builder: (_) => TicketDetailScreen(
+            ticketId: ticket.id,
+            boardProvider: widget.boardProvider,
+          ),
+        ))
+        .then((_) => widget.boardProvider.refresh());
+  }
+
+  void _openCreateTicket(BuildContext context) {
+    Navigator.of(context)
+        .push(MaterialPageRoute<void>(
+          builder: (_) =>
+              CreateTicketScreen(boardProvider: widget.boardProvider),
+        ))
+        .then((_) => widget.boardProvider.refresh());
+  }
+
+  void _openCreateBulletin(BuildContext context) {
+    Navigator.of(context)
+        .push(MaterialPageRoute<void>(
+          builder: (_) =>
+              CreateBulletinScreen(boardProvider: widget.boardProvider),
+        ))
+        .then((_) => widget.boardProvider.refresh());
+  }
+
+  Future<void> _resolveBulletin(String id) async {
+    await widget.boardProvider.client.resolveBulletin(id);
+    await widget.boardProvider.refresh();
   }
 
   @override
@@ -53,8 +92,9 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
                   ? Icons.visibility
                   : Icons.visibility_off_outlined,
             ),
-            tooltip:
-                provider.showTerminal ? 'Hide done/rejected' : 'Show done/rejected',
+            tooltip: provider.showTerminal
+                ? 'Hide done/rejected'
+                : 'Show done/rejected',
             onPressed: provider.toggleTerminal,
           ),
           IconButton(
@@ -62,12 +102,27 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
             tooltip: 'Refresh',
             onPressed: provider.refresh,
           ),
+          PopupMenuButton<String>(
+            onSelected: (value) {
+              if (value == 'create_bulletin') {
+                _openCreateBulletin(context);
+              }
+            },
+            itemBuilder: (_) => const [
+              PopupMenuItem(
+                value: 'create_bulletin',
+                child: ListTile(
+                  leading: Icon(Icons.campaign_outlined),
+                  title: Text('Create Bulletin'),
+                  contentPadding: EdgeInsets.zero,
+                ),
+              ),
+            ],
+          ),
         ],
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Create ticket — coming in Phase 3')),
-        ),
+        onPressed: () => _openCreateTicket(context),
         tooltip: 'New ticket',
         child: const Icon(Icons.add),
       ),
@@ -75,7 +130,10 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
         children: [
           _buildFilterRow(context, provider),
           if (provider.activeBulletins.isNotEmpty)
-            _BulletinBanner(bulletins: provider.activeBulletins),
+            BulletinBanner(
+              bulletins: provider.activeBulletins,
+              onResolve: _resolveBulletin,
+            ),
           if (provider.loading && provider.board == null)
             const Expanded(child: Center(child: CircularProgressIndicator()))
           else if (provider.error != null && provider.board == null)
@@ -145,8 +203,7 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
           children: [
             Icon(Icons.cloud_off, size: 48, color: theme.colorScheme.error),
             const SizedBox(height: 12),
-            Text('Failed to load board',
-                style: theme.textTheme.titleMedium),
+            Text('Failed to load board', style: theme.textTheme.titleMedium),
             const SizedBox(height: 4),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 32),
@@ -197,6 +254,8 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
                             padding: const EdgeInsets.only(right: 10),
                             child: KanbanColumn(
                               column: col,
+                              onTicketTap: (ticket) =>
+                                  _openTicketDetail(context, ticket),
                               onTicketDropped: (ticket, newStatus) =>
                                   provider.updateTicketStatus(
                                       ticket.id, newStatus),
@@ -217,6 +276,7 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
         if (onHold != null && onHold.tickets.isNotEmpty)
           _OnHoldSection(
             column: onHold,
+            onTicketTap: (ticket) => _openTicketDetail(context, ticket),
             onStatusChange: (ticket, newStatus) =>
                 provider.updateTicketStatus(ticket.id, newStatus),
           ),
@@ -225,61 +285,15 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
   }
 }
 
-/// Banner shown when there are active bulletins.
-class _BulletinBanner extends StatelessWidget {
-  final List<dynamic> bulletins;
-
-  const _BulletinBanner({required this.bulletins});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final isCritical = bulletins.any((b) {
-      final block = b.block;
-      return block == 'all';
-    });
-
-    final bgColor =
-        isCritical ? theme.colorScheme.errorContainer : Colors.amber.shade100;
-    final fgColor = isCritical
-        ? theme.colorScheme.onErrorContainer
-        : Colors.amber.shade900;
-
-    final titles =
-        bulletins.map((b) => b.title as String).join(' · ');
-
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      color: bgColor,
-      child: Row(
-        children: [
-          Icon(
-            isCritical ? Icons.block : Icons.warning_amber,
-            size: 16,
-            color: fgColor,
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              titles,
-              style: theme.textTheme.bodySmall?.copyWith(color: fgColor),
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
 /// Collapsible on-hold section below the main board.
 class _OnHoldSection extends StatelessWidget {
   final BoardColumn column;
+  final void Function(Ticket ticket) onTicketTap;
   final void Function(Ticket ticket, String newStatus) onStatusChange;
 
   const _OnHoldSection({
     required this.column,
+    required this.onTicketTap,
     required this.onStatusChange,
   });
 
@@ -292,8 +306,8 @@ class _OnHoldSection extends StatelessWidget {
         children: [
           Text(
             'On Hold',
-            style:
-                theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+            style: theme.textTheme.titleSmall
+                ?.copyWith(fontWeight: FontWeight.w600),
           ),
           const SizedBox(width: 8),
           Container(
@@ -322,8 +336,8 @@ class _OnHoldSection extends StatelessWidget {
               final ticket = column.tickets[index];
               return TicketCard(
                 ticket: ticket,
-                onStatusChange: (newStatus) =>
-                    onStatusChange(ticket, newStatus),
+                onTap: () => onTicketTap(ticket),
+                onStatusChange: (newStatus) => onStatusChange(ticket, newStatus),
               );
             },
           ),

--- a/phone/lib/screens/kanban_board_screen.dart
+++ b/phone/lib/screens/kanban_board_screen.dart
@@ -1,0 +1,334 @@
+import 'package:flutter/material.dart';
+
+import '../models/ticket.dart';
+import '../services/board_provider.dart';
+import '../widgets/board_column.dart';
+import '../widgets/ticket_card.dart';
+
+/// Main Kanban board screen.
+///
+/// Displays a horizontally scrollable board of [KanbanColumn] widgets,
+/// driven by [BoardProvider]. Features:
+/// - Project filter dropdown + team filter chips
+/// - Bulletin banner when active bulletins exist
+/// - Toggle terminal columns (done/rejected/cancelled)
+/// - Collapsible on-hold section below the main board
+/// - Pull-to-refresh
+/// - FAB for ticket creation (placeholder — Phase 3)
+class KanbanBoardScreen extends StatefulWidget {
+  final BoardProvider boardProvider;
+
+  const KanbanBoardScreen({super.key, required this.boardProvider});
+
+  @override
+  State<KanbanBoardScreen> createState() => _KanbanBoardScreenState();
+}
+
+class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
+  @override
+  void initState() {
+    super.initState();
+    if (widget.boardProvider.board == null) {
+      widget.boardProvider.refresh();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: widget.boardProvider,
+      builder: (context, _) => _buildScaffold(context),
+    );
+  }
+
+  Widget _buildScaffold(BuildContext context) {
+    final provider = widget.boardProvider;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Kanban Board'),
+        actions: [
+          IconButton(
+            icon: Icon(
+              provider.showTerminal
+                  ? Icons.visibility
+                  : Icons.visibility_off_outlined,
+            ),
+            tooltip:
+                provider.showTerminal ? 'Hide done/rejected' : 'Show done/rejected',
+            onPressed: provider.toggleTerminal,
+          ),
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: provider.refresh,
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Create ticket — coming in Phase 3')),
+        ),
+        tooltip: 'New ticket',
+        child: const Icon(Icons.add),
+      ),
+      body: Column(
+        children: [
+          _buildFilterRow(context, provider),
+          if (provider.activeBulletins.isNotEmpty)
+            _BulletinBanner(bulletins: provider.activeBulletins),
+          if (provider.loading && provider.board == null)
+            const Expanded(child: Center(child: CircularProgressIndicator()))
+          else if (provider.error != null && provider.board == null)
+            _buildError(context, provider)
+          else
+            Expanded(child: _buildBoardArea(context, provider)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilterRow(BuildContext context, BoardProvider provider) {
+    final projects = <String>['personal-assistant'];
+    if (provider.board != null &&
+        !projects.contains(provider.board!.project)) {
+      projects.add(provider.board!.project);
+    }
+
+    final teams = provider.board != null
+        ? (provider.board!.teamCounts.keys.toList()..sort())
+        : <String>[];
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Row(
+        children: [
+          DropdownButton<String>(
+            value: provider.selectedProject,
+            isDense: true,
+            underline: const SizedBox.shrink(),
+            items: projects
+                .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                .toList(),
+            onChanged: (p) {
+              if (p != null) provider.setProject(p);
+            },
+          ),
+          if (teams.isNotEmpty) ...[
+            const SizedBox(width: 12),
+            FilterChip(
+              label: const Text('All'),
+              selected: provider.selectedTeam == null,
+              onSelected: (_) => provider.setTeam(null),
+            ),
+            ...teams.map((team) => Padding(
+                  padding: const EdgeInsets.only(left: 6),
+                  child: FilterChip(
+                    label: Text(team),
+                    selected: provider.selectedTeam == team,
+                    onSelected: (_) => provider.setTeam(
+                        provider.selectedTeam == team ? null : team),
+                  ),
+                )),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildError(BuildContext context, BoardProvider provider) {
+    final theme = Theme.of(context);
+    return Expanded(
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.cloud_off, size: 48, color: theme.colorScheme.error),
+            const SizedBox(height: 12),
+            Text('Failed to load board',
+                style: theme.textTheme.titleMedium),
+            const SizedBox(height: 4),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                provider.error ?? '',
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.outline),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton.icon(
+              onPressed: provider.refresh,
+              icon: const Icon(Icons.refresh),
+              label: const Text('Retry'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBoardArea(BuildContext context, BoardProvider provider) {
+    final activeColumns = provider.activeColumns;
+    final terminalColumns =
+        provider.showTerminal ? provider.terminalColumns : <BoardColumn>[];
+    final allColumns = [...activeColumns, ...terminalColumns];
+    final onHold = provider.onHoldColumn;
+
+    return Column(
+      children: [
+        Expanded(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return RefreshIndicator(
+                onRefresh: provider.refresh,
+                child: SingleChildScrollView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  child: SizedBox(
+                    height: constraints.maxHeight,
+                    child: SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: allColumns.map((col) {
+                          return Padding(
+                            padding: const EdgeInsets.only(right: 10),
+                            child: KanbanColumn(
+                              column: col,
+                              onTicketDropped: (ticket, newStatus) =>
+                                  provider.updateTicketStatus(
+                                      ticket.id, newStatus),
+                              onTicketStatusChange: (ticket, newStatus) =>
+                                  provider.updateTicketStatus(
+                                      ticket.id, newStatus),
+                            ),
+                          );
+                        }).toList(),
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        if (onHold != null && onHold.tickets.isNotEmpty)
+          _OnHoldSection(
+            column: onHold,
+            onStatusChange: (ticket, newStatus) =>
+                provider.updateTicketStatus(ticket.id, newStatus),
+          ),
+      ],
+    );
+  }
+}
+
+/// Banner shown when there are active bulletins.
+class _BulletinBanner extends StatelessWidget {
+  final List<dynamic> bulletins;
+
+  const _BulletinBanner({required this.bulletins});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isCritical = bulletins.any((b) {
+      final block = b.block;
+      return block == 'all';
+    });
+
+    final bgColor =
+        isCritical ? theme.colorScheme.errorContainer : Colors.amber.shade100;
+    final fgColor = isCritical
+        ? theme.colorScheme.onErrorContainer
+        : Colors.amber.shade900;
+
+    final titles =
+        bulletins.map((b) => b.title as String).join(' · ');
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      color: bgColor,
+      child: Row(
+        children: [
+          Icon(
+            isCritical ? Icons.block : Icons.warning_amber,
+            size: 16,
+            color: fgColor,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              titles,
+              style: theme.textTheme.bodySmall?.copyWith(color: fgColor),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Collapsible on-hold section below the main board.
+class _OnHoldSection extends StatelessWidget {
+  final BoardColumn column;
+  final void Function(Ticket ticket, String newStatus) onStatusChange;
+
+  const _OnHoldSection({
+    required this.column,
+    required this.onStatusChange,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ExpansionTile(
+      leading: const Icon(Icons.pause_circle_outline, color: Colors.orange),
+      title: Row(
+        children: [
+          Text(
+            'On Hold',
+            style:
+                theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(width: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+            decoration: BoxDecoration(
+              color: Colors.orange.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Text(
+              '${column.count}',
+              style: theme.textTheme.labelSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: Colors.orange,
+              ),
+            ),
+          ),
+        ],
+      ),
+      children: [
+        SizedBox(
+          height: 240,
+          child: ListView.builder(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            itemCount: column.tickets.length,
+            itemBuilder: (context, index) {
+              final ticket = column.tickets[index];
+              return TicketCard(
+                ticket: ticket,
+                onStatusChange: (newStatus) =>
+                    onStatusChange(ticket, newStatus),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -1,0 +1,568 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+
+import '../models/ticket.dart';
+import '../services/board_provider.dart';
+import '../widgets/status_picker_sheet.dart';
+
+/// Full ticket detail view with read and edit modes.
+///
+/// Fetches the ticket by ID on init using [boardProvider.client].
+/// In read mode, displays all ticket fields.
+/// Toggle to edit mode via the AppBar edit icon to change status, priority,
+/// team, assignee, estimate, and tags. Save calls [boardProvider.client.updateTicket].
+class TicketDetailScreen extends StatefulWidget {
+  final String ticketId;
+  final BoardProvider boardProvider;
+
+  const TicketDetailScreen({
+    super.key,
+    required this.ticketId,
+    required this.boardProvider,
+  });
+
+  @override
+  State<TicketDetailScreen> createState() => _TicketDetailScreenState();
+}
+
+class _TicketDetailScreenState extends State<TicketDetailScreen> {
+  Ticket? _ticket;
+  bool _loading = true;
+  String? _error;
+  bool _editMode = false;
+  bool _saving = false;
+
+  // Edit state
+  String _editStatus = '';
+  String _editPriority = 'medium';
+  String _editEstimate = 'S';
+  List<String> _editTags = [];
+  final _teamController = TextEditingController();
+  final _assigneeController = TextEditingController();
+  final _tagInputController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadTicket();
+  }
+
+  @override
+  void dispose() {
+    _teamController.dispose();
+    _assigneeController.dispose();
+    _tagInputController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadTicket() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final ticket =
+          await widget.boardProvider.client.getTicket(widget.ticketId);
+      if (mounted) {
+        setState(() {
+          _ticket = ticket;
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = e.toString();
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  void _initEditFields(Ticket ticket) {
+    _editStatus = ticket.status;
+    _editPriority = ticket.priority;
+    _editEstimate = ticket.estimate ?? 'S';
+    _teamController.text = ticket.team ?? '';
+    _assigneeController.text = ticket.assignee ?? '';
+    _editTags = List.from(ticket.tags);
+  }
+
+  void _toggleEditMode() {
+    if (_ticket == null) return;
+    setState(() {
+      _editMode = !_editMode;
+      if (_editMode) _initEditFields(_ticket!);
+    });
+  }
+
+  Future<void> _save() async {
+    if (_ticket == null) return;
+    setState(() => _saving = true);
+    try {
+      final updates = <String, dynamic>{
+        'status': _editStatus,
+        'priority': _editPriority,
+        'estimate': _editEstimate,
+        'tags': _editTags,
+      };
+      final team = _teamController.text.trim();
+      final assignee = _assigneeController.text.trim();
+      if (team.isNotEmpty) updates['team'] = team;
+      if (assignee.isNotEmpty) updates['assignee'] = assignee;
+
+      await widget.boardProvider.client.updateTicket(_ticket!.id, updates);
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _saving = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Save failed: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_ticket?.id ?? 'Ticket'),
+        actions: [
+          if (_ticket != null) ...[
+            IconButton(
+              icon: Icon(_editMode ? Icons.close : Icons.edit_outlined),
+              tooltip: _editMode ? 'Cancel edit' : 'Edit',
+              onPressed: _toggleEditMode,
+            ),
+            if (_editMode)
+              _saving
+                  ? const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      child: SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    )
+                  : IconButton(
+                      icon: const Icon(Icons.check),
+                      tooltip: 'Save',
+                      onPressed: _save,
+                    ),
+          ],
+        ],
+      ),
+      body: _buildBody(context),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline,
+                color: Theme.of(context).colorScheme.error, size: 48),
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Text(_error!,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodySmall),
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton(onPressed: _loadTicket, child: const Text('Retry')),
+          ],
+        ),
+      );
+    }
+    if (_ticket == null) return const SizedBox.shrink();
+    return _editMode ? _buildEditView(context) : _buildReadView(context);
+  }
+
+  Widget _buildReadView(BuildContext context) {
+    final ticket = _ticket!;
+    final theme = Theme.of(context);
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            ticket.title,
+            style: theme.textTheme.headlineSmall
+                ?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              _StatusChip(status: ticket.status),
+              _PriorityChip(priority: ticket.priority),
+              if (ticket.type != null) _InfoChip(label: ticket.type!),
+              if (ticket.estimate != null)
+                _InfoChip(label: ticket.estimate!),
+            ],
+          ),
+          if (ticket.team != null || ticket.assignee != null) ...[
+            const SizedBox(height: 10),
+            Row(
+              children: [
+                if (ticket.team != null) ...[
+                  Icon(Icons.group_outlined,
+                      size: 14, color: theme.colorScheme.outline),
+                  const SizedBox(width: 4),
+                  Text(ticket.team!, style: theme.textTheme.bodySmall),
+                  const SizedBox(width: 16),
+                ],
+                if (ticket.assignee != null) ...[
+                  Icon(Icons.person_outline,
+                      size: 14, color: theme.colorScheme.outline),
+                  const SizedBox(width: 4),
+                  Text(ticket.assignee!, style: theme.textTheme.bodySmall),
+                ],
+              ],
+            ),
+          ],
+          if (ticket.summary != null && ticket.summary!.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            _SectionLabel('Summary'),
+            const SizedBox(height: 4),
+            Text(ticket.summary!, style: theme.textTheme.bodyMedium),
+          ],
+          if (ticket.description != null &&
+              ticket.description!.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            _SectionLabel('Description'),
+            const SizedBox(height: 4),
+            MarkdownBody(data: ticket.description!),
+          ],
+          if (ticket.docRef != null && ticket.docRef!.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            _SectionLabel('Doc Ref'),
+            const SizedBox(height: 4),
+            Text(
+              ticket.docRef!,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.primary),
+            ),
+          ],
+          if (ticket.tags.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            _SectionLabel('Tags'),
+            const SizedBox(height: 4),
+            Wrap(
+              spacing: 4,
+              runSpacing: 4,
+              children: ticket.tags
+                  .map((tag) => Chip(
+                        label: Text(tag),
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        visualDensity: VisualDensity.compact,
+                        padding: EdgeInsets.zero,
+                      ))
+                  .toList(),
+            ),
+          ],
+          if (ticket.comments.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            _SectionLabel('Comments'),
+            const SizedBox(height: 6),
+            ...ticket.comments.map((c) => _CommentCard(comment: c)),
+          ],
+          const SizedBox(height: 16),
+          Text(
+            'Created ${_formatDate(ticket.createdAt)}'
+            ' · Updated ${_formatDate(ticket.updatedAt)}'
+            '${ticket.resolvedAt != null ? ' · Resolved ${_formatDate(ticket.resolvedAt!)}' : ''}',
+            style: theme.textTheme.bodySmall
+                ?.copyWith(color: theme.colorScheme.outline),
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEditView(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _SectionLabel('Status'),
+          const SizedBox(height: 6),
+          GestureDetector(
+            onTap: () => showModalBottomSheet<void>(
+              context: context,
+              builder: (_) => StatusPickerSheet(
+                currentStatus: _editStatus,
+                onSelect: (s) {
+                  Navigator.of(context).pop();
+                  setState(() => _editStatus = s);
+                },
+              ),
+            ),
+            child: _StatusChip(status: _editStatus),
+          ),
+          const SizedBox(height: 16),
+          _SectionLabel('Priority'),
+          const SizedBox(height: 6),
+          DropdownButton<String>(
+            value: _editPriority,
+            isDense: true,
+            items: ['critical', 'high', 'medium', 'low']
+                .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                .toList(),
+            onChanged: (p) {
+              if (p != null) setState(() => _editPriority = p);
+            },
+          ),
+          const SizedBox(height: 16),
+          _SectionLabel('Estimate'),
+          const SizedBox(height: 6),
+          DropdownButton<String>(
+            value: _editEstimate,
+            isDense: true,
+            items: ['XS', 'S', 'M', 'L', 'XL']
+                .map((e) => DropdownMenuItem(value: e, child: Text(e)))
+                .toList(),
+            onChanged: (e) {
+              if (e != null) setState(() => _editEstimate = e);
+            },
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _teamController,
+            decoration: const InputDecoration(
+              labelText: 'Team',
+              border: OutlineInputBorder(),
+              isDense: true,
+            ),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _assigneeController,
+            decoration: const InputDecoration(
+              labelText: 'Assignee',
+              border: OutlineInputBorder(),
+              isDense: true,
+            ),
+          ),
+          const SizedBox(height: 16),
+          _SectionLabel('Tags'),
+          const SizedBox(height: 6),
+          Wrap(
+            spacing: 4,
+            runSpacing: 4,
+            children: [
+              ..._editTags.map(
+                (tag) => Chip(
+                  label: Text(tag),
+                  onDeleted: () => setState(() => _editTags.remove(tag)),
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  visualDensity: VisualDensity.compact,
+                  padding: EdgeInsets.zero,
+                ),
+              ),
+              SizedBox(
+                width: 140,
+                height: 36,
+                child: TextField(
+                  controller: _tagInputController,
+                  decoration: const InputDecoration(
+                    hintText: 'Add tag…',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                    contentPadding:
+                        EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                  ),
+                  onSubmitted: (tag) {
+                    final trimmed = tag.trim();
+                    if (trimmed.isNotEmpty && !_editTags.contains(trimmed)) {
+                      setState(() => _editTags.add(trimmed));
+                    }
+                    _tagInputController.clear();
+                  },
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: _saving ? null : _save,
+              child: _saving
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Save Changes'),
+            ),
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+
+  String _formatDate(DateTime dt) {
+    return '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String text;
+  const _SectionLabel(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      text,
+      style: theme.textTheme.labelSmall
+          ?.copyWith(color: theme.colorScheme.outline, letterSpacing: 0.5),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  final String status;
+  const _StatusChip({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = statusColor(status);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.5)),
+      ),
+      child: Text(
+        statusLabel(status),
+        style: TextStyle(
+          color: color,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _PriorityChip extends StatelessWidget {
+  final String priority;
+  const _PriorityChip({required this.priority});
+
+  Color _color() {
+    switch (priority) {
+      case 'critical':
+        return Colors.red;
+      case 'high':
+        return Colors.orange;
+      case 'medium':
+        return Colors.blue;
+      case 'low':
+        return Colors.grey;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _color();
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.5)),
+      ),
+      child: Text(
+        priority.toUpperCase(),
+        style: TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  final String label;
+  const _InfoChip({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: theme.colorScheme.onSurfaceVariant,
+          fontSize: 11,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}
+
+class _CommentCard extends StatelessWidget {
+  final TicketComment comment;
+  const _CommentCard({required this.comment});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    comment.author,
+                    style: theme.textTheme.labelSmall
+                        ?.copyWith(fontWeight: FontWeight.w600),
+                  ),
+                ),
+                Text(
+                  '${comment.timestamp.year}-'
+                  '${comment.timestamp.month.toString().padLeft(2, '0')}-'
+                  '${comment.timestamp.day.toString().padLeft(2, '0')}',
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.outline),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(comment.content, style: theme.textTheme.bodySmall),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 
 import '../models/activity_event.dart';
 import '../models/agent_team.dart';
+import '../models/bulletin.dart';
 import '../models/create_idea_payload.dart';
 import '../models/deploy_result.dart';
 import '../models/deployment.dart';
@@ -11,6 +12,7 @@ import '../models/feedback_payload.dart';
 import '../models/pa_team.dart';
 import '../models/review_item.dart';
 import '../models/team_folder.dart';
+import '../models/ticket.dart';
 import '../models/timer_info.dart';
 
 /// HTTP client for the agent workflow API endpoints.
@@ -394,6 +396,99 @@ class AgentApiClient {
         .toList();
   }
 
+  // --- Tickets ---
+
+  /// Get the kanban board view for a project.
+  ///
+  /// GET /api/board?project=X&team=Y → {"board": {...}}
+  Future<BoardView> getBoard({required String project, String? team}) async {
+    final params = <String, String>{'project': project};
+    if (team != null) params['team'] = team;
+    final query = '?${Uri(queryParameters: params).query}';
+    final response = await _get('/api/board$query');
+    return BoardView.fromJson(response['board'] as Map<String, dynamic>);
+  }
+
+  /// Get a single ticket by ID.
+  ///
+  /// GET /api/tickets/$id → {"ticket": {...}}
+  Future<Ticket> getTicket(String id) async {
+    final encoded = Uri.encodeComponent(id);
+    final response = await _get('/api/tickets/$encoded');
+    return Ticket.fromJson(response['ticket'] as Map<String, dynamic>);
+  }
+
+  /// List tickets with optional filters.
+  ///
+  /// GET /api/tickets?project=X&team=Y&status=Z → {"tickets": [...], "count": N}
+  Future<List<Ticket>> listTickets({
+    String? project,
+    String? team,
+    String? status,
+    String? priority,
+    String? type,
+  }) async {
+    final params = <String, String>{};
+    if (project != null) params['project'] = project;
+    if (team != null) params['team'] = team;
+    if (status != null) params['status'] = status;
+    if (priority != null) params['priority'] = priority;
+    if (type != null) params['type'] = type;
+    final query =
+        params.isNotEmpty ? '?${Uri(queryParameters: params).query}' : '';
+    final response = await _get('/api/tickets$query');
+    final tickets = response['tickets'] as List;
+    return tickets
+        .map((e) => Ticket.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Create a new ticket.
+  ///
+  /// POST /api/tickets body=data → {"ticket": {...}} (201)
+  Future<Ticket> createTicket(Map<String, dynamic> data) async {
+    final response = await _post('/api/tickets', body: data);
+    return Ticket.fromJson(response['ticket'] as Map<String, dynamic>);
+  }
+
+  /// Update an existing ticket.
+  ///
+  /// PATCH /api/tickets/$id body=updates → {"ticket": {...}}
+  Future<Ticket> updateTicket(String id, Map<String, dynamic> updates) async {
+    final encoded = Uri.encodeComponent(id);
+    final response = await _patch('/api/tickets/$encoded', body: updates);
+    return Ticket.fromJson(response['ticket'] as Map<String, dynamic>);
+  }
+
+  // --- Bulletins ---
+
+  /// List all bulletins.
+  ///
+  /// GET /api/bulletin → {"bulletins": [...], "count": N}
+  Future<List<Bulletin>> getBulletins() async {
+    final response = await _get('/api/bulletin');
+    final bulletins = response['bulletins'] as List;
+    return bulletins
+        .map((e) => Bulletin.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Create a new bulletin.
+  ///
+  /// POST /api/bulletin body=data → {"bulletin": {...}} (201)
+  Future<Bulletin> createBulletin(Map<String, dynamic> data) async {
+    final response = await _post('/api/bulletin', body: data);
+    return Bulletin.fromJson(response['bulletin'] as Map<String, dynamic>);
+  }
+
+  /// Resolve (dismiss) a bulletin.
+  ///
+  /// PATCH /api/bulletin/$id body={"status": "resolved"} → {"success": true}
+  Future<void> resolveBulletin(String id) async {
+    final encoded = Uri.encodeComponent(id);
+    await _patch('/api/bulletin/$encoded', body: {'status': 'resolved'});
+  }
+
   // --- HTTP helpers ---
 
   Future<Map<String, dynamic>> _get(String path) async {
@@ -415,7 +510,22 @@ class AgentApiClient {
           body: jsonEncode(body ?? {}),
         )
         .timeout(const Duration(seconds: 10));
-    if (response.statusCode != 200) {
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      _throwApiException(response.statusCode, response.body);
+    }
+    return jsonDecode(response.body) as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> _patch(String path,
+      {Map<String, dynamic>? body}) async {
+    final response = await _client
+        .patch(
+          Uri.parse('$baseUrl$path'),
+          headers: {'Content-Type': 'application/json'},
+          body: jsonEncode(body ?? {}),
+        )
+        .timeout(const Duration(seconds: 10));
+    if (response.statusCode < 200 || response.statusCode >= 300) {
       _throwApiException(response.statusCode, response.body);
     }
     return jsonDecode(response.body) as Map<String, dynamic>;

--- a/phone/lib/services/board_provider.dart
+++ b/phone/lib/services/board_provider.dart
@@ -41,6 +41,11 @@ class BoardProvider extends ChangeNotifier {
 
   BoardProvider(this._client);
 
+  // --- Client access ---
+
+  /// Exposes the underlying API client for direct ticket/bulletin operations.
+  AgentApiClient get client => _client;
+
   // --- Getters ---
 
   BoardView? get board => _board;

--- a/phone/lib/services/board_provider.dart
+++ b/phone/lib/services/board_provider.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../models/bulletin.dart';
+import '../models/ticket.dart';
+import 'agent_api_client.dart';
+
+/// Kanban board status categorization.
+const _activeStatuses = {
+  'idea',
+  'requirement-review',
+  'pending-approval',
+  'pending-implementation',
+  'implementing',
+  'review-uat',
+};
+
+const _terminalStatuses = {
+  'done',
+  'rejected',
+  'cancelled',
+};
+
+/// Provides kanban board state with polling support.
+///
+/// Fetches board columns and bulletins from the PA ticket API.
+/// Polls every 30 seconds when started. Supports project/team filtering
+/// and toggling visibility of terminal columns (done/rejected/cancelled).
+class BoardProvider extends ChangeNotifier {
+  final AgentApiClient _client;
+
+  BoardView? _board;
+  List<Bulletin> _bulletins = [];
+  bool _loading = false;
+  String? _error;
+  String _selectedProject = 'personal-assistant';
+  String? _selectedTeam;
+  bool _showTerminal = false;
+  Timer? _pollTimer;
+
+  BoardProvider(this._client);
+
+  // --- Getters ---
+
+  BoardView? get board => _board;
+  List<Bulletin> get bulletins => _bulletins;
+  bool get loading => _loading;
+  String? get error => _error;
+  String get selectedProject => _selectedProject;
+  String? get selectedTeam => _selectedTeam;
+  bool get showTerminal => _showTerminal;
+
+  /// Active (non-terminal, non-on-hold) columns in kanban order.
+  List<BoardColumn> get activeColumns {
+    if (_board == null) return [];
+    return _board!.columns
+        .where((c) => _activeStatuses.contains(c.status))
+        .toList();
+  }
+
+  /// Terminal columns: done, rejected, cancelled.
+  List<BoardColumn> get terminalColumns {
+    if (_board == null) return [];
+    return _board!.columns
+        .where((c) => _terminalStatuses.contains(c.status))
+        .toList();
+  }
+
+  /// The on-hold column, if present.
+  BoardColumn? get onHoldColumn {
+    if (_board == null) return null;
+    try {
+      return _board!.columns.firstWhere((c) => c.status == 'on-hold');
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Count of tickets requiring Sinh's action: pending-approval + review-uat.
+  int get actionableCount {
+    if (_board == null) return 0;
+    int count = 0;
+    for (final col in _board!.columns) {
+      if (col.status == 'pending-approval' || col.status == 'review-uat') {
+        count += col.count;
+      }
+    }
+    return count;
+  }
+
+  /// Active bulletins only.
+  List<Bulletin> get activeBulletins =>
+      _bulletins.where((b) => b.isActive).toList();
+
+  // --- Setters ---
+
+  void setProject(String project) {
+    if (_selectedProject == project) return;
+    _selectedProject = project;
+    notifyListeners();
+    refresh();
+  }
+
+  void setTeam(String? team) {
+    if (_selectedTeam == team) return;
+    _selectedTeam = team;
+    notifyListeners();
+    refresh();
+  }
+
+  void toggleTerminal() {
+    _showTerminal = !_showTerminal;
+    notifyListeners();
+  }
+
+  // --- Data loading ---
+
+  /// Fetch board and bulletins from the API.
+  Future<void> refresh() async {
+    final wasEmpty = _board == null;
+    if (wasEmpty) {
+      _loading = true;
+      notifyListeners();
+    }
+
+    try {
+      final results = await Future.wait([
+        _client.getBoard(project: _selectedProject, team: _selectedTeam),
+        _client.getBulletins(),
+      ]);
+      _board = results[0] as BoardView;
+      _bulletins = results[1] as List<Bulletin>;
+      _error = null;
+    } catch (e) {
+      _error = e.toString();
+      debugPrint('BoardProvider refresh error: $e');
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+
+  /// Optimistically update a ticket's status, rolling back on failure.
+  Future<void> updateTicketStatus(String ticketId, String newStatus) async {
+    // Capture old state for rollback
+    final oldBoard = _board;
+
+    // Optimistic update: rebuild board with new status
+    if (_board != null) {
+      _board = _buildBoardWithUpdatedTicket(_board!, ticketId, newStatus);
+      notifyListeners();
+    }
+
+    try {
+      await _client.updateTicket(ticketId, {'status': newStatus});
+      // Refresh to get authoritative state
+      await refresh();
+    } catch (e) {
+      // Rollback on failure
+      _board = oldBoard;
+      _error = e.toString();
+      debugPrint('BoardProvider updateTicketStatus error: $e');
+      notifyListeners();
+    }
+  }
+
+  // --- Polling ---
+
+  /// Start polling for board updates every 30 seconds.
+  void startPolling() {
+    refresh();
+    _pollTimer?.cancel();
+    _pollTimer = Timer.periodic(const Duration(seconds: 30), (_) {
+      refresh();
+    });
+  }
+
+  /// Stop polling.
+  void stopPolling() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
+  @override
+  void dispose() {
+    stopPolling();
+    super.dispose();
+  }
+
+  // --- Private helpers ---
+
+  /// Rebuild a BoardView with one ticket moved to a new status column.
+  BoardView _buildBoardWithUpdatedTicket(
+      BoardView board, String ticketId, String newStatus) {
+    Ticket? movedTicket;
+
+    // Remove ticket from its current column
+    final updatedColumns = board.columns.map((col) {
+      final idx = col.tickets.indexWhere((t) => t.id == ticketId);
+      if (idx == -1) return col;
+      movedTicket = col.tickets[idx];
+      final newTickets = List<Ticket>.from(col.tickets)..removeAt(idx);
+      return BoardColumn(
+        status: col.status,
+        tickets: newTickets,
+        count: col.count - 1,
+      );
+    }).toList();
+
+    if (movedTicket == null) return board;
+
+    // Add ticket to the target column (create column if missing)
+    final targetIdx =
+        updatedColumns.indexWhere((c) => c.status == newStatus);
+    if (targetIdx != -1) {
+      final col = updatedColumns[targetIdx];
+      updatedColumns[targetIdx] = BoardColumn(
+        status: col.status,
+        tickets: [movedTicket!, ...col.tickets],
+        count: col.count + 1,
+      );
+    } else {
+      updatedColumns.add(BoardColumn(
+        status: newStatus,
+        tickets: [movedTicket!],
+        count: 1,
+      ));
+    }
+
+    return BoardView(
+      project: board.project,
+      columns: updatedColumns,
+      total: board.total,
+      teamCounts: board.teamCounts,
+    );
+  }
+}

--- a/phone/lib/widgets/board_column.dart
+++ b/phone/lib/widgets/board_column.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+
+import '../models/ticket.dart';
+import 'status_picker_sheet.dart';
+import 'ticket_card.dart';
+
+/// A single Kanban column widget.
+///
+/// Shows a status header (name + ticket count badge) followed by a scrollable
+/// list of [TicketCard] widgets. Accepts [LongPressDraggable] drops via
+/// [DragTarget] — highlights with a border when a valid drag hovers.
+///
+/// Fixed width: 280px. Intended for use inside a horizontal [SingleChildScrollView].
+class KanbanColumn extends StatefulWidget {
+  /// The data model for this column (status + tickets).
+  final BoardColumn column;
+
+  /// Called when a ticket is dropped onto this column.
+  final void Function(Ticket ticket, String newStatus) onTicketDropped;
+
+  /// Called when a ticket card is tapped.
+  final void Function(Ticket ticket)? onTicketTap;
+
+  /// Called when status is changed via the [StatusPickerSheet].
+  final void Function(Ticket ticket, String newStatus)? onTicketStatusChange;
+
+  const KanbanColumn({
+    super.key,
+    required this.column,
+    required this.onTicketDropped,
+    this.onTicketTap,
+    this.onTicketStatusChange,
+  });
+
+  @override
+  State<KanbanColumn> createState() => _KanbanColumnState();
+}
+
+class _KanbanColumnState extends State<KanbanColumn> {
+  bool _isDragHovering = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final status = widget.column.status;
+    final color = statusColor(status);
+
+    return SizedBox(
+      width: 280,
+      child: DragTarget<Ticket>(
+        onWillAcceptWithDetails: (details) {
+          if (details.data.status == status) return false;
+          setState(() => _isDragHovering = true);
+          return true;
+        },
+        onLeave: (_) => setState(() => _isDragHovering = false),
+        onAcceptWithDetails: (details) {
+          setState(() => _isDragHovering = false);
+          widget.onTicketDropped(details.data, status);
+        },
+        builder: (context, candidateData, rejectedData) {
+          return AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.06),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: _isDragHovering
+                    ? color.withValues(alpha: 0.85)
+                    : color.withValues(alpha: 0.18),
+                width: _isDragHovering ? 2.0 : 1.0,
+              ),
+            ),
+            child: Column(
+              children: [
+                _buildHeader(context, color),
+                Expanded(
+                  child: ListView.builder(
+                    padding: const EdgeInsets.only(top: 4, bottom: 8),
+                    itemCount: widget.column.tickets.length,
+                    itemBuilder: (context, index) {
+                      final ticket = widget.column.tickets[index];
+                      return TicketCard(
+                        ticket: ticket,
+                        onTap: widget.onTicketTap != null
+                            ? () => widget.onTicketTap!(ticket)
+                            : null,
+                        onStatusChange: widget.onTicketStatusChange != null
+                            ? (newStatus) =>
+                                widget.onTicketStatusChange!(ticket, newStatus)
+                            : null,
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, Color color) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(12),
+          topRight: Radius.circular(12),
+        ),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              statusLabel(widget.column.status),
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Text(
+              '${widget.column.count}',
+              style: theme.textTheme.labelSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: color,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/phone/lib/widgets/bulletin_banner.dart
+++ b/phone/lib/widgets/bulletin_banner.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+
+import '../models/bulletin.dart';
+
+/// Banner widget displayed at the top of the Kanban board when active bulletins exist.
+///
+/// Collapses per-session via a dismiss button (does not resolve the bulletin).
+/// When [onResolve] is provided, each bulletin shows a trailing resolve icon.
+class BulletinBanner extends StatefulWidget {
+  final List<Bulletin> bulletins;
+
+  /// Called with the bulletin ID when the user requests resolution.
+  final Future<void> Function(String id)? onResolve;
+
+  const BulletinBanner({
+    super.key,
+    required this.bulletins,
+    this.onResolve,
+  });
+
+  @override
+  State<BulletinBanner> createState() => _BulletinBannerState();
+}
+
+class _BulletinBannerState extends State<BulletinBanner> {
+  bool _dismissed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dismissed || widget.bulletins.isEmpty) return const SizedBox.shrink();
+
+    final isCritical = widget.bulletins.any((b) => b.blocksAll);
+    final theme = Theme.of(context);
+    final bgColor = isCritical
+        ? theme.colorScheme.errorContainer
+        : Colors.amber.shade100;
+    final fgColor = isCritical
+        ? theme.colorScheme.onErrorContainer
+        : Colors.amber.shade900;
+
+    return Container(
+      width: double.infinity,
+      color: bgColor,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 4, 0),
+            child: Row(
+              children: [
+                Icon(
+                  isCritical ? Icons.block : Icons.warning_amber,
+                  size: 18,
+                  color: fgColor,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    widget.bulletins.length == 1
+                        ? '1 active bulletin'
+                        : '${widget.bulletins.length} active bulletins',
+                    style: TextStyle(
+                      color: fgColor,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 13,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: Icon(Icons.close, size: 16, color: fgColor),
+                  onPressed: () => setState(() => _dismissed = true),
+                  tooltip: 'Dismiss',
+                  padding: const EdgeInsets.all(8),
+                  constraints:
+                      const BoxConstraints(minWidth: 32, minHeight: 32),
+                ),
+              ],
+            ),
+          ),
+          ...widget.bulletins.map(
+            (b) => _BulletinRow(
+              bulletin: b,
+              fgColor: fgColor,
+              onResolve: widget.onResolve != null
+                  ? () => widget.onResolve!(b.id)
+                  : null,
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}
+
+/// A single bulletin row inside the banner.
+class _BulletinRow extends StatelessWidget {
+  final Bulletin bulletin;
+  final Color fgColor;
+  final Future<void> Function()? onResolve;
+
+  const _BulletinRow({
+    required this.bulletin,
+    required this.fgColor,
+    this.onResolve,
+  });
+
+  String get _blockText {
+    if (bulletin.blocksAll) return 'Blocking: all teams';
+    final teams = bulletin.blockedTeams;
+    if (teams.isEmpty) return '';
+    return 'Blocking: ${teams.join(', ')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final blockText = _blockText;
+    final exceptText = bulletin.except.isNotEmpty
+        ? 'Except: ${bulletin.except.join(', ')}'
+        : null;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 4, 0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  bulletin.title,
+                  style: TextStyle(
+                    color: fgColor,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 13,
+                  ),
+                ),
+                if (bulletin.message != null &&
+                    bulletin.message!.isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    bulletin.message!,
+                    style: TextStyle(color: fgColor, fontSize: 12),
+                  ),
+                ],
+                if (blockText.isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    blockText,
+                    style: TextStyle(
+                      color: fgColor.withValues(alpha: 0.8),
+                      fontSize: 11,
+                    ),
+                  ),
+                ],
+                if (exceptText != null) ...[
+                  const SizedBox(height: 1),
+                  Text(
+                    exceptText,
+                    style: TextStyle(
+                      color: fgColor.withValues(alpha: 0.8),
+                      fontSize: 11,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          if (onResolve != null)
+            _ResolveButton(fgColor: fgColor, onResolve: onResolve!),
+        ],
+      ),
+    );
+  }
+}
+
+class _ResolveButton extends StatefulWidget {
+  final Color fgColor;
+  final Future<void> Function() onResolve;
+
+  const _ResolveButton({required this.fgColor, required this.onResolve});
+
+  @override
+  State<_ResolveButton> createState() => _ResolveButtonState();
+}
+
+class _ResolveButtonState extends State<_ResolveButton> {
+  bool _resolving = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_resolving) {
+      return Padding(
+        padding: const EdgeInsets.all(10),
+        child: SizedBox(
+          width: 16,
+          height: 16,
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            color: widget.fgColor,
+          ),
+        ),
+      );
+    }
+    return IconButton(
+      icon: Icon(Icons.check_circle_outline, size: 18, color: widget.fgColor),
+      onPressed: () async {
+        setState(() => _resolving = true);
+        try {
+          await widget.onResolve();
+        } finally {
+          if (mounted) setState(() => _resolving = false);
+        }
+      },
+      tooltip: 'Resolve bulletin',
+      padding: const EdgeInsets.all(8),
+      constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+    );
+  }
+}

--- a/phone/lib/widgets/status_picker_sheet.dart
+++ b/phone/lib/widgets/status_picker_sheet.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+
+/// Ordered list of all ticket statuses for display.
+const _kAllStatuses = [
+  'idea',
+  'requirement-review',
+  'pending-approval',
+  'pending-implementation',
+  'implementing',
+  'review-uat',
+  'done',
+  'rejected',
+  'cancelled',
+  'on-hold',
+];
+
+/// Human-readable label for a ticket status.
+String statusLabel(String status) {
+  switch (status) {
+    case 'idea':
+      return 'Idea';
+    case 'requirement-review':
+      return 'Req Review';
+    case 'pending-approval':
+      return 'Pending Approval';
+    case 'pending-implementation':
+      return 'Pending Impl';
+    case 'implementing':
+      return 'Implementing';
+    case 'review-uat':
+      return 'Review/UAT';
+    case 'done':
+      return 'Done';
+    case 'rejected':
+      return 'Rejected';
+    case 'cancelled':
+      return 'Cancelled';
+    case 'on-hold':
+      return 'On Hold';
+    default:
+      return status;
+  }
+}
+
+/// Color indicator for a ticket status.
+Color statusColor(String status) {
+  switch (status) {
+    case 'idea':
+      return Colors.purple;
+    case 'requirement-review':
+    case 'pending-approval':
+      return Colors.amber;
+    case 'pending-implementation':
+    case 'implementing':
+      return Colors.blue;
+    case 'review-uat':
+      return Colors.green;
+    case 'done':
+      return Colors.grey;
+    case 'rejected':
+    case 'cancelled':
+      return Colors.red;
+    case 'on-hold':
+      return Colors.orange;
+    default:
+      return Colors.grey;
+  }
+}
+
+/// A bottom sheet for picking a new ticket status.
+///
+/// Shows all statuses with color indicators. The [currentStatus] is
+/// highlighted. Calls [onSelect] with the chosen status string.
+///
+/// Usage:
+/// ```dart
+/// showModalBottomSheet(
+///   context: context,
+///   builder: (_) => StatusPickerSheet(
+///     currentStatus: ticket.status,
+///     onSelect: (newStatus) { ... },
+///   ),
+/// );
+/// ```
+class StatusPickerSheet extends StatelessWidget {
+  final String currentStatus;
+  final void Function(String status) onSelect;
+
+  const StatusPickerSheet({
+    super.key,
+    required this.currentStatus,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              margin: const EdgeInsets.symmetric(vertical: 12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.outlineVariant,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: Text(
+              'Change Status',
+              style: theme.textTheme.titleMedium
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+          ),
+          const Divider(height: 1),
+          ..._kAllStatuses.map((status) {
+            final isSelected = status == currentStatus;
+            final color = statusColor(status);
+            return ListTile(
+              leading: Container(
+                width: 12,
+                height: 12,
+                decoration: BoxDecoration(
+                  color: color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              title: Text(
+                statusLabel(status),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight:
+                      isSelected ? FontWeight.w600 : FontWeight.normal,
+                ),
+              ),
+              trailing: isSelected
+                  ? Icon(Icons.check, color: theme.colorScheme.primary)
+                  : null,
+              selected: isSelected,
+              selectedColor: theme.colorScheme.primary,
+              onTap: () => onSelect(status),
+            );
+          }),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}

--- a/phone/lib/widgets/ticket_card.dart
+++ b/phone/lib/widgets/ticket_card.dart
@@ -1,0 +1,349 @@
+import 'package:flutter/material.dart';
+
+import '../models/ticket.dart';
+import 'status_picker_sheet.dart';
+
+/// A compact Material 3 card displaying ticket summary info for the Kanban board.
+///
+/// Wrapped in [LongPressDraggable] to support drag-and-drop status changes.
+/// Shows title (max 2 lines), priority badge, type badge, team name, and
+/// estimate badge. Trailing icon button opens [StatusPickerSheet].
+///
+/// The card is stateless — drag state is managed by [LongPressDraggable].
+class TicketCard extends StatelessWidget {
+  final Ticket ticket;
+
+  /// Called when the card is tapped (navigate to detail screen).
+  final VoidCallback? onTap;
+
+  /// Called when the user picks a new status from the [StatusPickerSheet].
+  final void Function(String newStatus)? onStatusChange;
+
+  const TicketCard({
+    super.key,
+    required this.ticket,
+    this.onTap,
+    this.onStatusChange,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return LongPressDraggable<Ticket>(
+      data: ticket,
+      feedback: _TicketCardFeedback(ticket: ticket),
+      childWhenDragging: Opacity(
+        opacity: 0.3,
+        child: _TicketCardBody(
+          ticket: ticket,
+          onTap: onTap,
+          onStatusChange: onStatusChange,
+        ),
+      ),
+      child: _TicketCardBody(
+        ticket: ticket,
+        onTap: onTap,
+        onStatusChange: onStatusChange,
+      ),
+    );
+  }
+}
+
+/// The inner card body — used for both normal and childWhenDragging states.
+class _TicketCardBody extends StatelessWidget {
+  final Ticket ticket;
+  final VoidCallback? onTap;
+  final void Function(String newStatus)? onStatusChange;
+
+  const _TicketCardBody({
+    required this.ticket,
+    this.onTap,
+    this.onStatusChange,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 10, 4, 10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Text(
+                      ticket.title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodyMedium
+                          ?.copyWith(fontWeight: FontWeight.w500),
+                    ),
+                  ),
+                  if (onStatusChange != null)
+                    _StatusIconButton(
+                      ticket: ticket,
+                      onStatusChange: onStatusChange!,
+                    ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              Wrap(
+                spacing: 4,
+                runSpacing: 4,
+                children: [
+                  _PriorityBadge(priority: ticket.priority),
+                  if (ticket.type != null) _TypeBadge(type: ticket.type!),
+                  if (ticket.estimate != null)
+                    _EstimateBadge(estimate: ticket.estimate!),
+                ],
+              ),
+              if (ticket.team != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  ticket.team!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Elevated, semi-transparent card shown while dragging.
+class _TicketCardFeedback extends StatelessWidget {
+  final Ticket ticket;
+
+  const _TicketCardFeedback({required this.ticket});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      elevation: 8,
+      borderRadius: BorderRadius.circular(12),
+      child: Opacity(
+        opacity: 0.88,
+        child: SizedBox(
+          width: 264,
+          child: Card(
+            margin: EdgeInsets.zero,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    ticket.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodyMedium
+                        ?.copyWith(fontWeight: FontWeight.w500),
+                  ),
+                  const SizedBox(height: 6),
+                  Wrap(
+                    spacing: 4,
+                    runSpacing: 4,
+                    children: [
+                      _PriorityBadge(priority: ticket.priority),
+                      if (ticket.type != null) _TypeBadge(type: ticket.type!),
+                      if (ticket.estimate != null)
+                        _EstimateBadge(estimate: ticket.estimate!),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Trailing icon button that opens the [StatusPickerSheet].
+class _StatusIconButton extends StatelessWidget {
+  final Ticket ticket;
+  final void Function(String) onStatusChange;
+
+  const _StatusIconButton({
+    required this.ticket,
+    required this.onStatusChange,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.more_horiz, size: 18),
+      padding: const EdgeInsets.all(4),
+      constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+      tooltip: 'Change status',
+      onPressed: () => showModalBottomSheet<void>(
+        context: context,
+        builder: (_) => StatusPickerSheet(
+          currentStatus: ticket.status,
+          onSelect: (newStatus) {
+            Navigator.of(context).pop();
+            onStatusChange(newStatus);
+          },
+        ),
+      ),
+    );
+  }
+}
+
+/// Priority badge — colored chip with text label.
+class _PriorityBadge extends StatelessWidget {
+  final String priority;
+
+  const _PriorityBadge({required this.priority});
+
+  Color _color(BuildContext context) {
+    switch (priority) {
+      case 'critical':
+        return Colors.red;
+      case 'high':
+        return Colors.orange;
+      case 'medium':
+        return Colors.blue;
+      case 'low':
+        return Colors.grey;
+      default:
+        return Theme.of(context).colorScheme.outline;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _color(context);
+    return _BadgeChip(
+      label: priority.toUpperCase(),
+      color: color,
+    );
+  }
+}
+
+/// Type badge — colored chip for ticket type.
+class _TypeBadge extends StatelessWidget {
+  final String type;
+
+  const _TypeBadge({required this.type});
+
+  Color _color(BuildContext context) {
+    switch (type) {
+      case 'feature':
+        return Colors.indigo;
+      case 'bug':
+        return Colors.red;
+      case 'task':
+        return Colors.teal;
+      case 'review-request':
+        return Colors.purple;
+      case 'work-report':
+        return Colors.brown;
+      case 'fyi':
+        return Colors.blueGrey;
+      case 'idea':
+        return Colors.amber;
+      case 'question':
+        return Colors.cyan;
+      default:
+        return Theme.of(context).colorScheme.outline;
+    }
+  }
+
+  String get _label {
+    switch (type) {
+      case 'feature':
+        return 'FEAT';
+      case 'bug':
+        return 'BUG';
+      case 'task':
+        return 'TASK';
+      case 'review-request':
+        return 'REVIEW';
+      case 'work-report':
+        return 'REPORT';
+      case 'fyi':
+        return 'FYI';
+      case 'idea':
+        return 'IDEA';
+      case 'question':
+        return 'Q?';
+      default:
+        return type.toUpperCase();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _BadgeChip(label: _label, color: _color(context));
+  }
+}
+
+/// Estimate badge — neutral chip showing XS/S/M/L/XL.
+class _EstimateBadge extends StatelessWidget {
+  final String estimate;
+
+  const _EstimateBadge({required this.estimate});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        estimate,
+        style: TextStyle(
+          color: theme.colorScheme.onSurfaceVariant,
+          fontSize: 10,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// Shared colored badge chip widget.
+class _BadgeChip extends StatelessWidget {
+  final String label;
+  final Color color;
+
+  const _BadgeChip({required this.label, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: color.withValues(alpha: 0.5), width: 1),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 10,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+}

--- a/phone/lib/widgets/ticket_card.dart
+++ b/phone/lib/widgets/ticket_card.dart
@@ -73,6 +73,15 @@ class _TicketCardBody extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              Text(
+                ticket.id,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 0.3,
+                ),
+              ),
+              const SizedBox(height: 2),
               Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -144,6 +153,15 @@ class _TicketCardFeedback extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  Text(
+                    ticket.id,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.primary,
+                      fontWeight: FontWeight.w600,
+                      letterSpacing: 0.3,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
                   Text(
                     ticket.title,
                     maxLines: 2,


### PR DESCRIPTION
## Summary

Implements the Kanban board phone UI (AVO-001) — a new primary tab that visualizes the ticket system with full CRUD capabilities.

### What's new
- **Kanban board screen** with horizontal-scroll columns for all ticket statuses
- **Ticket detail screen** with read/edit modes for all ticket fields
- **Create ticket** form with project, title, type, team, priority, estimate
- **Bulletin banner** showing active bulletins with block scope and resolve action
- **Create bulletin** form
- **Drag-and-drop** ticket status changes between columns
- **Status picker** bottom sheet as fallback for status changes
- **Badge count** on Kanban tab for actionable items (pending-approval + review-uat)
- **5-tab navigation**: Kanban (new, primary), Dashboard, Agent Review, Deployments, Teams

### Files changed (13 files, +2819 lines)
- 11 new files: models, screens, services, widgets
- 2 modified: main.dart (tab integration), agent_api_client.dart (API methods)

### API integration
- GET /api/board, GET/POST/PATCH /api/tickets, GET/POST/PATCH /api/bulletin
- 30s polling for real-time updates
- Optimistic UI updates with rollback on error

## Test plan
- [ ] Verify flutter analyze passes (clean)
- [ ] Launch phone app, confirm 5-tab navigation
- [ ] Kanban tab loads board data from PA serve API
- [ ] Tap ticket card opens detail screen
- [ ] Drag ticket between columns changes status
- [ ] Create new ticket via FAB
- [ ] Bulletin banner appears when active bulletins exist
- [ ] Badge count shows on Kanban tab icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)