### PR TITLE
feat(phone): AVO-010 dynamic project selector (#124)

### DIFF
--- a/phone/lib/models/ticket.dart
+++ b/phone/lib/models/ticket.dart
@@ -140,14 +140,26 @@ class BoardColumn {
 
 class TicketProject {
   final String key;
-  final int count;
+  final String? prefix;
+  final String? description;
+  final String? path;
+  final int activeTicketCount;
 
-  const TicketProject({required this.key, required this.count});
+  const TicketProject({
+    required this.key,
+    this.prefix,
+    this.description,
+    this.path,
+    required this.activeTicketCount,
+  });
 
   factory TicketProject.fromJson(Map<String, dynamic> json) {
     return TicketProject(
       key: json['key'] as String? ?? '',
-      count: json['count'] as int? ?? 0,
+      prefix: json['prefix'] as String?,
+      description: json['description'] as String?,
+      path: json['path'] as String?,
+      activeTicketCount: json['activeTicketCount'] as int? ?? 0,
     );
   }
 }

--- a/phone/lib/models/ticket.dart
+++ b/phone/lib/models/ticket.dart
@@ -138,6 +138,20 @@ class BoardColumn {
   }
 }
 
+class TicketProject {
+  final String key;
+  final int count;
+
+  const TicketProject({required this.key, required this.count});
+
+  factory TicketProject.fromJson(Map<String, dynamic> json) {
+    return TicketProject(
+      key: json['key'] as String? ?? '',
+      count: json['count'] as int? ?? 0,
+    );
+  }
+}
+
 class BoardView {
   final String project;
   final List<BoardColumn> columns;

--- a/phone/lib/screens/create_ticket_screen.dart
+++ b/phone/lib/screens/create_ticket_screen.dart
@@ -19,7 +19,7 @@ class _CreateTicketScreenState extends State<CreateTicketScreen> {
   final _formKey = GlobalKey<FormState>();
   bool _saving = false;
 
-  String _selectedProject = 'personal-assistant';
+  late String? _selectedProject;
   String _selectedType = 'task';
   String _selectedPriority = 'medium';
   String? _selectedEstimate;
@@ -28,7 +28,6 @@ class _CreateTicketScreenState extends State<CreateTicketScreen> {
   final _teamController = TextEditingController();
   final _summaryController = TextEditingController();
 
-  static const _projects = ['personal-assistant', 'avodah'];
   static const _types = [
     'feature',
     'bug',
@@ -43,6 +42,12 @@ class _CreateTicketScreenState extends State<CreateTicketScreen> {
   static const _estimates = ['XS', 'S', 'M', 'L', 'XL'];
 
   @override
+  void initState() {
+    super.initState();
+    _selectedProject = widget.boardProvider.selectedProject;
+  }
+
+  @override
   void dispose() {
     _titleController.dispose();
     _teamController.dispose();
@@ -55,7 +60,7 @@ class _CreateTicketScreenState extends State<CreateTicketScreen> {
     setState(() => _saving = true);
     try {
       final body = <String, dynamic>{
-        'project': _selectedProject,
+        'project': _selectedProject ?? '',
         'title': _titleController.text.trim(),
         'type': _selectedType,
         'priority': _selectedPriority,
@@ -109,21 +114,38 @@ class _CreateTicketScreenState extends State<CreateTicketScreen> {
         child: ListView(
           padding: const EdgeInsets.all(16),
           children: [
-            // Project
-            DropdownButtonFormField<String>(
-              initialValue: _selectedProject,
-              decoration: const InputDecoration(
-                labelText: 'Project',
-                border: OutlineInputBorder(),
-                isDense: true,
-              ),
-              items: _projects
-                  .map((p) => DropdownMenuItem(value: p, child: Text(p)))
-                  .toList(),
-              onChanged: (p) {
-                if (p != null) setState(() => _selectedProject = p);
-              },
-            ),
+            // Project — populated from API via boardProvider.projects
+            Builder(builder: (context) {
+              final projects = widget.boardProvider.projects;
+              if (projects.isEmpty) {
+                return const InputDecorator(
+                  decoration: InputDecoration(
+                    labelText: 'Project',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                  child: Text('No projects'),
+                );
+              }
+              // Ensure current selection is valid.
+              final validKey = projects.any((p) => p.key == _selectedProject)
+                  ? _selectedProject
+                  : projects.first.key;
+              return DropdownButtonFormField<String>(
+                initialValue: validKey,
+                decoration: const InputDecoration(
+                  labelText: 'Project',
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+                items: projects
+                    .map((p) => DropdownMenuItem(value: p.key, child: Text(p.key)))
+                    .toList(),
+                onChanged: (p) {
+                  if (p != null) setState(() => _selectedProject = p);
+                },
+              );
+            }),
             const SizedBox(height: 16),
 
             // Title

--- a/phone/lib/screens/kanban_board_screen.dart
+++ b/phone/lib/screens/kanban_board_screen.dart
@@ -146,11 +146,9 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
   }
 
   Widget _buildFilterRow(BuildContext context, BoardProvider provider) {
-    final projects = <String>['personal-assistant', 'avodah'];
-    if (provider.board != null &&
-        !projects.contains(provider.board!.project)) {
-      projects.add(provider.board!.project);
-    }
+    // Build project list from API response, sorted alphabetically.
+    final projectItems = provider.projects.toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
 
     final teams = provider.board != null
         ? (provider.board!.teamCounts.keys.toList()..sort())
@@ -161,17 +159,23 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       child: Row(
         children: [
-          DropdownButton<String>(
-            value: provider.selectedProject,
-            isDense: true,
-            underline: const SizedBox.shrink(),
-            items: projects
-                .map((p) => DropdownMenuItem(value: p, child: Text(p)))
-                .toList(),
-            onChanged: (p) {
-              if (p != null) provider.setProject(p);
-            },
-          ),
+          if (projectItems.isEmpty)
+            const Text('No projects')
+          else
+            DropdownButton<String>(
+              value: projectItems.any((p) => p.key == provider.selectedProject)
+                  ? provider.selectedProject
+                  : null,
+              isDense: true,
+              underline: const SizedBox.shrink(),
+              items: projectItems
+                  .map((p) => DropdownMenuItem(
+                      value: p.key, child: Text('${p.key} (${p.count})')))
+                  .toList(),
+              onChanged: (p) {
+                if (p != null) provider.setProject(p);
+              },
+            ),
           if (teams.isNotEmpty) ...[
             const SizedBox(width: 12),
             FilterChip(

--- a/phone/lib/screens/kanban_board_screen.dart
+++ b/phone/lib/screens/kanban_board_screen.dart
@@ -163,14 +163,17 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
             const Text('No projects')
           else
             DropdownButton<String>(
-              value: projectItems.any((p) => p.key == provider.selectedProject)
+              value: provider.selectedProject != null &&
+                      projectItems
+                          .any((p) => p.key == provider.selectedProject)
                   ? provider.selectedProject
                   : null,
               isDense: true,
               underline: const SizedBox.shrink(),
               items: projectItems
                   .map((p) => DropdownMenuItem(
-                      value: p.key, child: Text('${p.key} (${p.count})')))
+                      value: p.key,
+                      child: Text('${p.key} (${p.activeTicketCount})')))
                   .toList(),
               onChanged: (p) {
                 if (p != null) provider.setProject(p);

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -413,6 +413,22 @@ class AgentApiClient {
 
   // --- Tickets ---
 
+  /// List available ticket projects with active ticket counts.
+  ///
+  /// GET /api/ticket-projects → {"projects": [{"key": "avodah", "count": 5}, ...]}
+  /// Returns empty list on failure.
+  Future<List<TicketProject>> getTicketProjects() async {
+    try {
+      final response = await _get('/api/ticket-projects');
+      final projects = response['projects'] as List? ?? [];
+      return projects
+          .map((e) => TicketProject.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
   /// Get the kanban board view for a project.
   ///
   /// GET /api/board?project=X&team=Y → {"board": {...}}

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -413,16 +413,20 @@ class AgentApiClient {
 
   // --- Tickets ---
 
-  /// List available ticket projects with active ticket counts.
+  /// List available projects with full metadata.
   ///
-  /// GET /api/ticket-projects → {"projects": [{"key": "avodah", "count": 5}, ...]}
+  /// GET /api/projects → {"projects": [{key, prefix, description, path, activeTicketCount}, ...]}
+  /// Filters to projects with activeTicketCount > 0 for the dropdown.
   /// Returns empty list on failure.
-  Future<List<TicketProject>> getTicketProjects() async {
+  ///
+  /// Note: GET /api/ticket-projects is deprecated; this endpoint supersedes it.
+  Future<List<TicketProject>> getProjects() async {
     try {
-      final response = await _get('/api/ticket-projects');
+      final response = await _get('/api/projects');
       final projects = response['projects'] as List? ?? [];
       return projects
           .map((e) => TicketProject.fromJson(e as Map<String, dynamic>))
+          .where((p) => p.activeTicketCount > 0)
           .toList();
     } catch (_) {
       return [];

--- a/phone/lib/services/board_provider.dart
+++ b/phone/lib/services/board_provider.dart
@@ -32,6 +32,7 @@ class BoardProvider extends ChangeNotifier {
 
   BoardView? _board;
   List<Bulletin> _bulletins = [];
+  List<TicketProject> _projects = [];
   bool _loading = false;
   String? _error;
   String _selectedProject = 'personal-assistant';
@@ -50,6 +51,7 @@ class BoardProvider extends ChangeNotifier {
 
   BoardView? get board => _board;
   List<Bulletin> get bulletins => _bulletins;
+  List<TicketProject> get projects => _projects;
   bool get loading => _loading;
   String? get error => _error;
   String get selectedProject => _selectedProject;
@@ -133,9 +135,17 @@ class BoardProvider extends ChangeNotifier {
       final results = await Future.wait([
         _client.getBoard(project: _selectedProject, team: _selectedTeam),
         _client.getBulletins(),
+        _client.getTicketProjects(),
       ]);
       _board = results[0] as BoardView;
       _bulletins = results[1] as List<Bulletin>;
+      _projects = results[2] as List<TicketProject>;
+      // Update selected project to first alphabetically if current selection
+      // is not in the project list (and projects are available).
+      if (_projects.isNotEmpty &&
+          !_projects.any((p) => p.key == _selectedProject)) {
+        _selectedProject = (_projects.map((p) => p.key).toList()..sort()).first;
+      }
       _error = null;
     } catch (e) {
       _error = e.toString();

--- a/phone/lib/services/board_provider.dart
+++ b/phone/lib/services/board_provider.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/bulletin.dart';
 import '../models/ticket.dart';
 import 'agent_api_client.dart';
+
+const _prefSelectedProject = 'selected_board_project';
 
 /// Kanban board status categorization.
 const _activeStatuses = {
@@ -35,12 +38,20 @@ class BoardProvider extends ChangeNotifier {
   List<TicketProject> _projects = [];
   bool _loading = false;
   String? _error;
-  String _selectedProject = 'personal-assistant';
+  String? _selectedProject;
   String? _selectedTeam;
   bool _showTerminal = false;
   Timer? _pollTimer;
+  SharedPreferences? _prefs;
 
-  BoardProvider(this._client);
+  BoardProvider(this._client) {
+    _initPrefs();
+  }
+
+  Future<void> _initPrefs() async {
+    _prefs = await SharedPreferences.getInstance();
+    _selectedProject = _prefs!.getString(_prefSelectedProject);
+  }
 
   // --- Client access ---
 
@@ -54,7 +65,7 @@ class BoardProvider extends ChangeNotifier {
   List<TicketProject> get projects => _projects;
   bool get loading => _loading;
   String? get error => _error;
-  String get selectedProject => _selectedProject;
+  String? get selectedProject => _selectedProject;
   String? get selectedTeam => _selectedTeam;
   bool get showTerminal => _showTerminal;
 
@@ -105,6 +116,7 @@ class BoardProvider extends ChangeNotifier {
   void setProject(String project) {
     if (_selectedProject == project) return;
     _selectedProject = project;
+    _prefs?.setString(_prefSelectedProject, project);
     notifyListeners();
     refresh();
   }
@@ -132,20 +144,23 @@ class BoardProvider extends ChangeNotifier {
     }
 
     try {
-      final results = await Future.wait([
-        _client.getBoard(project: _selectedProject, team: _selectedTeam),
-        _client.getBulletins(),
-        _client.getTicketProjects(),
-      ]);
-      _board = results[0] as BoardView;
-      _bulletins = results[1] as List<Bulletin>;
-      _projects = results[2] as List<TicketProject>;
-      // Update selected project to first alphabetically if current selection
-      // is not in the project list (and projects are available).
+      // Load projects first to determine selected project before fetching board.
+      final projectsList = await _client.getProjects();
+      _projects = projectsList;
+
+      // Resolve selected project: persisted → first alphabetically.
       if (_projects.isNotEmpty &&
           !_projects.any((p) => p.key == _selectedProject)) {
         _selectedProject = (_projects.map((p) => p.key).toList()..sort()).first;
       }
+
+      final results = await Future.wait([
+        _client.getBoard(
+            project: _selectedProject ?? '', team: _selectedTeam),
+        _client.getBulletins(),
+      ]);
+      _board = results[0] as BoardView;
+      _bulletins = results[1] as List<Bulletin>;
       _error = null;
     } catch (e) {
       _error = e.toString();


### PR DESCRIPTION
## Summary

AVO-010: Dynamic project selector for Kanban board phone app.

### Phase 2 (commit 23e40ff)
- Added `TicketProject` model and `AgentApiClient.getTicketProjects()`
- Integrated into `BoardProvider` with project filtering
- Added project dropdown to `KanbanBoardScreen`

### Phase 3 (commit e0345e9)
- Migrated client from `GET /api/ticket-projects` to unified `GET /api/projects` (PA-917)
- `TicketProject` model: added `prefix`, `description`, `path`, renamed `count` → `activeTicketCount`
- `AgentApiClient`: renamed to `getProjects()`, filters `activeTicketCount > 0`
- `BoardProvider`: SharedPreferences persistence for selected project, restored on app startup
- `CreateTicketScreen`: removed hardcoded project list, uses API-driven list from provider
- Removed all hardcoded project keys (`'personal-assistant'`, `['personal-assistant', 'avodah']`)

## Test plan
- [ ] Verify dropdown loads projects from `GET /api/projects`
- [ ] Select a project, restart app, verify selection persists
- [ ] Verify CreateTicketScreen shows API-driven project list
- [ ] Verify graceful degradation when API is unreachable
- [ ] Run `dart analyze` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)