### PR TITLE
feat(phone): AVO-008 ticket-to-deploy integration

### DIFF
--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -79,7 +79,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
     reviewProvider.startAutoRefresh();
 
     final deploymentProvider = DeploymentProvider(apiClient);
-    deploymentProvider.refresh();
+    deploymentProvider.startAutoRefresh();
 
     final teamBrowserProvider = TeamBrowserProvider(apiClient);
     teamBrowserProvider.refreshTeams();

--- a/phone/lib/models/deploy_routing.dart
+++ b/phone/lib/models/deploy_routing.dart
@@ -1,0 +1,82 @@
+import 'pa_team.dart';
+
+/// Result of GET /api/deploy-routing.
+///
+/// Returns all teams with non-interactive deploy modes and available repos.
+/// Server already filters out interactive modes, so all returned modes are
+/// safe to display.
+class DeployRouting {
+  final List<RoutingTeam> teams;
+  final List<PaRepo> repos;
+
+  const DeployRouting({required this.teams, required this.repos});
+
+  factory DeployRouting.fromJson(Map<String, dynamic> json) {
+    return DeployRouting(
+      teams: (json['teams'] as List?)
+              ?.map((e) => RoutingTeam.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      repos: (json['repos'] as List?)
+              ?.map((e) => PaRepo.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    );
+  }
+
+  /// Convert teams to [PaTeam] list for use with [DeploySheet].
+  List<PaTeam> toPaTeams() => teams.map((t) => t.toPaTeam()).toList();
+}
+
+/// A team entry from GET /api/deploy-routing.
+class RoutingTeam {
+  final String name;
+  final String description;
+  final List<RoutingMode> modes;
+
+  const RoutingTeam({
+    required this.name,
+    required this.description,
+    required this.modes,
+  });
+
+  factory RoutingTeam.fromJson(Map<String, dynamic> json) {
+    return RoutingTeam(
+      name: json['name'] as String,
+      description: json['description'] as String? ?? '',
+      modes: (json['modes'] as List?)
+              ?.map((e) => RoutingMode.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    );
+  }
+
+  /// Convert to [PaTeam] for use with [DeploySheet].
+  PaTeam toPaTeam() => PaTeam(
+        name: name,
+        description: description,
+        deployModes: modes
+            .map((m) => DeployMode(id: m.id, label: m.label, modeType: m.modeType))
+            .toList(),
+      );
+}
+
+/// A deploy mode from GET /api/deploy-routing.
+///
+/// Uses camelCase JSON keys (modeType) unlike [DeployMode] which uses
+/// snake_case (mode_type) from GET /api/pa-teams.
+class RoutingMode {
+  final String id;
+  final String label;
+  final String? modeType;
+
+  const RoutingMode({required this.id, required this.label, this.modeType});
+
+  factory RoutingMode.fromJson(Map<String, dynamic> json) {
+    return RoutingMode(
+      id: json['id'] as String,
+      label: json['label'] as String,
+      modeType: json['modeType'] as String?,
+    );
+  }
+}

--- a/phone/lib/screens/activity_timeline_screen.dart
+++ b/phone/lib/screens/activity_timeline_screen.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../models/activity_event.dart';
 import '../models/deployment.dart';
 import '../services/agent_api_client.dart';
+import '../utils/deploy_helpers.dart';
 import '../widgets/activity_event_tile.dart';
 
 /// Full-screen activity timeline for a single deployment.
@@ -187,7 +189,7 @@ class _DeploymentHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final color = _statusColor(context, deployment.status);
+    final color = statusColor(context,deployment.status);
 
     return Container(
       width: double.infinity,
@@ -210,7 +212,7 @@ class _DeploymentHeader extends StatelessWidget {
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Icon(_statusIcon(deployment.status), color: color, size: 16),
+                  Icon(statusIcon(deployment.status), color: color, size: 16),
                   const SizedBox(width: 4),
                   Text(
                     deployment.status,
@@ -285,6 +287,36 @@ class _DeploymentHeader extends StatelessWidget {
               (deployment.error != null || deployment.exitCode != null)) ...[
             const SizedBox(height: 10),
             _ErrorDetailsSection(deployment: deployment),
+          ],
+          // Log file link
+          if (deployment.logFile != null) ...[
+            const SizedBox(height: 8),
+            GestureDetector(
+              onTap: () {
+                Clipboard.setData(ClipboardData(text: deployment.logFile!));
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Log file path copied')),
+                );
+              },
+              child: Row(
+                children: [
+                  Icon(Icons.description_outlined,
+                      size: 14, color: theme.colorScheme.primary),
+                  const SizedBox(width: 4),
+                  Expanded(
+                    child: Text(
+                      deployment.logFile!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.primary,
+                        decoration: TextDecoration.underline,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ],
         ],
       ),
@@ -388,38 +420,3 @@ class _ErrorDetailsSection extends StatelessWidget {
   }
 }
 
-// --- Shared helpers ---
-
-Color _statusColor(BuildContext context, String status) {
-  switch (status.toLowerCase()) {
-    case 'running':
-      return Colors.blue;
-    case 'success':
-    case 'completed':
-      return Colors.green;
-    case 'partial':
-      return Colors.orange;
-    case 'failed':
-    case 'crashed':
-      return Colors.red;
-    default:
-      return Theme.of(context).colorScheme.outline;
-  }
-}
-
-IconData _statusIcon(String status) {
-  switch (status.toLowerCase()) {
-    case 'running':
-      return Icons.play_circle_outline;
-    case 'success':
-    case 'completed':
-      return Icons.check_circle_outline;
-    case 'partial':
-      return Icons.warning_amber_outlined;
-    case 'failed':
-    case 'crashed':
-      return Icons.error_outline;
-    default:
-      return Icons.help_outline;
-  }
-}

--- a/phone/lib/screens/deployment_screen.dart
+++ b/phone/lib/screens/deployment_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/deployment.dart';
 import '../services/agent_api_client.dart';
 import '../services/deployment_provider.dart';
+import '../utils/deploy_helpers.dart';
 import 'activity_timeline_screen.dart';
 
 /// Shows deployment status with filtering by team and status.
@@ -225,9 +226,9 @@ class _FilterBar extends StatelessWidget {
                 label: Text(status),
                 selected: provider.filterStatus == status,
                 avatar: Icon(
-                  _statusIcon(status),
+                  statusIcon(status),
                   size: 14,
-                  color: _statusColor(context, status),
+                  color: statusColor(context,status),
                 ),
                 onSelected: (selected) => provider.setFilterStatus(
                   selected ? status : null,
@@ -249,7 +250,7 @@ class _DeploymentTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final color = _statusColor(context, deployment.status);
+    final color = statusColor(context,deployment.status);
     final isCrashed = deployment.isFailed;
 
     return Card(
@@ -271,7 +272,7 @@ class _DeploymentTile extends StatelessWidget {
             leading: CircleAvatar(
               backgroundColor: color.withValues(alpha: 0.15),
               child:
-                  Icon(_statusIcon(deployment.status), color: color, size: 20),
+                  Icon(statusIcon(deployment.status), color: color, size: 20),
             ),
             title: Text(
               deployment.deploymentId,
@@ -341,10 +342,28 @@ class _DeploymentTile extends StatelessWidget {
       ));
     }
 
-    return Text.rich(
+    final firstLine = Text.rich(
       TextSpan(children: parts),
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
+    );
+
+    final summary = deployment.summary;
+    if (summary == null || summary.isEmpty) return firstLine;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        firstLine,
+        Text(
+          summary,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodySmall
+              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+        ),
+      ],
     );
   }
 }
@@ -376,41 +395,7 @@ class _CompactModelBadge extends StatelessWidget {
   }
 }
 
-// --- Shared helpers ---
-
-Color _statusColor(BuildContext context, String status) {
-  switch (status.toLowerCase()) {
-    case 'running':
-      return Colors.blue;
-    case 'success':
-    case 'completed':
-      return Colors.green;
-    case 'partial':
-      return Colors.orange;
-    case 'failed':
-    case 'crashed':
-      return Colors.red;
-    default:
-      return Theme.of(context).colorScheme.outline;
-  }
-}
-
-IconData _statusIcon(String status) {
-  switch (status.toLowerCase()) {
-    case 'running':
-      return Icons.play_circle_outline;
-    case 'success':
-    case 'completed':
-      return Icons.check_circle_outline;
-    case 'partial':
-      return Icons.warning_amber_outlined;
-    case 'failed':
-    case 'crashed':
-      return Icons.error_outline;
-    default:
-      return Icons.help_outline;
-  }
-}
+// --- Local helpers ---
 
 String _formatTimestamp(String iso) {
   // Show short date+time from ISO string, e.g. "2026-03-13T08:00:00+07:00" → "Mar 13 08:00"

--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
+import '../models/deploy_routing.dart';
+import '../models/deployment.dart';
 import '../models/ticket.dart';
 import '../services/board_provider.dart';
+import '../widgets/deploy_sheet.dart';
 import '../widgets/status_picker_sheet.dart';
+import 'activity_timeline_screen.dart';
 
 /// Full ticket detail view with read and edit modes.
 ///
@@ -31,6 +35,10 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
   String? _error;
   bool _editMode = false;
   bool _saving = false;
+
+  // Deploy state
+  DeployRouting? _deployRouting;
+  bool _fetchingRouting = false;
 
   // Edit state
   String _editStatus = '';
@@ -125,6 +133,109 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
     }
   }
 
+  Future<void> _onDeploy() async {
+    if (_ticket == null) return;
+    final ticket = _ticket!;
+    final messenger = ScaffoldMessenger.of(context);
+    final errorColor = Theme.of(context).colorScheme.error;
+    final client = widget.boardProvider.client;
+
+    // Fetch routing if not cached.
+    if (_deployRouting == null) {
+      setState(() => _fetchingRouting = true);
+      try {
+        final routing = await client.getDeployRouting();
+        if (mounted) setState(() => _deployRouting = routing);
+      } catch (e) {
+        if (mounted) {
+          setState(() => _fetchingRouting = false);
+          messenger.showSnackBar(SnackBar(
+            content: Text('Failed to load deploy routing: $e'),
+            backgroundColor: errorColor,
+          ));
+        }
+        return;
+      }
+      if (mounted) setState(() => _fetchingRouting = false);
+    }
+
+    if (!mounted) return;
+    final routing = _deployRouting!;
+    final paTeams = routing.toPaTeams();
+
+    // Auto-suggest team from ticket.assignee.
+    String? initialTeam;
+    if (ticket.assignee != null &&
+        paTeams.any((t) => t.name == ticket.assignee)) {
+      initialTeam = ticket.assignee;
+    }
+
+    // Pre-fill objective as "{id}: {title}" and repo from project.
+    final initialObjective = '${ticket.id}: ${ticket.title}';
+    final initialRepo = ticket.project.isNotEmpty ? ticket.project : null;
+
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => DeploySheet(
+        paTeams: paTeams,
+        paRepos: routing.repos,
+        initialTeam: initialTeam,
+        initialObjective: initialObjective,
+        initialRepo: initialRepo,
+        onDeploy: (team, mode, objective, {repo}) async {
+          Navigator.pop(context);
+          try {
+            final result = await client.triggerDeployment(
+              team,
+              mode,
+              objective: objective.isNotEmpty ? objective : null,
+              repo: repo,
+              ticket: ticket.id,
+            );
+            if (mounted) {
+              final deployment = Deployment(
+                deploymentId: result.deploymentId,
+                team: result.team,
+                status: 'running',
+                startedAt: DateTime.now().toIso8601String(),
+              );
+              messenger.showSnackBar(SnackBar(
+                content: Text(
+                  result.deploymentId.isNotEmpty
+                      ? 'Deployed ${result.deploymentId}'
+                      : 'Deployment started',
+                ),
+                duration: const Duration(seconds: 8),
+                action: SnackBarAction(
+                  label: 'View',
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute<void>(
+                        builder: (_) => ActivityTimelineScreen(
+                          deployment: deployment,
+                          client: client,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ));
+            }
+          } catch (e) {
+            if (mounted) {
+              messenger.showSnackBar(SnackBar(
+                content: Text('Deploy failed: $e'),
+                backgroundColor: errorColor,
+              ));
+            }
+          }
+        },
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -132,6 +243,20 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
         title: Text(_ticket?.id ?? 'Ticket'),
         actions: [
           if (_ticket != null) ...[
+            _fetchingRouting
+                ? const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 16),
+                    child: SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  )
+                : IconButton(
+                    icon: const Icon(Icons.rocket_launch_outlined),
+                    tooltip: 'Deploy agent',
+                    onPressed: _editMode ? null : _onDeploy,
+                  ),
             IconButton(
               icon: Icon(_editMode ? Icons.close : Icons.edit_outlined),
               tooltip: _editMode ? 'Cancel edit' : 'Edit',

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -7,6 +7,7 @@ import '../models/agent_team.dart';
 import '../models/bulletin.dart';
 import '../models/create_idea_payload.dart';
 import '../models/deploy_result.dart';
+import '../models/deploy_routing.dart';
 import '../models/deployment.dart';
 import '../models/feedback_payload.dart';
 import '../models/pa_team.dart';
@@ -355,16 +356,27 @@ class AgentApiClient {
         .toList();
   }
 
+  /// Fetch deploy routing — teams with non-interactive modes + repos.
+  ///
+  /// Calls GET /api/deploy-routing (added in PA-906).
+  /// Server already filters out interactive modes.
+  Future<DeployRouting> getDeployRouting() async {
+    final response = await _get('/api/deploy-routing');
+    return DeployRouting.fromJson(response);
+  }
+
   /// Trigger a PA team deployment.
   ///
   /// Validates team + mode on the server before executing.
   /// Returns immediately after the subprocess is started.
   /// Optional [repo] passes `--repo <name>` to PA (for codebase-aware modes).
+  /// Optional [ticket] links the deployment to a ticket in the registry.
   Future<DeployResult> triggerDeployment(
     String team,
     String mode, {
     String? objective,
     String? repo,
+    String? ticket,
   }) async {
     final body = <String, dynamic>{'team': team, 'mode': mode};
     if (objective != null && objective.isNotEmpty) {
@@ -372,6 +384,9 @@ class AgentApiClient {
     }
     if (repo != null && repo.isNotEmpty) {
       body['repo'] = repo;
+    }
+    if (ticket != null && ticket.isNotEmpty) {
+      body['ticket'] = ticket;
     }
     final response = await _post('/api/deploy', body: body);
     return DeployResult.fromJson(response);

--- a/phone/lib/utils/deploy_helpers.dart
+++ b/phone/lib/utils/deploy_helpers.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+/// Returns the color for a deployment status.
+Color statusColor(BuildContext context, String status) {
+  switch (status.toLowerCase()) {
+    case 'running':
+      return Colors.blue;
+    case 'success':
+    case 'completed':
+      return Colors.green;
+    case 'partial':
+      return Colors.orange;
+    case 'failed':
+    case 'crashed':
+      return Colors.red;
+    default:
+      return Theme.of(context).colorScheme.outline;
+  }
+}
+
+/// Returns the icon for a deployment status.
+IconData statusIcon(String status) {
+  switch (status.toLowerCase()) {
+    case 'running':
+      return Icons.play_circle_outline;
+    case 'success':
+    case 'completed':
+      return Icons.check_circle_outline;
+    case 'partial':
+      return Icons.warning_amber_outlined;
+    case 'failed':
+    case 'crashed':
+      return Icons.error_outline;
+    default:
+      return Icons.help_outline;
+  }
+}

--- a/phone/lib/widgets/deploy_sheet.dart
+++ b/phone/lib/widgets/deploy_sheet.dart
@@ -35,6 +35,9 @@ class DeploySheet extends StatefulWidget {
   /// Pre-filled objective text. User can edit before launching.
   final String? initialObjective;
 
+  /// Pre-selected repo name. User can change before launching.
+  final String? initialRepo;
+
   /// Called when user taps Launch.
   /// [objective] may be empty string if user left the field blank.
   /// [repo] is null when no repo was selected.
@@ -47,6 +50,7 @@ class DeploySheet extends StatefulWidget {
     this.paRepos = const [],
     this.initialTeam,
     this.initialObjective,
+    this.initialRepo,
     required this.onDeploy,
   });
 
@@ -66,6 +70,12 @@ class _DeploySheetState extends State<DeploySheet> {
     super.initState();
     _objectiveController =
         TextEditingController(text: widget.initialObjective ?? '');
+
+    // Pre-select repo if provided and it exists in the list.
+    if (widget.initialRepo != null &&
+        widget.paRepos.any((r) => r.name == widget.initialRepo)) {
+      _selectedRepo = widget.initialRepo;
+    }
 
     // Pre-select team from initialTeam, or auto-select if only one team.
     if (widget.initialTeam != null &&

--- a/phone/lib/widgets/deploy_sheet.dart
+++ b/phone/lib/widgets/deploy_sheet.dart
@@ -114,6 +114,17 @@ class _DeploySheetState extends State<DeploySheet> {
   bool get _canLaunch =>
       _selectedTeam != null && _selectedMode != null && !_deploying;
 
+  Color? _modeTypeColor(String? modeType) {
+    switch (modeType) {
+      case 'work':
+        return Colors.blue;
+      case 'housekeeping':
+        return Colors.orange;
+      default:
+        return null;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -252,9 +263,19 @@ class _DeploySheetState extends State<DeploySheet> {
           runSpacing: 4,
           children: paTeam.deployModes.map((mode) {
             final selected = _selectedMode == mode.id;
+            final modeColor = _modeTypeColor(mode.modeType);
             return FilterChip(
               label: Text(mode.label),
               selected: selected,
+              backgroundColor:
+                  modeColor?.withValues(alpha: 0.12),
+              selectedColor: modeColor?.withValues(alpha: 0.25),
+              avatar: modeColor != null
+                  ? CircleAvatar(
+                      backgroundColor: modeColor,
+                      radius: 5,
+                    )
+                  : null,
               onSelected: _deploying
                   ? null
                   : (_) => setState(() {


### PR DESCRIPTION
## Summary

- **Phase 1:** Deploy agent from ticket detail screen — rocket button in AppBar, DeployRouting model, getDeployRouting() API client, triggerDeployment() ticket param, SnackBar "View" navigation to ActivityTimelineScreen
- **Phase 2:** Bug fixes — auto-refresh deployments (B1), summary/logFile display (B2), mode type color chips (B3), shared deploy helpers extraction (B4)

## Acceptance Criteria

- [x] AC1: TicketDetailScreen shows deploy button (rocket icon) for all tickets
- [x] AC2: Deploy button opens DeploySheet pre-filled with team from ticket.assignee, objective as {id}: {title}, repo from ticket.project
- [x] AC3: User can edit team, mode, objective, and repo before launching
- [x] AC4: Successful deploy sends ticket param in POST /api/deploy body
- [x] AC5: Successful deploy shows SnackBar with "View" action → ActivityTimelineScreen
- [x] AC6: DeploymentScreen auto-refreshes running deployments
- [x] AC7: Deployment summary displayed on deployment tiles
- [x] AC8: Mode chips show visual differentiation by modeType
- [x] AC9: Duplicated deploy status helpers extracted into shared utility

## Dependencies

- PA-906 (merged PR #17) — server-side deploy routing API

## Ticket

AVO-008

## Test plan

- [ ] Open any ticket → verify rocket icon in AppBar
- [ ] Tap rocket → verify DeploySheet opens pre-filled (team, objective, repo)
- [ ] Edit fields and launch → verify deployment starts with ticket param
- [ ] Verify SnackBar appears with "View" action
- [ ] Check DeploymentScreen auto-refreshes
- [ ] Verify summary shows on deployment tiles
- [ ] Verify mode chips are color-coded (blue/orange)

🤖 Generated with [Claude Code](https://claude.com/claude-code)