### PR TITLE
fix(phone): deploy UX fixes — AVO-008/AVO-011

### DIFF
--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -218,23 +218,46 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
               ));
               return;
             }
-            // Fetch real deployment from server instead of fabricating one.
+            // Server may return empty deployment_id (ID generated async).
+            // Poll listDeployments to find the real deployment.
             Deployment? deployment;
-            if (result.deploymentId.isNotEmpty) {
-              await Future<void>.delayed(const Duration(seconds: 1));
+            final beforeDeploy = DateTime.now().subtract(const Duration(seconds: 5));
+            for (var attempt = 0; attempt < 3; attempt++) {
+              await Future<void>.delayed(const Duration(seconds: 2));
+              if (!mounted) return;
               try {
                 final deployments = await client.listDeployments();
-                deployment = deployments.cast<Deployment?>().firstWhere(
-                      (d) => d!.deploymentId == result.deploymentId,
-                      orElse: () => null,
-                    );
+                // Match by exact ID if available, else by team + recent start.
+                if (result.deploymentId.isNotEmpty) {
+                  deployment = deployments.cast<Deployment?>().firstWhere(
+                        (d) => d!.deploymentId == result.deploymentId,
+                        orElse: () => null,
+                      );
+                } else {
+                  // Find most recent deployment for this team started after our trigger.
+                  final candidates = deployments.where((d) {
+                    if (d.team != team) return false;
+                    final started = DateTime.tryParse(d.startedAt);
+                    return started != null && started.isAfter(beforeDeploy);
+                  }).toList()
+                    ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
+                  if (candidates.isNotEmpty) {
+                    deployment = candidates.first;
+                  }
+                }
+                if (deployment != null) break;
               } catch (_) {
-                // Non-fatal — we'll still show the SnackBar without View.
+                // Retry on next attempt.
               }
             }
             if (!mounted) return;
+            final displayId = deployment?.deploymentId ?? result.deploymentId;
             messenger.showSnackBar(SnackBar(
-              content: Text('Deployed ${result.deploymentId}'),
+              content: Text(
+                displayId.isNotEmpty
+                    ? 'Deployed $displayId'
+                    : 'Deployment launched',
+              ),
               duration: const Duration(seconds: 8),
               action: deployment != null
                   ? SnackBarAction(

--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -42,6 +42,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
 
   // Deploy state
   DeployRouting? _deployRouting;
+  DateTime? _deployRoutingFetchedAt;
   bool _fetchingRouting = false;
 
   // Edit state
@@ -146,12 +147,19 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
     final errorColor = Theme.of(context).colorScheme.error;
     final client = widget.boardProvider.client;
 
-    // Fetch routing if not cached.
-    if (_deployRouting == null) {
+    // Fetch routing if not cached or stale (>5 min).
+    final routingStale = _deployRoutingFetchedAt != null &&
+        DateTime.now().difference(_deployRoutingFetchedAt!).inMinutes >= 5;
+    if (_deployRouting == null || routingStale) {
       setState(() => _fetchingRouting = true);
       try {
         final routing = await client.getDeployRouting();
-        if (mounted) setState(() => _deployRouting = routing);
+        if (mounted) {
+          setState(() {
+            _deployRouting = routing;
+            _deployRoutingFetchedAt = DateTime.now();
+          });
+        }
       } catch (e) {
         if (mounted) {
           setState(() => _fetchingRouting = false);
@@ -199,36 +207,52 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
               repo: repo,
               ticket: ticket.id,
             );
-            if (mounted) {
-              final deployment = Deployment(
-                deploymentId: result.deploymentId,
-                team: result.team,
-                status: 'running',
-                startedAt: DateTime.now().toIso8601String(),
-              );
+            if (!mounted) return;
+            if (!result.started) {
               messenger.showSnackBar(SnackBar(
                 content: Text(
-                  result.deploymentId.isNotEmpty
-                      ? 'Deployed ${result.deploymentId}'
-                      : 'Deployment started',
+                  'Deploy failed: server did not start deployment'
+                  '${result.deploymentId.isNotEmpty ? ' (${result.deploymentId})' : ''}',
                 ),
-                duration: const Duration(seconds: 8),
-                action: SnackBarAction(
-                  label: 'View',
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute<void>(
-                        builder: (_) => ActivityTimelineScreen(
-                          deployment: deployment,
-                          client: client,
-                        ),
-                      ),
-                    );
-                  },
-                ),
+                backgroundColor: errorColor,
               ));
+              return;
             }
+            // Fetch real deployment from server instead of fabricating one.
+            Deployment? deployment;
+            if (result.deploymentId.isNotEmpty) {
+              await Future<void>.delayed(const Duration(seconds: 1));
+              try {
+                final deployments = await client.listDeployments();
+                deployment = deployments.cast<Deployment?>().firstWhere(
+                      (d) => d!.deploymentId == result.deploymentId,
+                      orElse: () => null,
+                    );
+              } catch (_) {
+                // Non-fatal — we'll still show the SnackBar without View.
+              }
+            }
+            if (!mounted) return;
+            messenger.showSnackBar(SnackBar(
+              content: Text('Deployed ${result.deploymentId}'),
+              duration: const Duration(seconds: 8),
+              action: deployment != null
+                  ? SnackBarAction(
+                      label: 'View',
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute<void>(
+                            builder: (_) => ActivityTimelineScreen(
+                              deployment: deployment!,
+                              client: client,
+                            ),
+                          ),
+                        );
+                      },
+                    )
+                  : null,
+            ));
           } catch (e) {
             if (mounted) {
               messenger.showSnackBar(SnackBar(

--- a/phone/lib/widgets/deploy_sheet.dart
+++ b/phone/lib/widgets/deploy_sheet.dart
@@ -209,7 +209,7 @@ class _DeploySheetState extends State<DeploySheet> {
                   minLines: 2,
                   maxLines: 5,
                   decoration: InputDecoration(
-                    hintText: 'e.g. 2026-03-16-task.md or leave blank',
+                    hintText: 'e.g. AVO-008: Implement feature or leave blank',
                     border: const OutlineInputBorder(),
                     contentPadding: const EdgeInsets.symmetric(
                       horizontal: 12,


### PR DESCRIPTION
## Summary
- **Validate `result.started`**: Show error SnackBar when server returns `started=false` instead of silently showing false success
- **Replace fabricated Deployment**: Fetch real deployment from `GET /api/deployments` after 1s delay; only show "View" action if server confirms deployment exists
- **Update hint text**: DeploySheet objective hint now shows ticket example (`AVO-008: Implement feature`) instead of inbox filename
- **Routing cache TTL**: Deploy routing refreshes after 5 minutes instead of caching indefinitely

## Tickets
- AVO-008: Ticket-to-Deploy Integration (UAT fixes)
- AVO-011: Fix phone deploy UX

## Test plan
- [ ] Deploy from ticket detail — verify error shown when server returns `started: false`
- [ ] Deploy from ticket detail — verify "View" action navigates to real server deployment
- [ ] Check deploy routing refreshes after 5 minutes
- [ ] Verify hint text in DeploySheet shows ticket example

🤖 Generated with [Claude Code](https://claude.com/claude-code)