### PR TITLE
feat(phone): AVO-014 PA API sync (doc_refs, board filtering, search)

### DIFF
--- a/phone/lib/models/ticket.dart
+++ b/phone/lib/models/ticket.dart
@@ -3,6 +3,34 @@
 // Matches the API response shapes from pa serve /api/tickets and /api/board.
 // JSON keys are camelCase as returned by the server.
 
+class DocRef {
+  final String type; // requirements|spike|implementation|review-report|attachment
+  final String path;
+  final bool primary;
+  final DateTime? addedAt;
+  final String? addedBy;
+
+  const DocRef({
+    required this.type,
+    required this.path,
+    this.primary = false,
+    this.addedAt,
+    this.addedBy,
+  });
+
+  factory DocRef.fromJson(Map<String, dynamic> json) {
+    return DocRef(
+      type: json['type'] as String? ?? 'attachment',
+      path: json['path'] as String? ?? '',
+      primary: json['primary'] as bool? ?? false,
+      addedAt: json['addedAt'] != null
+          ? DateTime.tryParse(json['addedAt'] as String)
+          : null,
+      addedBy: json['addedBy'] as String?,
+    );
+  }
+}
+
 class TicketComment {
   final String id;
   final String author;
@@ -45,9 +73,8 @@ class Ticket {
   final String? from;
   final String? to;
   final List<String> tags;
-  final List<String> dependencies;
-  final List<String> attachments;
-  final String? docRef;
+  final List<String> blockedBy;
+  final List<DocRef> docRefs;
   final List<TicketComment> comments;
   final DateTime createdAt;
   final DateTime updatedAt;
@@ -68,9 +95,8 @@ class Ticket {
     this.from,
     this.to,
     required this.tags,
-    required this.dependencies,
-    required this.attachments,
-    this.docRef,
+    required this.blockedBy,
+    required this.docRefs,
     required this.comments,
     required this.createdAt,
     required this.updatedAt,
@@ -79,9 +105,30 @@ class Ticket {
 
   factory Ticket.fromJson(Map<String, dynamic> json) {
     final tagsList = json['tags'] as List? ?? [];
-    final depsList = json['dependencies'] as List? ?? [];
-    final attachmentsList = json['attachments'] as List? ?? [];
     final commentsList = json['comments'] as List? ?? [];
+
+    // blockedBy: try new field first, fall back to deprecated dependencies
+    final blockedByRaw =
+        (json['blockedBy'] as List?) ?? (json['dependencies'] as List?) ?? [];
+
+    // doc_refs: try new array first, fall back to legacy doc_ref string
+    List<DocRef> docRefs;
+    final docRefsRaw = json['doc_refs'] as List?;
+    if (docRefsRaw != null && docRefsRaw.isNotEmpty) {
+      docRefs = docRefsRaw
+          .map((e) => DocRef.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } else if (json['doc_ref'] != null) {
+      docRefs = [
+        DocRef(
+          type: 'attachment',
+          path: json['doc_ref'] as String,
+          primary: true,
+        ),
+      ];
+    } else {
+      docRefs = [];
+    }
 
     return Ticket(
       id: json['id'] as String? ?? '',
@@ -98,9 +145,8 @@ class Ticket {
       from: json['from'] as String?,
       to: json['to'] as String?,
       tags: tagsList.map((e) => e as String).toList(),
-      dependencies: depsList.map((e) => e as String).toList(),
-      attachments: attachmentsList.map((e) => e as String).toList(),
-      docRef: json['doc_ref'] as String?,
+      blockedBy: blockedByRaw.map((e) => e as String).toList(),
+      docRefs: docRefs,
       comments: commentsList
           .map((e) => TicketComment.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/phone/lib/screens/kanban_board_screen.dart
+++ b/phone/lib/screens/kanban_board_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../models/ticket.dart';
@@ -30,12 +32,29 @@ class KanbanBoardScreen extends StatefulWidget {
 }
 
 class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
+  final _searchController = TextEditingController();
+  Timer? _debounceTimer;
+
   @override
   void initState() {
     super.initState();
     if (widget.boardProvider.board == null) {
       widget.boardProvider.refresh();
     }
+  }
+
+  @override
+  void dispose() {
+    _debounceTimer?.cancel();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String value) {
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(const Duration(milliseconds: 300), () {
+      widget.boardProvider.setSearchQuery(value);
+    });
   }
 
   void _openTicketDetail(BuildContext context, Ticket ticket) {
@@ -154,50 +173,79 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
         ? (provider.board!.teamCounts.keys.toList()..sort())
         : <String>[];
 
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      child: Row(
-        children: [
-          if (projectItems.isEmpty)
-            const Text('No projects')
-          else
-            DropdownButton<String>(
-              value: provider.selectedProject != null &&
-                      projectItems
-                          .any((p) => p.key == provider.selectedProject)
-                  ? provider.selectedProject
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: [
+              if (projectItems.isEmpty)
+                const Text('No projects')
+              else
+                DropdownButton<String>(
+                  value: provider.selectedProject != null &&
+                          projectItems
+                              .any((p) => p.key == provider.selectedProject)
+                      ? provider.selectedProject
+                      : null,
+                  isDense: true,
+                  underline: const SizedBox.shrink(),
+                  items: projectItems
+                      .map((p) => DropdownMenuItem(
+                          value: p.key,
+                          child: Text('${p.key} (${p.activeTicketCount})')))
+                      .toList(),
+                  onChanged: (p) {
+                    if (p != null) provider.setProject(p);
+                  },
+                ),
+              if (teams.isNotEmpty) ...[
+                const SizedBox(width: 12),
+                FilterChip(
+                  label: const Text('All'),
+                  selected: provider.selectedTeam == null,
+                  onSelected: (_) => provider.setTeam(null),
+                ),
+                ...teams.map((team) => Padding(
+                      padding: const EdgeInsets.only(left: 6),
+                      child: FilterChip(
+                        label: Text(team),
+                        selected: provider.selectedTeam == team,
+                        onSelected: (_) => provider.setTeam(
+                            provider.selectedTeam == team ? null : team),
+                      ),
+                    )),
+              ],
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+          child: TextField(
+            controller: _searchController,
+            onChanged: _onSearchChanged,
+            decoration: InputDecoration(
+              hintText: 'Search tickets…',
+              prefixIcon: const Icon(Icons.search, size: 20),
+              suffixIcon: provider.searchQuery.isNotEmpty
+                  ? IconButton(
+                      icon: const Icon(Icons.clear, size: 20),
+                      onPressed: () {
+                        _searchController.clear();
+                        widget.boardProvider.setSearchQuery('');
+                      },
+                    )
                   : null,
               isDense: true,
-              underline: const SizedBox.shrink(),
-              items: projectItems
-                  .map((p) => DropdownMenuItem(
-                      value: p.key,
-                      child: Text('${p.key} (${p.activeTicketCount})')))
-                  .toList(),
-              onChanged: (p) {
-                if (p != null) provider.setProject(p);
-              },
+              border: const OutlineInputBorder(),
+              contentPadding:
+                  const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
             ),
-          if (teams.isNotEmpty) ...[
-            const SizedBox(width: 12),
-            FilterChip(
-              label: const Text('All'),
-              selected: provider.selectedTeam == null,
-              onSelected: (_) => provider.setTeam(null),
-            ),
-            ...teams.map((team) => Padding(
-                  padding: const EdgeInsets.only(left: 6),
-                  child: FilterChip(
-                    label: Text(team),
-                    selected: provider.selectedTeam == team,
-                    onSelected: (_) => provider.setTeam(
-                        provider.selectedTeam == team ? null : team),
-                  ),
-                )),
-          ],
-        ],
-      ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -13,8 +13,8 @@ import 'activity_timeline_screen.dart';
 /// Full ticket detail view with read and edit modes.
 ///
 /// Fetches the ticket by ID on init using [boardProvider.client].
-/// In read mode, displays all ticket fields. Doc ref and attachments are
-/// tappable — they navigate to [DocumentViewerScreen].
+/// In read mode, displays all ticket fields. Doc refs are tappable rows
+/// with type badges — they navigate to [DocumentViewerScreen].
 /// A comment input bar is fixed at the bottom of the read view.
 /// Toggle to edit mode via the AppBar edit icon to change status, priority,
 /// team, assignee, estimate, and tags. Save calls [boardProvider.client.updateTicket].
@@ -457,9 +457,8 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
             from: _ticket!.from,
             to: _ticket!.to,
             tags: _ticket!.tags,
-            dependencies: _ticket!.dependencies,
-            attachments: _ticket!.attachments,
-            docRef: _ticket!.docRef,
+            blockedBy: _ticket!.blockedBy,
+            docRefs: _ticket!.docRefs,
             comments: _ticket!.comments
                 .where((c) => c.id != comment.id)
                 .toList(),
@@ -598,7 +597,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
                   Icon(Icons.person_outline,
                       size: 14, color: theme.colorScheme.outline),
                   const SizedBox(width: 4),
-                  Text(ticket.assignee!, style: theme.textTheme.bodySmall),
+                  _AssigneeText(assignee: ticket.assignee!),
                 ],
               ],
             ),
@@ -616,51 +615,18 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
             const SizedBox(height: 4),
             MarkdownBody(data: ticket.description!),
           ],
-          if (ticket.docRef != null && ticket.docRef!.isNotEmpty) ...[
+          if (ticket.docRefs.isNotEmpty) ...[
             const SizedBox(height: 16),
-            _SectionLabel('Doc Ref'),
+            _SectionLabel('Doc Refs'),
             const SizedBox(height: 4),
-            InkWell(
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => DocumentViewerScreen(
-                    path: ticket.docRef!,
-                    client: widget.boardProvider.client,
-                  ),
-                ),
-              ),
-              child: Text(
-                ticket.docRef!,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.primary,
-                  decoration: TextDecoration.underline,
-                ),
-              ),
-            ),
-          ],
-          if (ticket.attachments.isNotEmpty) ...[
-            const SizedBox(height: 16),
-            _SectionLabel('Attachments'),
-            const SizedBox(height: 4),
-            ...ticket.attachments.map(
-              (attachment) => ListTile(
-                dense: true,
-                contentPadding: EdgeInsets.zero,
-                leading: Icon(Icons.attach_file,
-                    size: 16, color: theme.colorScheme.primary),
-                title: Text(
-                  attachment.split('/').last,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.primary,
-                    decoration: TextDecoration.underline,
-                  ),
-                ),
+            ...ticket.docRefs.map(
+              (ref) => _DocRefRow(
+                docRef: ref,
                 onTap: () => Navigator.push(
                   context,
                   MaterialPageRoute(
                     builder: (_) => DocumentViewerScreen(
-                      path: attachment,
+                      path: ref.path,
                       client: widget.boardProvider.client,
                     ),
                   ),
@@ -973,6 +939,138 @@ class _InfoChip extends StatelessWidget {
           color: theme.colorScheme.onSurfaceVariant,
           fontSize: 11,
           fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}
+
+/// Displays an assignee string with team/agent parsing.
+/// If [assignee] contains '/', renders "team/" in muted text + "agent" in bold.
+class _AssigneeText extends StatelessWidget {
+  final String assignee;
+  const _AssigneeText({required this.assignee});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (!assignee.contains('/')) {
+      return Text(assignee, style: theme.textTheme.bodySmall);
+    }
+    final idx = assignee.indexOf('/');
+    final teamPart = assignee.substring(0, idx + 1); // includes '/'
+    final agentPart = assignee.substring(idx + 1);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          teamPart,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.outline,
+          ),
+        ),
+        Text(
+          agentPart,
+          style: theme.textTheme.bodySmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A tappable row displaying a single [DocRef] with a type badge, optional
+/// star for primary, and the ref path.
+class _DocRefRow extends StatelessWidget {
+  final DocRef docRef;
+  final VoidCallback onTap;
+  const _DocRefRow({required this.docRef, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          children: [
+            _DocRefBadge(type: docRef.type),
+            const SizedBox(width: 8),
+            if (docRef.primary) ...[
+              const Icon(Icons.star, size: 12, color: Colors.amber),
+              const SizedBox(width: 4),
+            ],
+            Expanded(
+              child: Text(
+                docRef.path,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                  decoration: TextDecoration.underline,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Colored badge chip showing the doc ref type abbreviation.
+class _DocRefBadge extends StatelessWidget {
+  final String type;
+  const _DocRefBadge({required this.type});
+
+  String get _label {
+    switch (type) {
+      case 'requirements':
+        return 'REQ';
+      case 'implementation':
+        return 'IMPL';
+      case 'spike':
+        return 'SPIKE';
+      case 'review-report':
+        return 'REVIEW';
+      default:
+        return 'ATTACH';
+    }
+  }
+
+  Color get _color {
+    switch (type) {
+      case 'requirements':
+        return Colors.indigo;
+      case 'implementation':
+        return Colors.green;
+      case 'spike':
+        return Colors.teal;
+      case 'review-report':
+        return Colors.purple;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _color;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: color.withValues(alpha: 0.5)),
+      ),
+      child: Text(
+        _label,
+        style: TextStyle(
+          color: color,
+          fontSize: 10,
+          fontWeight: FontWeight.w700,
         ),
       ),
     );

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -435,9 +435,14 @@ class AgentApiClient {
 
   /// Get the kanban board view for a project.
   ///
-  /// GET /api/board?project=X&team=Y → {"board": {...}}
+  /// GET /api/board?project=X&team=Y&excludeTags=backlog,archived&excludeTypes=fyi,work-report → {"board": {...}}
+  /// Always excludes backlog/archived tickets and fyi/work-report types to match CLI defaults.
   Future<BoardView> getBoard({required String project, String? team}) async {
-    final params = <String, String>{'project': project};
+    final params = <String, String>{
+      'project': project,
+      'excludeTags': 'backlog,archived',
+      'excludeTypes': 'fyi,work-report',
+    };
     if (team != null) params['team'] = team;
     final query = '?${Uri(queryParameters: params).query}';
     final response = await _get('/api/board$query');
@@ -462,6 +467,9 @@ class AgentApiClient {
     String? status,
     String? priority,
     String? type,
+    String? tags,
+    String? excludeTags,
+    String? search,
   }) async {
     final params = <String, String>{};
     if (project != null) params['project'] = project;
@@ -469,6 +477,9 @@ class AgentApiClient {
     if (status != null) params['status'] = status;
     if (priority != null) params['priority'] = priority;
     if (type != null) params['type'] = type;
+    if (tags != null) params['tags'] = tags;
+    if (excludeTags != null) params['excludeTags'] = excludeTags;
+    if (search != null) params['search'] = search;
     final query =
         params.isNotEmpty ? '?${Uri(queryParameters: params).query}' : '';
     final response = await _get('/api/tickets$query');

--- a/phone/lib/services/board_provider.dart
+++ b/phone/lib/services/board_provider.dart
@@ -41,6 +41,7 @@ class BoardProvider extends ChangeNotifier {
   String? _selectedProject;
   String? _selectedTeam;
   bool _showTerminal = false;
+  String _searchQuery = '';
   Timer? _pollTimer;
   SharedPreferences? _prefs;
 
@@ -68,12 +69,14 @@ class BoardProvider extends ChangeNotifier {
   String? get selectedProject => _selectedProject;
   String? get selectedTeam => _selectedTeam;
   bool get showTerminal => _showTerminal;
+  String get searchQuery => _searchQuery;
 
   /// Active (non-terminal, non-on-hold) columns in kanban order.
   List<BoardColumn> get activeColumns {
     if (_board == null) return [];
     return _board!.columns
         .where((c) => _activeStatuses.contains(c.status))
+        .map((c) => _applySearch(c))
         .toList();
   }
 
@@ -82,6 +85,7 @@ class BoardProvider extends ChangeNotifier {
     if (_board == null) return [];
     return _board!.columns
         .where((c) => _terminalStatuses.contains(c.status))
+        .map((c) => _applySearch(c))
         .toList();
   }
 
@@ -89,7 +93,8 @@ class BoardProvider extends ChangeNotifier {
   BoardColumn? get onHoldColumn {
     if (_board == null) return null;
     try {
-      return _board!.columns.firstWhere((c) => c.status == 'on-hold');
+      final col = _board!.columns.firstWhere((c) => c.status == 'on-hold');
+      return _applySearch(col);
     } catch (_) {
       return null;
     }
@@ -130,6 +135,12 @@ class BoardProvider extends ChangeNotifier {
 
   void toggleTerminal() {
     _showTerminal = !_showTerminal;
+    notifyListeners();
+  }
+
+  void setSearchQuery(String query) {
+    if (_searchQuery == query) return;
+    _searchQuery = query;
     notifyListeners();
   }
 
@@ -219,6 +230,19 @@ class BoardProvider extends ChangeNotifier {
   }
 
   // --- Private helpers ---
+
+  /// Filter a column's tickets by the current search query (client-side).
+  BoardColumn _applySearch(BoardColumn col) {
+    if (_searchQuery.isEmpty) return col;
+    final query = _searchQuery.toLowerCase();
+    final filtered =
+        col.tickets.where((t) => t.title.toLowerCase().contains(query)).toList();
+    return BoardColumn(
+      status: col.status,
+      tickets: filtered,
+      count: filtered.length,
+    );
+  }
 
   /// Rebuild a BoardView with one ticket moved to a new status column.
   BoardView _buildBoardWithUpdatedTicket(

--- a/phone/lib/widgets/ticket_card.dart
+++ b/phone/lib/widgets/ticket_card.dart
@@ -110,7 +110,7 @@ class _TicketCardBody extends StatelessWidget {
                   if (ticket.type != null) _TypeBadge(type: ticket.type!),
                   if (ticket.estimate != null)
                     _EstimateBadge(estimate: ticket.estimate!),
-                  if (ticket.docRef != null && ticket.docRef!.isNotEmpty)
+                  if (ticket.docRefs.isNotEmpty)
                     Icon(
                       Icons.description_outlined,
                       size: 14,
@@ -118,14 +118,9 @@ class _TicketCardBody extends StatelessWidget {
                     ),
                 ],
               ),
-              if (ticket.team != null) ...[
+              if (ticket.assignee != null) ...[
                 const SizedBox(height: 4),
-                Text(
-                  ticket.team!,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.outline,
-                  ),
-                ),
+                _AssigneeText(assignee: ticket.assignee!),
               ],
             ],
           ),
@@ -339,6 +334,47 @@ class _EstimateBadge extends StatelessWidget {
           fontWeight: FontWeight.w600,
         ),
       ),
+    );
+  }
+}
+
+/// Assignee display: if assignee contains '/', shows 'team/' in muted text
+/// followed by 'agent' in bold. Otherwise shows plain text.
+class _AssigneeText extends StatelessWidget {
+  final String assignee;
+
+  const _AssigneeText({required this.assignee});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (!assignee.contains('/')) {
+      return Text(
+        assignee,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.outline,
+        ),
+      );
+    }
+    final idx = assignee.indexOf('/');
+    final teamPart = assignee.substring(0, idx + 1); // includes '/'
+    final agentPart = assignee.substring(idx + 1);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          teamPart,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.outline,
+          ),
+        ),
+        Text(
+          agentPart,
+          style: theme.textTheme.bodySmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- **F1/F8**: Updated Ticket model — `DocRef` class replaces `docRef`/`attachments`, `blockedBy` replaces `dependencies`, backward compat preserved
- **F2/F7**: Ticket detail screen — typed doc_refs list with color-coded badges (REQ/IMPL/SPIKE/REVIEW/ATTACH), primary star, tappable rows; assignee team/agent styled display
- **F3**: Ticket card — doc icon checks `docRefs.isNotEmpty`
- **F4/F5**: API client — `getBoard()` auto-filters backlog/archived/fyi/work-report; `listTickets()` gains tags/excludeTags/search params
- **F6**: Kanban board — search TextField with 300ms debounce, client-side title filtering

Implements all 8 functional requirements and 8 acceptance criteria from AVO-014.

## Test plan
- [ ] Open a ticket with doc_refs → verify typed list with badges, primary star, tap opens DocumentViewerScreen
- [ ] Kanban board loads → verify no backlog/archived/fyi/work-report tickets visible
- [ ] Type in kanban search bar → verify tickets filter by title match
- [ ] Check assignee display → verify team/agent split styling
- [ ] Check ticket with blockedBy field → verify parsed correctly
- [ ] Check backward compat: old doc_ref string → wraps in single DocRef

🤖 Generated with [Claude Code](https://claude.com/claude-code)