### PR TITLE
feat(phone): show doc_ref icon on kanban ticket cards

### DIFF
--- a/phone/lib/widgets/ticket_card.dart
+++ b/phone/lib/widgets/ticket_card.dart
@@ -110,6 +110,12 @@ class _TicketCardBody extends StatelessWidget {
                   if (ticket.type != null) _TypeBadge(type: ticket.type!),
                   if (ticket.estimate != null)
                     _EstimateBadge(estimate: ticket.estimate!),
+                  if (ticket.docRef != null && ticket.docRef!.isNotEmpty)
+                    Icon(
+                      Icons.description_outlined,
+                      size: 14,
+                      color: theme.colorScheme.primary,
+                    ),
                 ],
               ),
               if (ticket.team != null) ...[


### PR DESCRIPTION
## Summary
- Adds doc_ref icon visibility on kanban ticket cards in the phone Flutter app

## Test plan
- [ ] Verify doc_ref icon shows on ticket cards that have a doc_ref set
- [ ] Verify no icon shown on cards without doc_ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)