### PR TITLE
feat(avodah): AVO-015 — Category-First Time Tracking with Orphan Worklogs

### DIFF
--- a/mcp/bin/avo.dart
+++ b/mcp/bin/avo.dart
@@ -106,7 +106,8 @@ Future<void> main(List<String> args) async {
           taskService: taskService,
           worklogService: worklogService))
       ..addCommand(JiraCommand(jiraService, paths))
-      ..addCommand(DbCommand(db: db, clock: clock, paths: paths));
+      ..addCommand(DbCommand(db: db, clock: clock, paths: paths))
+      ..addCommand(ConfigCommand(avoConfig, paths));
 
     // No args → run status + hint
     if (args.isEmpty) {

--- a/mcp/lib/cli/commands.dart
+++ b/mcp/lib/cli/commands.dart
@@ -1927,13 +1927,14 @@ class WorklogCommand extends Command<void> {
     addSubcommand(WorklogEditCommand(worklogService, taskService, jiraService: jiraService));
     addSubcommand(WorklogListCommand(worklogService, taskService));
     addSubcommand(WorklogDeleteCommand(worklogService, taskService));
+    addSubcommand(WorklogAssignCommand(worklogService, taskService, jiraService: jiraService));
   }
 
   @override
   String get name => 'worklog';
 
   @override
-  String get description => 'Worklog management (add, edit, list, delete)';
+  String get description => 'Worklog management (add, edit, list, delete, assign)';
 }
 
 /// Worklog list subcommand (under `avo worklog list`).
@@ -1941,6 +1942,8 @@ class WorklogListCommand extends WorklogSubcommand {
   WorklogListCommand(super.worklogService, super.taskService) {
     argParser.addOption('count', abbr: 'n', help: 'Number of entries',
         defaultsTo: '10');
+    argParser.addFlag('orphan', abbr: 'o', help: 'List only orphan worklogs (no task)',
+        defaultsTo: false);
   }
 
   @override
@@ -1950,35 +1953,55 @@ class WorklogListCommand extends WorklogSubcommand {
   String get description => 'List recent worklogs';
 
   @override
-  String get invocation => 'avo worklog list [-n count]';
+  String get invocation => 'avo worklog list [-n count] [--orphan]';
 
   @override
-  String? get usageFooter => '\nShows the 10 most recent worklogs by default.';
+  String? get usageFooter => '\nShows the 10 most recent worklogs by default.\n'
+      'Use --orphan to list only orphan worklogs (no task assigned).';
 
   @override
   Future<void> run() async {
     final limit = int.tryParse(argResults?['count'] as String? ?? '10') ?? 10;
-    final worklogs = await worklogService.listRecent(limit: limit);
+    final showOrphanOnly = argResults?['orphan'] as bool? ?? false;
+
+    List<WorklogDocument> worklogs;
+    if (showOrphanOnly) {
+      worklogs = await worklogService.listOrphan();
+    } else {
+      worklogs = await worklogService.listRecent(limit: limit);
+    }
 
     if (worklogs.isEmpty) {
-      print('No worklogs yet.');
-      print('');
-      print(hint('avo worklog add', 'to log manually'));
+      if (showOrphanOnly) {
+        print('No orphan worklogs.');
+        print('');
+        print(hint('avo worklog add', 'to create an orphan worklog'));
+      } else {
+        print('No worklogs yet.');
+        print('');
+        print(hint('avo worklog add', 'to log manually'));
+      }
       return;
     }
 
-    print('Recent Worklogs (${worklogs.length}):');
+    final header = showOrphanOnly
+        ? 'Orphan Worklogs (${worklogs.length}):'
+        : 'Recent Worklogs (${worklogs.length}):';
+    print(header);
     print(separator());
     for (final w in worklogs) {
-      final title = await resolveTaskTitle(taskService, w.taskId);
+      final title = w.isOrphan
+          ? '(no task)'
+          : await resolveTaskTitle(taskService, w.taskId);
       final dur = formatDuration(Duration(milliseconds: w.durationMs));
       final startDate = formatRelativeDate(w.startTime);
       final startTime = formatTime(w.startTime);
       final syncIcon = w.jiraDirty ? ' [modified]' : w.isSyncedToJira ? ' [synced]' : '';
+      final categoryStr = w.category != null ? ' [${w.category}]' : '';
       final commentStr = w.comment != null && w.comment!.isNotEmpty
           ? '  "${w.comment}"'
           : '';
-      print('  ${w.id.substring(0, 8)}  $title  $dur  $startDate $startTime$syncIcon$commentStr');
+      print('  ${w.id.substring(0, 8)}  $title  $dur  $startDate $startTime$categoryStr$syncIcon$commentStr');
     }
   }
 }
@@ -2047,6 +2070,9 @@ class WorklogAddCommand extends WorklogSubcommand {
     argParser.addOption('start', abbr: 's', help: 'Start time (e.g. 9:00, 2026-02-15T09:00)');
     argParser.addOption('duration', abbr: 'd', help: 'Duration (e.g. 1h30m, 45m)');
     argParser.addOption('message', abbr: 'm', help: 'Description/comment');
+    argParser.addOption('category', abbr: 'c', help: 'Category (for orphan worklogs)');
+    argParser.addFlag('no-task', help: 'Create an orphan worklog (no task)',
+        negatable: false);
   }
 
   @override
@@ -2056,15 +2082,17 @@ class WorklogAddCommand extends WorklogSubcommand {
   String get description => 'Add a worklog with start time and duration';
 
   @override
-  String get invocation => 'avo worklog add [-t task] [-s start] [-d duration] [-m message]';
+  String get invocation => 'avo worklog add [-t task] [-s start] [-d duration] [-m message] [--no-task] [--category cat]';
 
   @override
   String? get usageFooter => '\nExamples:\n'
       '  avo worklog add -t a1b2 -s 9:00 -d 1h30m -m "morning work"\n'
-      '  avo worklog add                    # interactive mode\n'
+      '  avo worklog add --no-task -c Working -s 9:00 -d 1h  # orphan worklog\n'
+      '  avo worklog add --no-task          # interactive orphan mode\n'
       '\n'
       'Time formats: 9:00, 14:30, 2026-02-15T09:00, yesterday 14:00\n'
-      'Duration formats: 30m, 1h, 1h30m, 2h 15m';
+      'Duration formats: 30m, 1h, 1h30m, 2h 15m\n'
+      'Use --no-task to create orphan worklogs without a task.';
 
   @override
   Future<void> run() async {
@@ -2072,26 +2100,38 @@ class WorklogAddCommand extends WorklogSubcommand {
     final startInput = argResults?['start'] as String?;
     final durationInput = argResults?['duration'] as String?;
     var comment = argResults?['message'] as String?;
+    final categoryInput = argResults?['category'] as String?;
+    final noTask = argResults?['no-task'] as bool? ?? false;
 
-    // Also accept task as positional arg
+    // Also accept task as positional arg (but not when --no-task is set)
     final rest = argResults?.rest ?? [];
-    if (taskInput == null && rest.isNotEmpty) {
+    if (taskInput == null && !noTask && rest.isNotEmpty) {
       taskInput = rest.first;
     }
+
+    // Orphan worklog mode: --no-task flag is set
+    final isOrphan = noTask;
 
     // Determine if interactive mode is needed
     final interactive = taskInput == null || startInput == null || durationInput == null;
 
-    // Resolve task
-    String taskId;
+    // Resolve task (null for orphan)
+    String? taskId;
     String taskTitle;
-    if (taskInput == null) {
+    String? category;
+    if (isOrphan) {
+      // Orphan mode: no task, use category
+      taskId = '';
+      taskTitle = '(no task)';
+      category = categoryInput;
+    } else if (taskInput == null) {
       // Interactive task picker
       final tasks = await taskService.list();
       if (tasks.isEmpty) {
         print('No active tasks.');
         print('');
         print(hint('avo task add <title>', 'to create one'));
+        print(hint('avo worklog add --no-task', 'to create an orphan worklog'));
         return;
       }
 
@@ -2200,30 +2240,144 @@ class WorklogAddCommand extends WorklogSubcommand {
       }
     }
 
+    // Resolve category (for orphan worklogs in interactive mode)
+    if (category == null && interactive && isOrphan) {
+      final rl = TerminalReadline();
+      final input = rl.readLine('Category (optional, e.g. Working, Learning): ');
+      if (input != null && input.trim().isNotEmpty) {
+        category = input.trim();
+      }
+    }
+
     final worklog = await worklogService.createWorklog(
-      taskId: taskId,
+      taskId: taskId ?? '',
       start: start!,
       duration: duration!,
       comment: comment,
+      category: category,
     );
 
-    print('Logged ${formatDuration(duration)} on "$taskTitle"');
-    print(kvRow('Worklog:', worklog.id.substring(0, 8)));
-    print(kvRow('Start:', formatTime(start)));
-    print(kvRow('End:', formatTime(start.add(duration))));
-    if (comment != null) print(kvRow('Comment:', comment));
+    if (isOrphan) {
+      print('Logged ${formatDuration(duration)} (orphan - no task)');
+      print(kvRow('Worklog:', worklog.id.substring(0, 8)));
+      print(kvRow('Start:', formatTime(start)));
+      print(kvRow('End:', formatTime(start.add(duration))));
+      if (category != null) print(kvRow('Category:', category));
+      if (comment != null) print(kvRow('Comment:', comment));
+      print('');
+      print(hint('avo worklog assign ${worklog.id.substring(0, 8)} <task-id>', 'to assign to a task'));
+    } else {
+      print('Logged ${formatDuration(duration)} on "$taskTitle"');
+      print(kvRow('Worklog:', worklog.id.substring(0, 8)));
+      print(kvRow('Start:', formatTime(start)));
+      print(kvRow('End:', formatTime(start.add(duration))));
+      if (comment != null) print(kvRow('Comment:', comment));
 
-    // Auto-push worklog to Jira if service is available
-    if (jiraService != null) {
-      final pushed = await jiraService!.pushWorklog(worklog.id);
-      if (pushed) {
-        print(kvRow('Jira:', 'worklog synced'));
+      // Auto-push worklog to Jira if service is available
+      if (jiraService != null) {
+        final pushed = await jiraService!.pushWorklog(worklog.id);
+        if (pushed) {
+          print(kvRow('Jira:', 'worklog synced'));
+        }
       }
     }
 
     print('');
     print(hint('avo today', 'to see today\'s total'));
     print(hint('avo worklog edit ${worklog.id.substring(0, 8)}', 'to edit'));
+  }
+}
+
+/// Worklog assign subcommand (under `avo worklog assign`).
+/// Assigns an orphan worklog to a task.
+class WorklogAssignCommand extends WorklogSubcommand {
+  WorklogAssignCommand(super.worklogService, super.taskService,
+      {super.jiraService});
+
+  @override
+  String get name => 'assign';
+
+  @override
+  String get description => 'Assign an orphan worklog to a task';
+
+  @override
+  String get invocation => 'avo worklog assign <worklog-id> <task-id>';
+
+  @override
+  String? get usageFooter => '\nAssigns an orphan worklog to a task.\n'
+      'The worklog\'s category will be set from the task if the task has one.\n'
+      'If the task is Jira-linked, the worklog will be marked dirty for Jira sync.\n'
+      '\nExample:\n'
+      '  avo worklog assign abc123 def456\n'
+      '  avo worklog assign abc123 -t def456';
+
+  @override
+  Future<void> run() async {
+    final args = argResults?.rest ?? [];
+    if (args.length < 2) {
+      print('Missing arguments.');
+      print('');
+      print('  Usage: avo worklog assign <worklog-id> <task-id>');
+      print(hint('avo worklog list --orphan', 'to see orphan worklogs'));
+      print(hint('avo task list', 'to see available tasks'));
+      return;
+    }
+
+    final worklogIdInput = args[0];
+    var taskInput = args[1];
+
+    // Also accept task as --task option
+    final taskOption = argResults?['task'] as String?;
+    if (taskOption != null) {
+      taskInput = taskOption;
+    }
+
+    try {
+      final worklog = await worklogService.assignToTask(
+        worklogIdOrPrefix: worklogIdInput,
+        taskIdOrPrefix: taskInput,
+        getTask: taskService.show,
+      );
+
+      final taskTitle = await resolveTaskTitle(taskService, worklog.taskId);
+      print('Assigned worklog ${worklog.id.substring(0, 8)} to "$taskTitle"');
+      final worklogCategory = worklog.category;
+      if (worklogCategory != null) {
+        print(kvRow('Category:', worklogCategory));
+      }
+      if (worklog.jiraDirty) {
+        print(kvRow('Jira:', 'marked dirty for re-sync'));
+      }
+
+      print('');
+      print(hint('avo worklog edit ${worklog.id.substring(0, 8)}', 'to edit'));
+    } on WorklogNotFoundException {
+      print('No worklog found matching "$worklogIdInput".');
+      print('');
+      print(hint('avo worklog list --orphan', 'to see orphan worklogs'));
+    } on AmbiguousWorklogIdException catch (e) {
+      print('Multiple worklogs match "$worklogIdInput":');
+      for (final id in e.matchingIds) {
+        print('  ${id.substring(0, 8)}');
+      }
+      print('');
+      print(hintPlain('Use a longer prefix to be specific.'));
+    } on WorklogNotAssignedException catch (e) {
+      print('Cannot assign: ${e.message}');
+      print('');
+      print(hint('avo worklog list', 'to see worklogs'));
+    } on TaskNotFoundException {
+      print('No task found matching "$taskInput".');
+      print('');
+      print(hint('avo task list', 'to see available tasks'));
+    } on AmbiguousTaskIdException catch (e) {
+      print('Multiple tasks match "$taskInput":');
+      for (final id in e.matchingIds) {
+        print('  ${id.substring(0, 8)}');
+      }
+      print('');
+      print(hintPlain('Use a longer prefix to be specific.'));
+    }
   }
 }
 

--- a/mcp/lib/cli/commands.dart
+++ b/mcp/lib/cli/commands.dart
@@ -1967,7 +1967,7 @@ class WorklogListCommand extends WorklogSubcommand {
 
     List<WorklogDocument> worklogs;
     if (showOrphanOnly) {
-      worklogs = await worklogService.listOrphan();
+      worklogs = await worklogService.listOrphan(limit: limit);
     } else {
       worklogs = await worklogService.listRecent(limit: limit);
     }

--- a/mcp/lib/cli/commands.dart
+++ b/mcp/lib/cli/commands.dart
@@ -2251,7 +2251,7 @@ class WorklogAddCommand extends WorklogSubcommand {
     }
 
     final worklog = await worklogService.createWorklog(
-      taskId: taskId ?? '',
+      taskId: taskId,
       start: start!,
       duration: duration!,
       comment: comment,
@@ -2293,7 +2293,9 @@ class WorklogAddCommand extends WorklogSubcommand {
 /// Assigns an orphan worklog to a task.
 class WorklogAssignCommand extends WorklogSubcommand {
   WorklogAssignCommand(super.worklogService, super.taskService,
-      {super.jiraService});
+      {super.jiraService}) {
+    argParser.addOption('task', abbr: 't', help: 'Task ID or prefix');
+  }
 
   @override
   String get name => 'assign';
@@ -4017,7 +4019,9 @@ class ConfigChipsCommand extends Command<void> {
 class ConfigChipsListCommand extends Command<void> {
   final AvoConfig _config;
 
-  ConfigChipsListCommand(this._config);
+  ConfigChipsListCommand(this._config) {
+    argParser.addOption('category', help: 'Filter by category');
+  }
 
   @override
   String get name => 'list';

--- a/mcp/lib/cli/commands.dart
+++ b/mcp/lib/cli/commands.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:avodah_core/avodah_core.dart';
 
+import '../config/avo_config.dart';
 import '../config/paths.dart';
 import '../services/jira_service.dart';
 import '../services/plan_service.dart';
@@ -3974,4 +3975,207 @@ class DbDumpCommand extends Command<void> {
         'cancelled': row.cancelled,
         'created': row.created,
       };
+}
+
+// ── Config Command ─────────────────────────────────────────────────────────
+
+/// Config management command group.
+class ConfigCommand extends Command<void> {
+  final AvoConfig _config;
+  final AvodahPaths _paths;
+
+  ConfigCommand(this._config, this._paths) {
+    addSubcommand(ConfigChipsCommand(_config, _paths));
+  }
+
+  @override
+  String get name => 'config';
+
+  @override
+  String get description => 'Configuration management';
+}
+
+/// Per-category comment chip presets for quick comments when stopping timers.
+class ConfigChipsCommand extends Command<void> {
+  final AvoConfig _config;
+  final AvodahPaths _paths;
+
+  ConfigChipsCommand(this._config, this._paths) {
+    addSubcommand(ConfigChipsListCommand(_config));
+    addSubcommand(ConfigChipsAddCommand(_config, _paths));
+    addSubcommand(ConfigChipsRemoveCommand(_config, _paths));
+  }
+
+  @override
+  String get name => 'chips';
+
+  @override
+  String get description => 'Manage per-category comment chip presets';
+}
+
+/// List chip presets.
+class ConfigChipsListCommand extends Command<void> {
+  final AvoConfig _config;
+
+  ConfigChipsListCommand(this._config);
+
+  @override
+  String get name => 'list';
+
+  @override
+  String get description => 'List chip presets';
+
+  @override
+  String get invocation => 'avo config chips list [--category <category>]';
+
+  @override
+  Future<void> run() async {
+    final category = argResults?['category'] as String?;
+
+    final chips = Map<String, List<String>>.from(_config.categoryChips);
+
+    if (chips.isEmpty) {
+      print('No chip presets configured.');
+      print('');
+      print(hint('avo config chips add <category> <chip>',
+          'to add a chip preset'));
+      return;
+    }
+
+    if (category != null) {
+      // List chips for specific category
+      final categoryChips = chips[category];
+      if (categoryChips == null || categoryChips.isEmpty) {
+        print('No chip presets for "$category".');
+        print('');
+        print('Available categories: ${chips.keys.join(", ")}');
+      } else {
+        print('Chips for "$category":');
+        for (final chip in categoryChips) {
+          print('  - $chip');
+        }
+      }
+    } else {
+      // List all chips
+      print('Chip Presets:');
+      print(separator());
+      final sortedCats = chips.keys.toList()..sort();
+      for (final cat in sortedCats) {
+        final catChips = chips[cat]!;
+        print('  $cat (${catChips.length}):');
+        for (final chip in catChips) {
+          print('    - $chip');
+        }
+        print('');
+      }
+    }
+  }
+}
+
+/// Add a chip preset.
+class ConfigChipsAddCommand extends Command<void> {
+  final AvoConfig _config;
+  final AvodahPaths _paths;
+
+  ConfigChipsAddCommand(this._config, this._paths);
+
+  @override
+  String get name => 'add';
+
+  @override
+  String get description => 'Add a chip preset to a category';
+
+  @override
+  String get invocation => 'avo config chips add <category> <chip>';
+
+  @override
+  Future<void> run() async {
+    final args = argResults?.rest ?? [];
+    if (args.length < 2) {
+      print('Missing arguments.');
+      print('');
+      print('  Usage: avo config chips add <category> <chip>');
+      print('');
+      print('  Example: avo config chips add Working standup');
+      return;
+    }
+
+    final category = args[0];
+    final chip = args[1];
+
+    final newChips = Map<String, List<String>>.from(_config.categoryChips);
+    final categoryChips = List<String>.from(newChips[category] ?? []);
+
+    if (categoryChips.contains(chip)) {
+      print('Chip "$chip" already exists in "$category".');
+      return;
+    }
+
+    categoryChips.add(chip);
+    newChips[category] = categoryChips;
+
+    final newConfig = AvoConfig(
+      categories: _config.categories,
+      syncPort: _config.syncPort,
+      syncInterval: _config.syncInterval,
+      categoryChips: newChips,
+    );
+
+    await newConfig.save(_paths);
+    print('Added chip "$chip" to "$category".');
+  }
+}
+
+/// Remove a chip preset.
+class ConfigChipsRemoveCommand extends Command<void> {
+  final AvoConfig _config;
+  final AvodahPaths _paths;
+
+  ConfigChipsRemoveCommand(this._config, this._paths);
+
+  @override
+  String get name => 'remove';
+
+  @override
+  String get description => 'Remove a chip preset from a category';
+
+  @override
+  String get invocation => 'avo config chips remove <category> <chip>';
+
+  @override
+  Future<void> run() async {
+    final args = argResults?.rest ?? [];
+    if (args.length < 2) {
+      print('Missing arguments.');
+      print('');
+      print('  Usage: avo config chips remove <category> <chip>');
+      print('');
+      print('  Example: avo config chips remove Working standup');
+      return;
+    }
+
+    final category = args[0];
+    final chip = args[1];
+
+    final newChips = Map<String, List<String>>.from(_config.categoryChips);
+    final categoryChips = List<String>.from(newChips[category] ?? []);
+
+    if (!categoryChips.contains(chip)) {
+      print('Chip "$chip" not found in "$category".');
+      return;
+    }
+
+    categoryChips.remove(chip);
+    newChips[category] = categoryChips;
+
+    final newConfig = AvoConfig(
+      categories: _config.categories,
+      syncPort: _config.syncPort,
+      syncInterval: _config.syncInterval,
+      categoryChips: newChips,
+    );
+
+    await newConfig.save(_paths);
+    print('Removed chip "$chip" from "$category".');
+  }
 }

--- a/mcp/lib/config/avo_config.dart
+++ b/mcp/lib/config/avo_config.dart
@@ -106,6 +106,7 @@ class AvoConfig {
   Future<void> save(AvodahPaths paths) async {
     final configPath = p.join(paths.configDir, 'config.json');
     final file = File(configPath);
+    file.parent.createSync(recursive: true);
     await file.writeAsString(jsonEncode(toJson()));
   }
 }

--- a/mcp/lib/config/avo_config.dart
+++ b/mcp/lib/config/avo_config.dart
@@ -20,6 +20,11 @@ class AvoConfig {
   /// Interval in seconds between snapshot pushes to connected clients.
   final int syncInterval;
 
+  /// Per-category comment chip presets for quick comments when stopping timers.
+  /// Example: {'Working': ['standup', 'code review', 'debugging'],
+  ///           'Learning': ['reading', 'course']}
+  final Map<String, List<String>> categoryChips;
+
   static const defaultCategories = [
     'Learning',
     'Working',
@@ -32,6 +37,7 @@ class AvoConfig {
     this.categories = const [],
     this.syncPort = 9847,
     this.syncInterval = 30,
+    this.categoryChips = const {},
   });
 
   /// Effective categories list — user's if set, otherwise defaults.
@@ -64,10 +70,42 @@ class AvoConfig {
     final syncPort = (syncMap?['port'] as int?) ?? 9847;
     final syncInterval = (syncMap?['intervalSeconds'] as int?) ?? 30;
 
+    final chipsMap = json['categoryChips'] as Map<String, dynamic>?;
+    final categoryChips = <String, List<String>>{};
+    if (chipsMap != null) {
+      for (final entry in chipsMap.entries) {
+        final chips = (entry.value as List<dynamic>?)
+                ?.map((e) => e as String)
+                .toList() ??
+            [];
+        categoryChips[entry.key] = chips;
+      }
+    }
+
     return AvoConfig(
       categories: categories,
       syncPort: syncPort,
       syncInterval: syncInterval,
+      categoryChips: categoryChips,
     );
+  }
+
+  /// Converts this config to a JSON-serializable map.
+  Map<String, dynamic> toJson() {
+    return {
+      'categories': categories,
+      'sync': {
+        'port': syncPort,
+        'intervalSeconds': syncInterval,
+      },
+      'categoryChips': categoryChips,
+    };
+  }
+
+  /// Saves this config to `~/.config/avodah/config.json`.
+  Future<void> save(AvodahPaths paths) async {
+    final configPath = p.join(paths.configDir, 'config.json');
+    final file = File(configPath);
+    await file.writeAsString(jsonEncode(toJson()));
   }
 }

--- a/mcp/lib/services/sync_api_service.dart
+++ b/mcp/lib/services/sync_api_service.dart
@@ -61,7 +61,9 @@ class SyncApiService {
     final path = request.uri.path;
     final method = request.method;
 
-    if (path != '/api/sync/deltas' && path != '/api/config/categories') {
+    if (path != '/api/sync/deltas' &&
+        path != '/api/config/categories' &&
+        path != '/api/config/category-chips') {
       return false;
     }
 
@@ -83,6 +85,13 @@ class SyncApiService {
       if (path == '/api/config/categories') {
         if (method == 'GET') {
           await _handleGetCategories(request);
+        } else {
+          _jsonResponse(request, HttpStatus.methodNotAllowed,
+              {'error': 'Method not allowed'});
+        }
+      } else if (path == '/api/config/category-chips') {
+        if (method == 'GET') {
+          await _handleGetCategoryChips(request);
         } else {
           _jsonResponse(request, HttpStatus.methodNotAllowed,
               {'error': 'Method not allowed'});
@@ -173,6 +182,27 @@ class SyncApiService {
       ..sort();
 
     _jsonResponse(request, HttpStatus.ok, {'categories': allCategories});
+  }
+
+  /// GET /api/config/category-chips?category=Working
+  ///
+  /// Returns the list of chip presets for the specified category.
+  /// If no category is specified, returns all category chips as a map.
+  Future<void> _handleGetCategoryChips(HttpRequest request) async {
+    final category = request.uri.queryParameters['category'];
+
+    final chips = config?.categoryChips ?? {};
+
+    if (category != null) {
+      // Return chips for specific category
+      _jsonResponse(request, HttpStatus.ok, {
+        'category': category,
+        'chips': chips[category] ?? [],
+      });
+    } else {
+      // Return all chips
+      _jsonResponse(request, HttpStatus.ok, {'categoryChips': chips});
+    }
   }
 
   /// Merges a batch of incoming CRDT deltas from [remoteNode] into the local DB.

--- a/mcp/lib/services/sync_api_service.dart
+++ b/mcp/lib/services/sync_api_service.dart
@@ -47,7 +47,7 @@ class SyncApiService {
   final JiraService? jiraService;
 
   /// User config for categories, etc.
-  final AvoConfig? config;
+  AvoConfig? config;
 
   SyncApiService({
     required this.db,
@@ -254,6 +254,7 @@ class SyncApiService {
           categoryChips: newChips,
         );
         await newConfig.save(AvodahPaths());
+        config = newConfig;
         _jsonResponse(request, HttpStatus.ok, {
           'success': true,
           'action': 'added',
@@ -279,6 +280,7 @@ class SyncApiService {
           categoryChips: newChips,
         );
         await newConfig.save(AvodahPaths());
+        config = newConfig;
       }
       _jsonResponse(request, HttpStatus.ok, {
         'success': true,
@@ -324,6 +326,7 @@ class SyncApiService {
         categoryChips: newChips,
       );
       await newConfig.save(AvodahPaths());
+      config = newConfig;
     }
 
     _jsonResponse(request, HttpStatus.ok, {

--- a/mcp/lib/services/sync_api_service.dart
+++ b/mcp/lib/services/sync_api_service.dart
@@ -16,6 +16,7 @@ import 'package:avodah_core/avodah_core.dart';
 import 'package:drift/drift.dart' show Value;
 
 import '../config/avo_config.dart';
+import '../config/paths.dart';
 import 'jira_service.dart';
 
 /// Document type identifiers used in sync delta payloads.
@@ -70,7 +71,7 @@ class SyncApiService {
     // CORS headers
     request.response.headers.add('Access-Control-Allow-Origin', '*');
     request.response.headers
-        .add('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+        .add('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
     request.response.headers
         .add('Access-Control-Allow-Headers', 'Content-Type');
 
@@ -92,6 +93,10 @@ class SyncApiService {
       } else if (path == '/api/config/category-chips') {
         if (method == 'GET') {
           await _handleGetCategoryChips(request);
+        } else if (method == 'POST') {
+          await _handleUpdateCategoryChip(request);
+        } else if (method == 'DELETE') {
+          await _handleDeleteCategoryChip(request);
         } else {
           _jsonResponse(request, HttpStatus.methodNotAllowed,
               {'error': 'Method not allowed'});
@@ -203,6 +208,129 @@ class SyncApiService {
       // Return all chips
       _jsonResponse(request, HttpStatus.ok, {'categoryChips': chips});
     }
+  }
+
+  /// POST /api/config/category-chips
+  ///
+  /// Adds or removes a chip preset for a category.
+  /// Body: {"action": "add"|"remove", "category": "Working", "chip": "standup"}
+  Future<void> _handleUpdateCategoryChip(HttpRequest request) async {
+    if (config == null) {
+      _jsonResponse(request, HttpStatus.serviceUnavailable,
+          {'error': 'Config not available'});
+      return;
+    }
+
+    final body = await utf8.decoder.bind(request).join();
+    final json = jsonDecode(body) as Map<String, dynamic>;
+
+    final action = json['action'] as String?;
+    final category = json['category'] as String?;
+    final chip = json['chip'] as String?;
+
+    if (action == null || category == null || chip == null) {
+      _jsonResponse(request, HttpStatus.badRequest,
+          {'error': 'Missing required fields: action, category, chip'});
+      return;
+    }
+
+    if (chip.isEmpty) {
+      _jsonResponse(request, HttpStatus.badRequest,
+          {'error': 'Chip text cannot be empty'});
+      return;
+    }
+
+    final newChips = Map<String, List<String>>.from(config!.categoryChips);
+    final categoryChips = List<String>.from(newChips[category] ?? []);
+
+    if (action == 'add') {
+      if (!categoryChips.contains(chip)) {
+        categoryChips.add(chip);
+        newChips[category] = categoryChips;
+        final newConfig = AvoConfig(
+          categories: config!.categories,
+          syncPort: config!.syncPort,
+          syncInterval: config!.syncInterval,
+          categoryChips: newChips,
+        );
+        await newConfig.save(AvodahPaths());
+        _jsonResponse(request, HttpStatus.ok, {
+          'success': true,
+          'action': 'added',
+          'category': category,
+          'chip': chip,
+        });
+      } else {
+        _jsonResponse(request, HttpStatus.ok, {
+          'success': true,
+          'action': 'already_exists',
+          'category': category,
+          'chip': chip,
+        });
+      }
+    } else if (action == 'remove') {
+      if (categoryChips.contains(chip)) {
+        categoryChips.remove(chip);
+        newChips[category] = categoryChips;
+        final newConfig = AvoConfig(
+          categories: config!.categories,
+          syncPort: config!.syncPort,
+          syncInterval: config!.syncInterval,
+          categoryChips: newChips,
+        );
+        await newConfig.save(AvodahPaths());
+      }
+      _jsonResponse(request, HttpStatus.ok, {
+        'success': true,
+        'action': 'removed',
+        'category': category,
+        'chip': chip,
+      });
+    } else {
+      _jsonResponse(request, HttpStatus.badRequest,
+          {'error': 'Invalid action. Use "add" or "remove"'});
+    }
+  }
+
+  /// DELETE /api/config/category-chips?category=Working&chip=standup
+  ///
+  /// Removes a chip preset from a category.
+  Future<void> _handleDeleteCategoryChip(HttpRequest request) async {
+    if (config == null) {
+      _jsonResponse(request, HttpStatus.serviceUnavailable,
+          {'error': 'Config not available'});
+      return;
+    }
+
+    final category = request.uri.queryParameters['category'];
+    final chip = request.uri.queryParameters['chip'];
+
+    if (category == null || chip == null) {
+      _jsonResponse(request, HttpStatus.badRequest,
+          {'error': 'Missing required query parameters: category, chip'});
+      return;
+    }
+
+    final newChips = Map<String, List<String>>.from(config!.categoryChips);
+    final categoryChips = List<String>.from(newChips[category] ?? []);
+
+    if (categoryChips.contains(chip)) {
+      categoryChips.remove(chip);
+      newChips[category] = categoryChips;
+      final newConfig = AvoConfig(
+        categories: config!.categories,
+        syncPort: config!.syncPort,
+        syncInterval: config!.syncInterval,
+        categoryChips: newChips,
+      );
+      await newConfig.save(AvodahPaths());
+    }
+
+    _jsonResponse(request, HttpStatus.ok, {
+      'success': true,
+      'category': category,
+      'chip': chip,
+    });
   }
 
   /// Merges a batch of incoming CRDT deltas from [remoteNode] into the local DB.

--- a/mcp/lib/services/timer_service.dart
+++ b/mcp/lib/services/timer_service.dart
@@ -93,6 +93,7 @@ class TimerService {
     required String taskTitle,
     String? taskId,
     String? note,
+    String? category,
   }) async {
     final existing = await _loadActiveTimer();
     if (existing != null) {
@@ -106,6 +107,7 @@ class TimerService {
       taskTitle: taskTitle,
       taskId: resolvedTaskId,
       note: note,
+      category: category,
     );
 
     await _saveTimer(timer);
@@ -127,6 +129,7 @@ class TimerService {
     final startedAt = timer.startedAt!;
     final note = timer.note;
     final elapsed = timer.elapsed;
+    final category = timer.category;
 
     // Stop the timer (clears all fields)
     timer.stop();
@@ -140,6 +143,7 @@ class TimerService {
       start: startedAt,
       end: now,
       comment: comment ?? note,
+      category: category,
     );
 
     await _saveWorklog(worklog);

--- a/mcp/lib/services/worklog_service.dart
+++ b/mcp/lib/services/worklog_service.dart
@@ -113,7 +113,6 @@ class WorklogService {
     String? comment,
   }) async {
     final now = DateTime.now();
-    final durationMs = durationMinutes * 60 * 1000;
     final start = now.subtract(Duration(minutes: durationMinutes));
 
     final worklog = WorklogDocument.create(

--- a/mcp/lib/services/worklog_service.dart
+++ b/mcp/lib/services/worklog_service.dart
@@ -274,14 +274,21 @@ class WorklogService {
   }
 
   /// Returns all non-deleted orphan worklogs (where taskId is empty).
-  Future<List<WorklogDocument>> listOrphan() async {
+  /// If [limit] is provided, returns at most that many entries.
+  Future<List<WorklogDocument>> listOrphan({int? limit}) async {
     final rows = await db.select(db.worklogEntries).get();
 
-    return rows
+    var docs = rows
         .map((row) => WorklogDocument.fromDrift(worklog: row, clock: clock))
         .where((doc) => !doc.isDeleted && doc.taskId.isEmpty)
         .toList()
       ..sort((a, b) => b.startMs.compareTo(a.startMs));
+
+    if (limit != null) {
+      docs = docs.take(limit).toList();
+    }
+
+    return docs;
   }
 
   /// Returns all non-deleted worklogs for a given category.
@@ -366,9 +373,11 @@ class WorklogService {
     final taskSummaries = byTask.entries.map((entry) {
       final totalMs = entry.value.fold<int>(0, (sum, w) => sum + w.durationMs);
       // Use taskId as title — the caller can resolve to a task name
+      // Fallback to '(no task)' for orphan worklogs with empty taskId
+      final taskTitle = entry.key.isEmpty ? '(no task)' : entry.key;
       return TaskTimeSummary(
         taskId: entry.key,
-        taskTitle: entry.key,
+        taskTitle: taskTitle,
         total: Duration(milliseconds: totalMs),
       );
     }).toList()

--- a/mcp/lib/services/worklog_service.dart
+++ b/mcp/lib/services/worklog_service.dart
@@ -134,6 +134,7 @@ class WorklogService {
     required DateTime start,
     required Duration duration,
     String? comment,
+    String? category,
   }) async {
     final end = start.add(duration);
     final worklog = WorklogDocument.create(
@@ -142,6 +143,7 @@ class WorklogService {
       start: start.millisecondsSinceEpoch,
       end: end.millisecondsSinceEpoch,
       comment: comment,
+      category: category,
     );
     await _saveWorklog(worklog);
     return worklog;
@@ -272,7 +274,70 @@ class WorklogService {
       ..sort((a, b) => b.startMs.compareTo(a.startMs));
   }
 
+  /// Returns all non-deleted orphan worklogs (where taskId is empty).
+  Future<List<WorklogDocument>> listOrphan() async {
+    final rows = await db.select(db.worklogEntries).get();
+
+    return rows
+        .map((row) => WorklogDocument.fromDrift(worklog: row, clock: clock))
+        .where((doc) => !doc.isDeleted && doc.taskId.isEmpty)
+        .toList()
+      ..sort((a, b) => b.startMs.compareTo(a.startMs));
+  }
+
+  /// Returns all non-deleted worklogs for a given category.
+  Future<List<WorklogDocument>> listByCategory(String category) async {
+    final rows = await db.select(db.worklogEntries).get();
+
+    return rows
+        .map((row) => WorklogDocument.fromDrift(worklog: row, clock: clock))
+        .where((doc) => !doc.isDeleted && doc.category == category)
+        .toList()
+      ..sort((a, b) => b.startMs.compareTo(a.startMs));
+  }
+
+  /// Assigns an orphan worklog to a task.
+  ///
+  /// - Sets the worklog's taskId to the target task's ID
+  /// - Inherits the task's category if the worklog has no category
+  /// - Sets jiraDirty=true if the task has a Jira issue link
+  ///
+  /// Throws [WorklogNotFoundException] if no worklog matches.
+  /// Throws [AmbiguousWorklogIdException] if multiple worklogs match.
+  /// Throws [TaskNotFoundException] if no task matches.
+  /// Throws [AmbiguousTaskIdException] if multiple tasks match.
+  Future<WorklogDocument> assignToTask({
+    required String worklogIdOrPrefix,
+    required String taskIdOrPrefix,
+    required Future<TaskDocument> Function(String) getTask,
+  }) async {
+    final worklog = await show(worklogIdOrPrefix);
+
+    if (!worklog.isOrphan) {
+      throw WorklogNotAssignedException(
+          'Worklog ${worklog.id.substring(0, 8)} already has a task (${worklog.taskId.substring(0, 8)}). '
+          'Use edit to change its task instead.');
+    }
+
+    final task = await getTask(taskIdOrPrefix);
+
+    worklog.taskId = task.id;
+    // Inherit task's category if worklog has no category
+    if (worklog.category == null && task.category != null) {
+      worklog.category = task.category;
+    }
+    // Mark jiraDirty if task has Jira issue link
+    if (task.hasIssueLink) {
+      worklog.markJiraDirty();
+    }
+
+    worklog.updatedMs = DateTime.now().millisecondsSinceEpoch;
+    await _saveWorklog(worklog);
+    return worklog;
+  }
+
   /// Returns total logged time per task as a map of taskId → Duration.
+  /// Orphan worklogs are grouped under the empty-string key.
   Future<Map<String, Duration>> timeByTask() async {
     final rows = await db.select(db.worklogEntries).get();
     final result = <String, int>{};
@@ -343,4 +408,13 @@ class AmbiguousWorklogIdException implements Exception {
   String toString() =>
       'Multiple worklogs match "$prefix": ${matchingIds.map((id) => id.substring(0, 8)).join(', ')}. '
       'Use a longer prefix.';
+}
+
+/// Thrown when trying to assign a worklog that is not an orphan.
+class WorklogNotAssignedException implements Exception {
+  final String message;
+  WorklogNotAssignedException(this.message);
+
+  @override
+  String toString() => message;
 }

--- a/mcp/test/services/avo_config_chips_test.dart
+++ b/mcp/test/services/avo_config_chips_test.dart
@@ -1,0 +1,299 @@
+/// Tests for AvoConfig categoryChips and the /api/config/category-chips endpoint.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:avodah_core/avodah_core.dart';
+import 'package:avodah_mcp/config/avo_config.dart';
+import 'package:avodah_mcp/config/paths.dart';
+import 'package:avodah_mcp/services/sync_api_service.dart';
+import 'package:avodah_mcp/storage/database_opener.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AvoConfig categoryChips', () {
+    test('fromJson parses categoryChips correctly', () {
+      final json = {
+        'categories': ['Working', 'Learning'],
+        'sync': {'port': 9847, 'intervalSeconds': 30},
+        'categoryChips': {
+          'Working': ['standup', 'code review', 'debugging'],
+          'Learning': ['reading', 'course'],
+        },
+      };
+
+      final config = AvoConfig.fromJson(json);
+
+      expect(config.categories, equals(['Working', 'Learning']));
+      expect(config.syncPort, equals(9847));
+      expect(config.syncInterval, equals(30));
+      expect(config.categoryChips, hasLength(2));
+      expect(config.categoryChips['Working'], equals(['standup', 'code review', 'debugging']));
+      expect(config.categoryChips['Learning'], equals(['reading', 'course']));
+    });
+
+    test('toJson serializes categoryChips correctly', () {
+      const config = AvoConfig(
+        categories: ['Working'],
+        syncPort: 9847,
+        syncInterval: 30,
+        categoryChips: {
+          'Working': ['standup', 'debugging'],
+        },
+      );
+
+      final json = config.toJson();
+
+      expect(json['categories'], equals(['Working']));
+      expect(json['sync'], equals({'port': 9847, 'intervalSeconds': 30}));
+      expect(json['categoryChips'], equals({'Working': ['standup', 'debugging']}));
+    });
+
+    test('load/save round-trip preserves categoryChips', () async {
+      // Create a temp directory for the config
+      final tmp = await Directory.systemTemp.createTemp('avo_config_test_');
+      final paths = AvodahPaths(configDir: tmp.path);
+
+      final originalConfig = AvoConfig(
+        categories: ['Working', 'Learning'],
+        syncPort: 9848,
+        syncInterval: 60,
+        categoryChips: {
+          'Working': ['standup', 'code review', 'debugging'],
+          'Learning': ['reading', 'course', 'practice'],
+        },
+      );
+
+      // Save the config
+      await originalConfig.save(paths);
+
+      // Load the config
+      final loadedConfig = await AvoConfig.load(paths);
+
+      expect(loadedConfig.categories, equals(['Working', 'Learning']));
+      expect(loadedConfig.syncPort, equals(9848));
+      expect(loadedConfig.syncInterval, equals(60));
+      expect(loadedConfig.categoryChips, equals({
+        'Working': ['standup', 'code review', 'debugging'],
+        'Learning': ['reading', 'course', 'practice'],
+      }));
+
+      // Cleanup
+      await tmp.delete(recursive: true);
+    });
+
+    test('load returns default config when file does not exist', () async {
+      final tmp = await Directory.systemTemp.createTemp('avo_config_test_');
+      final paths = AvodahPaths(configDir: tmp.path);
+
+      final config = await AvoConfig.load(paths);
+
+      expect(config.categories, isEmpty);
+      expect(config.categoryChips, isEmpty);
+      expect(config.effectiveCategories, equals(AvoConfig.defaultCategories));
+
+      // Cleanup
+      await tmp.delete(recursive: true);
+    });
+
+    test('load handles malformed JSON gracefully', () async {
+      final tmp = await Directory.systemTemp.createTemp('avo_config_test_');
+      final paths = AvodahPaths(configDir: tmp.path);
+
+      // Write malformed JSON
+      final configFile = File('${tmp.path}/config.json');
+      await configFile.writeAsString('not valid json {{{');
+
+      final config = await AvoConfig.load(paths);
+
+      // Should return default config
+      expect(config.categories, isEmpty);
+      expect(config.categoryChips, isEmpty);
+
+      // Cleanup
+      await tmp.delete(recursive: true);
+    });
+  });
+
+  group('SyncApiService /api/config/category-chips', () {
+    late AppDatabase db;
+    late HybridLogicalClock clock;
+    late SyncApiService syncApi;
+
+    setUp(() {
+      db = openMemoryDatabase();
+      clock = HybridLogicalClock(nodeId: 'desktop-1');
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('GET /api/config/category-chips returns all chips when no category specified', () async {
+      final config = AvoConfig(
+        categoryChips: {
+          'Working': ['standup', 'code review'],
+          'Learning': ['reading'],
+        },
+      );
+      syncApi = SyncApiService(db: db, clock: clock, config: config);
+
+      final server = await HttpServer.bind('127.0.0.1', 0);
+      server.listen((req) async {
+        final handled = await syncApi.handleRequest(req);
+        if (!handled) {
+          req.response
+            ..statusCode = HttpStatus.notFound
+            ..write('Not found')
+            ..close();
+        }
+      });
+
+      final port = server.port;
+      final client = HttpClient();
+      final req = await client.get('127.0.0.1', port, '/api/config/category-chips');
+      final resp = await req.close();
+
+      expect(resp.statusCode, equals(HttpStatus.ok));
+
+      final body = await resp.transform(utf8.decoder).join();
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      expect(json['categoryChips'], hasLength(2));
+      expect(json['categoryChips']['Working'], equals(['standup', 'code review']));
+      expect(json['categoryChips']['Learning'], equals(['reading']));
+
+      client.close();
+      await server.close();
+    });
+
+    test('GET /api/config/category-chips?category=Working returns chips for specific category', () async {
+      final config = AvoConfig(
+        categoryChips: {
+          'Working': ['standup', 'code review', 'debugging'],
+          'Learning': ['reading'],
+        },
+      );
+      syncApi = SyncApiService(db: db, clock: clock, config: config);
+
+      final server = await HttpServer.bind('127.0.0.1', 0);
+      server.listen((req) async {
+        final handled = await syncApi.handleRequest(req);
+        if (!handled) {
+          req.response
+            ..statusCode = HttpStatus.notFound
+            ..write('Not found')
+            ..close();
+        }
+      });
+
+      final port = server.port;
+      final client = HttpClient();
+      final req = await client.get('127.0.0.1', port, '/api/config/category-chips?category=Working');
+      final resp = await req.close();
+
+      expect(resp.statusCode, equals(HttpStatus.ok));
+
+      final body = await resp.transform(utf8.decoder).join();
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      expect(json['category'], equals('Working'));
+      expect(json['chips'], equals(['standup', 'code review', 'debugging']));
+
+      client.close();
+      await server.close();
+    });
+
+    test('GET /api/config/category-chips?category=Unknown returns empty chips', () async {
+      final config = AvoConfig(
+        categoryChips: {
+          'Working': ['standup'],
+        },
+      );
+      syncApi = SyncApiService(db: db, clock: clock, config: config);
+
+      final server = await HttpServer.bind('127.0.0.1', 0);
+      server.listen((req) async {
+        final handled = await syncApi.handleRequest(req);
+        if (!handled) {
+          req.response
+            ..statusCode = HttpStatus.notFound
+            ..write('Not found')
+            ..close();
+        }
+      });
+
+      final port = server.port;
+      final client = HttpClient();
+      final req = await client.get('127.0.0.1', port, '/api/config/category-chips?category=Unknown');
+      final resp = await req.close();
+
+      expect(resp.statusCode, equals(HttpStatus.ok));
+
+      final body = await resp.transform(utf8.decoder).join();
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      expect(json['category'], equals('Unknown'));
+      expect(json['chips'], isEmpty);
+
+      client.close();
+      await server.close();
+    });
+
+    test('GET /api/config/category-chips returns empty when no config', () async {
+      syncApi = SyncApiService(db: db, clock: clock, config: null);
+
+      final server = await HttpServer.bind('127.0.0.1', 0);
+      server.listen((req) async {
+        final handled = await syncApi.handleRequest(req);
+        if (!handled) {
+          req.response
+            ..statusCode = HttpStatus.notFound
+            ..write('Not found')
+            ..close();
+        }
+      });
+
+      final port = server.port;
+      final client = HttpClient();
+      final req = await client.get('127.0.0.1', port, '/api/config/category-chips');
+      final resp = await req.close();
+
+      expect(resp.statusCode, equals(HttpStatus.ok));
+
+      final body = await resp.transform(utf8.decoder).join();
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      expect(json['categoryChips'], isEmpty);
+
+      client.close();
+      await server.close();
+    });
+
+    test('POST /api/config/category-chips returns method not allowed', () async {
+      syncApi = SyncApiService(db: db, clock: clock);
+
+      final server = await HttpServer.bind('127.0.0.1', 0);
+      server.listen((req) async {
+        final handled = await syncApi.handleRequest(req);
+        if (!handled) {
+          req.response
+            ..statusCode = HttpStatus.notFound
+            ..write('Not found')
+            ..close();
+        }
+      });
+
+      final port = server.port;
+      final client = HttpClient();
+      final req = await client.post('127.0.0.1', port, '/api/config/category-chips');
+      final resp = await req.close();
+
+      expect(resp.statusCode, equals(HttpStatus.methodNotAllowed));
+
+      client.close();
+      await server.close();
+    });
+  });
+}

--- a/mcp/test/services/avo_config_chips_test.dart
+++ b/mcp/test/services/avo_config_chips_test.dart
@@ -295,5 +295,263 @@ void main() {
       client.close();
       await server.close();
     });
+
+    test('POST /api/config/category-chips add success', () async {
+      final config = AvoConfig(
+        categoryChips: {
+          'Working': ['standup'],
+        },
+      );
+      syncApi = SyncApiService(db: db, clock: clock, config: config);
+
+      final server = await HttpServer.bind('127.0.0.1', 0);
+      server.listen((req) async {
+        final handled = await syncApi.handleRequest(req);
+        if (!handled) {
+          req.response
+            ..statusCode = HttpStatus.notFound
+            ..write('Not found')
+            ..close();
+        }
+      });
+
+      final port = server.port;
+      final client = HttpClient();
+      final req = await client.post('127.0.0.1', port, '/api/config/category-chips');
+      req.write(jsonEncode({
+        'action': 'add',
+        'category': 'Working',
+        'chip': 'code review',
+      }));
+      final resp = await req.close();
+
+      expect(resp.statusCode, equals(HttpStatus.ok));
+
+      final body = await resp.transform(utf8.decoder).join();
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      expect(json['success'], isTrue);
+      expect(json['action'], equals('added'));
+      expect(json['category'], equals('Working'));
+      expect(json['chip'], equals('code review'));
+
+      client.close();
+      await server.close();
+    });
+
+    test('POST /api/config/category-chips remove success', () async {
+      final config = AvoConfig(
+        categoryChips: {
+          'Working': ['standup', 'debugging'],
+        },
+      );
+      syncApi = SyncApiService(db: db, clock: clock, config: config);
+
+      final server = await HttpServer.bind('127.0.0.1', 0);
+      server.listen((req) async {
+        final handled = await syncApi.handleRequest(req);
+        if (!handled) {
+          req.response
+            ..statusCode = HttpStatus.notFound
+            ..write('Not found')
+            ..close();
+        }
+      });
+
+      final port = server.port;
+      final client = HttpClient();
+      final req = await client.post('127.0.0.1', port, '/api/config/category-chips');
+      req.write(jsonEncode({
+        'action': 'remove',
+        'category': 'Working',
+        'chip': 'standup',
+      }));
+      final resp = await req.close();
+
+      expect(resp.statusCode, equals(HttpStatus.ok));
+
+      final body = await resp.transform(utf8.decoder).join();
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      expect(json['success'], isTrue);
+      expect(json['action'], equals('removed'));
+      expect(json['category'], equals('Working'));
+      expect(json['chip'], equals('standup'));
+
+      client.close();
+      await server.close();
+    });
+
+    test('POST /api/config/category-chips missing action field returns 400', () async {
+      syncApi = SyncApiService(db: db, clock: clock, config: AvoConfig());
+
+      final server = await HttpServer.bind('127.0.0.1', 0);
+      server.listen((req) async {
+        final handled = await syncApi.handleRequest(req);
+        if (!handled) {
+          req.response
+            ..statusCode = HttpStatus.notFound
+            ..write('Not found')
+            ..close();
+        }
+      });
+
+      final port = server.port;
+      final client = HttpClient();
+      final req = await client.post('127.0.0.1', port, '/api/config/category-chips');
+      req.write(jsonEncode({
+        'category': 'Working',
+        'chip': 'standup',
+      }));
+      final resp = await req.close();
+
+      expect(resp.statusCode, equals(HttpStatus.badRequest));
+
+      final body = await resp.transform(utf8.decoder).join();
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      expect(json['error'], contains('Missing required fields'));
+
+      client.close();
+      await server.close();
+    });
+
+    test('POST /api/config/category-chips empty chip returns 400', () async {
+      syncApi = SyncApiService(db: db, clock: clock, config: AvoConfig());
+
+      final server = await HttpServer.bind('127.0.0.1', 0);
+      server.listen((req) async {
+        final handled = await syncApi.handleRequest(req);
+        if (!handled) {
+          req.response
+            ..statusCode = HttpStatus.notFound
+            ..write('Not found')
+            ..close();
+        }
+      });
+
+      final port = server.port;
+      final client = HttpClient();
+      final req = await client.post('127.0.0.1', port, '/api/config/category-chips');
+      req.write(jsonEncode({
+        'action': 'add',
+        'category': 'Working',
+        'chip': '',
+      }));
+      final resp = await req.close();
+
+      expect(resp.statusCode, equals(HttpStatus.badRequest));
+
+      final body = await resp.transform(utf8.decoder).join();
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      expect(json['error'], contains('cannot be empty'));
+
+      client.close();
+      await server.close();
+    });
+
+    test('POST /api/config/category-chips invalid action returns 400', () async {
+      syncApi = SyncApiService(db: db, clock: clock, config: AvoConfig());
+
+      final server = await HttpServer.bind('127.0.0.1', 0);
+      server.listen((req) async {
+        final handled = await syncApi.handleRequest(req);
+        if (!handled) {
+          req.response
+            ..statusCode = HttpStatus.notFound
+            ..write('Not found')
+            ..close();
+        }
+      });
+
+      final port = server.port;
+      final client = HttpClient();
+      final req = await client.post('127.0.0.1', port, '/api/config/category-chips');
+      req.write(jsonEncode({
+        'action': 'invalid_action',
+        'category': 'Working',
+        'chip': 'standup',
+      }));
+      final resp = await req.close();
+
+      expect(resp.statusCode, equals(HttpStatus.badRequest));
+
+      final body = await resp.transform(utf8.decoder).join();
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      expect(json['error'], contains('Invalid action'));
+
+      client.close();
+      await server.close();
+    });
+
+    test('DELETE /api/config/category-chips success', () async {
+      final config = AvoConfig(
+        categoryChips: {
+          'Working': ['standup', 'debugging'],
+        },
+      );
+      syncApi = SyncApiService(db: db, clock: clock, config: config);
+
+      final server = await HttpServer.bind('127.0.0.1', 0);
+      server.listen((req) async {
+        final handled = await syncApi.handleRequest(req);
+        if (!handled) {
+          req.response
+            ..statusCode = HttpStatus.notFound
+            ..write('Not found')
+            ..close();
+        }
+      });
+
+      final port = server.port;
+      final client = HttpClient();
+      final req = await client.delete('127.0.0.1', port, '/api/config/category-chips?category=Working&chip=standup');
+      final resp = await req.close();
+
+      expect(resp.statusCode, equals(HttpStatus.ok));
+
+      final body = await resp.transform(utf8.decoder).join();
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      expect(json['success'], isTrue);
+      expect(json['category'], equals('Working'));
+      expect(json['chip'], equals('standup'));
+
+      client.close();
+      await server.close();
+    });
+
+    test('DELETE /api/config/category-chips missing params returns 400', () async {
+      syncApi = SyncApiService(db: db, clock: clock, config: AvoConfig());
+
+      final server = await HttpServer.bind('127.0.0.1', 0);
+      server.listen((req) async {
+        final handled = await syncApi.handleRequest(req);
+        if (!handled) {
+          req.response
+            ..statusCode = HttpStatus.notFound
+            ..write('Not found')
+            ..close();
+        }
+      });
+
+      final port = server.port;
+      final client = HttpClient();
+      // Missing chip parameter
+      final req = await client.delete('127.0.0.1', port, '/api/config/category-chips?category=Working');
+      final resp = await req.close();
+
+      expect(resp.statusCode, equals(HttpStatus.badRequest));
+
+      final body = await resp.transform(utf8.decoder).join();
+      final json = jsonDecode(body) as Map<String, dynamic>;
+
+      expect(json['error'], contains('Missing required query parameters'));
+
+      client.close();
+      await server.close();
+    });
   });
 }

--- a/mcp/test/services/avo_config_chips_test.dart
+++ b/mcp/test/services/avo_config_chips_test.dart
@@ -271,7 +271,7 @@ void main() {
       await server.close();
     });
 
-    test('POST /api/config/category-chips returns method not allowed', () async {
+    test('POST /api/config/category-chips returns service unavailable when no config', () async {
       syncApi = SyncApiService(db: db, clock: clock);
 
       final server = await HttpServer.bind('127.0.0.1', 0);
@@ -290,7 +290,7 @@ void main() {
       final req = await client.post('127.0.0.1', port, '/api/config/category-chips');
       final resp = await req.close();
 
-      expect(resp.statusCode, equals(HttpStatus.methodNotAllowed));
+      expect(resp.statusCode, equals(HttpStatus.serviceUnavailable));
 
       client.close();
       await server.close();

--- a/mcp/test/services/timer_document_test.dart
+++ b/mcp/test/services/timer_document_test.dart
@@ -1,0 +1,94 @@
+import 'package:avodah_core/avodah_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TimerDocument', () {
+    late HybridLogicalClock clock;
+
+    setUp(() {
+      clock = HybridLogicalClock(nodeId: 'test-node');
+    });
+
+    group('category', () {
+      test('start() accepts optional category', () {
+        final timer = TimerDocument.start(
+          clock: clock,
+          taskTitle: 'Working',
+          category: 'Working',
+        );
+
+        expect(timer.category, equals('Working'));
+        expect(timer.taskTitle, equals('Working'));
+        expect(timer.isRunning, isTrue);
+      });
+
+      test('start() without category leaves it null', () {
+        final timer = TimerDocument.start(
+          clock: clock,
+          taskTitle: 'Some work',
+        );
+
+        expect(timer.category, isNull);
+      });
+
+      test('stop() clears category', () {
+        final timer = TimerDocument.start(
+          clock: clock,
+          taskTitle: 'Working',
+          category: 'Working',
+        );
+
+        expect(timer.category, equals('Working'));
+
+        timer.stop();
+
+        expect(timer.category, isNull);
+        expect(timer.isRunning, isFalse);
+      });
+
+      test('category can be set and changed', () {
+        final timer = TimerDocument.start(
+          clock: clock,
+          taskTitle: 'Some work',
+        );
+
+        expect(timer.category, isNull);
+
+        timer.category = 'Learning';
+
+        expect(timer.category, equals('Learning'));
+
+        timer.category = 'Meetings';
+
+        expect(timer.category, equals('Meetings'));
+      });
+    });
+
+    group('toModel', () {
+      test('toModel includes category', () {
+        final timer = TimerDocument.start(
+          clock: clock,
+          taskTitle: 'Working',
+          category: 'Working',
+        );
+
+        final model = timer.toModel();
+
+        expect(model.category, equals('Working'));
+        expect(model.taskTitle, equals('Working'));
+        expect(model.isRunning, isTrue);
+      });
+
+      test('toModel includes category as null when not set', () {
+        final timer = TimerDocument.start(
+          clock: clock,
+          taskTitle: 'Some work',
+        );
+
+        final model = timer.toModel();
+
+        expect(model.category, isNull);
+      });
+    });
+  });
+}

--- a/mcp/test/services/worklog_service_test.dart
+++ b/mcp/test/services/worklog_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:avodah_core/avodah_core.dart';
 import 'package:avodah_mcp/services/worklog_service.dart';
+import 'package:avodah_mcp/services/task_service.dart';
 import 'package:avodah_mcp/storage/database_opener.dart';
 import 'package:test/test.dart';
 
@@ -692,6 +693,327 @@ void main() {
 
       expect(info.count, equals(1));
       expect(info.total.inMinutes, equals(60));
+    });
+  });
+
+  group('listOrphan', () {
+    test('returns empty list when no worklogs', () async {
+      final orphans = await service.listOrphan();
+      expect(orphans, isEmpty);
+    });
+
+    test('returns only orphan worklogs', () async {
+      final now = DateTime.now();
+      // Orphan worklog (no task)
+      final orphan = WorklogDocument.create(
+        clock: clock,
+        taskId: '',
+        start: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+        category: 'Working',
+      );
+      // Regular worklog (with task)
+      final regular = WorklogDocument.create(
+        clock: clock,
+        taskId: 'task-1',
+        start: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+        end: now.millisecondsSinceEpoch,
+      );
+
+      await db.into(db.worklogEntries).insert(orphan.toDriftCompanion());
+      await db.into(db.worklogEntries).insert(regular.toDriftCompanion());
+
+      final orphans = await service.listOrphan();
+
+      expect(orphans, hasLength(1));
+      expect(orphans.first.isOrphan, isTrue);
+      expect(orphans.first.category, equals('Working'));
+    });
+
+    test('excludes deleted worklogs', () async {
+      final now = DateTime.now();
+      final orphan = WorklogDocument.create(
+        clock: clock,
+        taskId: '',
+        start: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+      );
+
+      await db.into(db.worklogEntries).insert(orphan.toDriftCompanion());
+      await service.deleteWorklog(orphan.id);
+
+      final orphans = await service.listOrphan();
+
+      expect(orphans, isEmpty);
+    });
+
+    test('returns most recent orphans first', () async {
+      final now = DateTime.now();
+      final orphan1 = WorklogDocument.create(
+        clock: clock,
+        taskId: '',
+        start: now.subtract(const Duration(hours: 3)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+      );
+      final orphan2 = WorklogDocument.create(
+        clock: clock,
+        taskId: '',
+        start: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+        end: now.millisecondsSinceEpoch,
+      );
+
+      await db.into(db.worklogEntries).insert(orphan1.toDriftCompanion());
+      await db.into(db.worklogEntries).insert(orphan2.toDriftCompanion());
+
+      final orphans = await service.listOrphan();
+
+      expect(orphans.first.id, equals(orphan2.id));
+    });
+  });
+
+  group('listByCategory', () {
+    test('returns empty list when no matching worklogs', () async {
+      final results = await service.listByCategory('Working');
+      expect(results, isEmpty);
+    });
+
+    test('filters worklogs by category', () async {
+      final now = DateTime.now();
+      final workingWl = WorklogDocument.create(
+        clock: clock,
+        taskId: 'task-1',
+        start: now.subtract(const Duration(hours: 3)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+        category: 'Working',
+      );
+      final learningWl = WorklogDocument.create(
+        clock: clock,
+        taskId: 'task-2',
+        start: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+        category: 'Learning',
+      );
+      final noCatWl = WorklogDocument.create(
+        clock: clock,
+        taskId: 'task-3',
+        start: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+        end: now.millisecondsSinceEpoch,
+      );
+
+      await db.into(db.worklogEntries).insert(workingWl.toDriftCompanion());
+      await db.into(db.worklogEntries).insert(learningWl.toDriftCompanion());
+      await db.into(db.worklogEntries).insert(noCatWl.toDriftCompanion());
+
+      final working = await service.listByCategory('Working');
+      final learning = await service.listByCategory('Learning');
+
+      expect(working, hasLength(1));
+      expect(working.first.category, equals('Working'));
+      expect(learning, hasLength(1));
+      expect(learning.first.category, equals('Learning'));
+    });
+
+    test('excludes deleted worklogs', () async {
+      final now = DateTime.now();
+      final worklog = WorklogDocument.create(
+        clock: clock,
+        taskId: 'task-1',
+        start: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+        category: 'Working',
+      );
+
+      await db.into(db.worklogEntries).insert(worklog.toDriftCompanion());
+      await service.deleteWorklog(worklog.id);
+
+      final results = await service.listByCategory('Working');
+
+      expect(results, isEmpty);
+    });
+  });
+
+  group('createWorklog with category', () {
+    test('creates worklog with category', () async {
+      final start = DateTime(2026, 2, 15, 9, 0);
+      final worklog = await service.createWorklog(
+        taskId: '',
+        start: start,
+        duration: const Duration(hours: 1),
+        category: 'Working',
+      );
+
+      expect(worklog.taskId, isEmpty);
+      expect(worklog.isOrphan, isTrue);
+      expect(worklog.category, equals('Working'));
+    });
+
+    test('persists category to database', () async {
+      final start = DateTime(2026, 2, 15, 9, 0);
+      await service.createWorklog(
+        taskId: '',
+        start: start,
+        duration: const Duration(hours: 1),
+        category: 'Learning',
+      );
+
+      final recent = await service.listRecent();
+      expect(recent.first.category, equals('Learning'));
+    });
+  });
+
+  group('assignToTask', () {
+    late TaskService taskService;
+
+    setUp(() {
+      taskService = TaskService(db: db, clock: clock);
+    });
+
+    test('assigns orphan worklog to task', () async {
+      final now = DateTime.now();
+      final orphan = WorklogDocument.create(
+        clock: clock,
+        taskId: '',
+        start: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+        category: 'Working',
+      );
+      await db.into(db.worklogEntries).insert(orphan.toDriftCompanion());
+
+      final task = await taskService.add(
+        title: 'Test Task',
+        category: 'Development',
+      );
+
+      final updated = await service.assignToTask(
+        worklogIdOrPrefix: orphan.id,
+        taskIdOrPrefix: task.id,
+        getTask: taskService.show,
+      );
+
+      expect(updated.taskId, equals(task.id));
+      expect(updated.isOrphan, isFalse);
+    });
+
+    test('inherits task category when worklog has no category', () async {
+      final now = DateTime.now();
+      final orphan = WorklogDocument.create(
+        clock: clock,
+        taskId: '',
+        start: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+      );
+      await db.into(db.worklogEntries).insert(orphan.toDriftCompanion());
+
+      final task = await taskService.add(
+        title: 'Test Task',
+        category: 'Development',
+      );
+
+      final updated = await service.assignToTask(
+        worklogIdOrPrefix: orphan.id,
+        taskIdOrPrefix: task.id,
+        getTask: taskService.show,
+      );
+
+      expect(updated.category, equals('Development'));
+    });
+
+    test('preserves worklog category when already set', () async {
+      final now = DateTime.now();
+      final orphan = WorklogDocument.create(
+        clock: clock,
+        taskId: '',
+        start: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+        category: 'Working',
+      );
+      await db.into(db.worklogEntries).insert(orphan.toDriftCompanion());
+
+      final task = await taskService.add(
+        title: 'Test Task',
+        category: 'Development',
+      );
+
+      final updated = await service.assignToTask(
+        worklogIdOrPrefix: orphan.id,
+        taskIdOrPrefix: task.id,
+        getTask: taskService.show,
+      );
+
+      // Worklog category should be preserved
+      expect(updated.category, equals('Working'));
+    });
+
+    test('marks jiraDirty when task has Jira issue link', () async {
+      final now = DateTime.now();
+      final orphan = WorklogDocument.create(
+        clock: clock,
+        taskId: '',
+        start: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+      );
+      await db.into(db.worklogEntries).insert(orphan.toDriftCompanion());
+
+      final task = await taskService.add(
+        title: 'Jira Task',
+        category: 'Development',
+      );
+      // Simulate Jira link
+      task.issueId = 'PROJ-123';
+      task.issueProviderId = 'jira';
+      await db.into(db.tasks).insertOnConflictUpdate(task.toDriftCompanion());
+
+      final updated = await service.assignToTask(
+        worklogIdOrPrefix: orphan.id,
+        taskIdOrPrefix: task.id,
+        getTask: taskService.show,
+      );
+
+      expect(updated.jiraDirty, isTrue);
+    });
+
+    test('throws WorklogNotAssignedException when worklog already has task',
+        () async {
+      final now = DateTime.now();
+      final worklog = WorklogDocument.create(
+        clock: clock,
+        taskId: 'existing-task',
+        start: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+      );
+      await db.into(db.worklogEntries).insert(worklog.toDriftCompanion());
+
+      final task = await taskService.add(title: 'New Task');
+
+      expect(
+        () => service.assignToTask(
+          worklogIdOrPrefix: worklog.id,
+          taskIdOrPrefix: task.id,
+          getTask: taskService.show,
+        ),
+        throwsA(isA<WorklogNotAssignedException>()),
+      );
+    });
+
+    test('finds worklog by prefix', () async {
+      final now = DateTime.now();
+      final orphan = WorklogDocument.create(
+        clock: clock,
+        taskId: '',
+        start: now.subtract(const Duration(hours: 2)).millisecondsSinceEpoch,
+        end: now.subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+      );
+      await db.into(db.worklogEntries).insert(orphan.toDriftCompanion());
+
+      final task = await taskService.add(title: 'Test Task');
+
+      final updated = await service.assignToTask(
+        worklogIdOrPrefix: orphan.id.substring(0, 8),
+        taskIdOrPrefix: task.id,
+        getTask: taskService.show,
+      );
+
+      expect(updated.taskId, equals(task.id));
     });
   });
 }

--- a/packages/avodah_core/lib/documents/timer_document.dart
+++ b/packages/avodah_core/lib/documents/timer_document.dart
@@ -25,6 +25,7 @@ class TimerFields {
   static const String pausedAt = 'pausedAt';
   static const String accumulatedMs = 'accumulatedMs';
   static const String note = 'note';
+  static const String category = 'category';
 }
 
 /// A CRDT-backed timer document.
@@ -50,6 +51,7 @@ class TimerDocument extends CrdtDocument<TimerDocument> {
     String? projectId,
     String? projectTitle,
     String? note,
+    String? category,
   }) {
     final doc = TimerDocument(
       id: activeTimerId,
@@ -60,6 +62,7 @@ class TimerDocument extends CrdtDocument<TimerDocument> {
     doc.projectId = projectId;
     doc.projectTitle = projectTitle;
     doc.note = note;
+    doc.category = category;
     doc.startedAtMs = DateTime.now().millisecondsSinceEpoch;
     doc.isRunning = true;
     doc.pausedAtMs = null;
@@ -112,6 +115,7 @@ class TimerDocument extends CrdtDocument<TimerDocument> {
     setInt(TimerFields.pausedAt, timer.pausedAt);
     setInt(TimerFields.accumulatedMs, timer.accumulatedMs);
     setString(TimerFields.note, timer.note);
+    setString(TimerFields.category, timer.category);
   }
 
   // ============================================================
@@ -138,6 +142,10 @@ class TimerDocument extends CrdtDocument<TimerDocument> {
   /// Optional note about current work.
   String? get note => getString(TimerFields.note);
   set note(String? value) => setString(TimerFields.note, value);
+
+  /// Category for orphan timers (no task required).
+  String? get category => getString(TimerFields.category);
+  set category(String? value) => setString(TimerFields.category, value);
 
   // ============================================================
   // Timer State
@@ -251,6 +259,7 @@ class TimerDocument extends CrdtDocument<TimerDocument> {
     projectId = null;
     projectTitle = null;
     note = null;
+    category = null;
 
     return totalMs;
   }
@@ -277,6 +286,7 @@ class TimerDocument extends CrdtDocument<TimerDocument> {
       pausedAt: Value(pausedAtMs),
       accumulatedMs: Value(accumulatedMs),
       note: Value(note),
+      category: Value(category),
       crdtClock: Value(clock.lastTimestamp.pack()),
       crdtState: Value(toCrdtState()),
     );
@@ -296,6 +306,7 @@ class TimerDocument extends CrdtDocument<TimerDocument> {
       elapsed: elapsed,
       elapsedFormatted: elapsedFormatted,
       note: note,
+      category: category,
     );
   }
 
@@ -321,6 +332,7 @@ class TimerModel {
   final Duration elapsed;
   final String elapsedFormatted;
   final String? note;
+  final String? category;
 
   const TimerModel({
     required this.isRunning,
@@ -334,6 +346,7 @@ class TimerModel {
     required this.elapsed,
     required this.elapsedFormatted,
     this.note,
+    this.category,
   });
 
   @override

--- a/packages/avodah_core/lib/documents/timer_document.dart
+++ b/packages/avodah_core/lib/documents/timer_document.dart
@@ -99,9 +99,23 @@ class TimerDocument extends CrdtDocument<TimerDocument> {
     // If no CRDT state exists, initialize from Drift fields
     if (state.isEmpty) {
       doc._initializeFromDrift(timer);
+    } else {
+      // Backfill fields added in later schema versions (e.g. category in v12)
+      doc._backfillFromDrift(timer);
     }
 
     return doc;
+  }
+
+  /// Backfills fields from Drift columns when they are missing from CRDT
+  /// state. This handles fields added in later schema versions (e.g.
+  /// category in v12) for timers whose CRDT state was written before
+  /// those fields existed.
+  void _backfillFromDrift(TimerEntry timer) {
+    final keys = fieldKeys.toSet();
+    if (!keys.contains(TimerFields.category) && timer.category != null) {
+      setString(TimerFields.category, timer.category);
+    }
   }
 
   /// Initializes fields from Drift entity when no CRDT state exists.

--- a/packages/avodah_core/lib/documents/worklog_document.dart
+++ b/packages/avodah_core/lib/documents/worklog_document.dart
@@ -21,6 +21,7 @@ class WorklogFields {
   static const String duration = 'duration';
   static const String date = 'date';
   static const String comment = 'comment';
+  static const String category = 'category';
   static const String jiraWorklogId = 'jiraWorklogId';
   static const String jiraDirty = 'jiraDirty';
   static const String created = 'created';
@@ -35,23 +36,26 @@ class WorklogDocument extends CrdtDocument<WorklogDocument> {
   /// Creates a new worklog document with a generated UUID.
   ///
   /// [start] and [end] are Unix milliseconds.
+  /// [taskId] is optional — defaults to empty string for orphan worklogs.
   factory WorklogDocument.create({
     required HybridLogicalClock clock,
-    required String taskId,
+    String? taskId,
     required int start,
     required int end,
     String? comment,
+    String? category,
   }) {
     final doc = WorklogDocument(
       id: const Uuid().v4(),
       clock: clock,
     );
-    doc.taskId = taskId;
+    doc.taskId = taskId ?? '';
     doc.startMs = start;
     doc.endMs = end;
     doc.durationMs = end - start;
     doc.date = _dateFromMs(start);
     doc.comment = comment;
+    doc.category = category;
     final now = DateTime.now().millisecondsSinceEpoch;
     doc.createdMs = now;
     doc.updatedMs = now;
@@ -61,10 +65,11 @@ class WorklogDocument extends CrdtDocument<WorklogDocument> {
   /// Creates a worklog from a timer session.
   factory WorklogDocument.fromTimer({
     required HybridLogicalClock clock,
-    required String taskId,
+    String? taskId,
     required DateTime start,
     required DateTime end,
     String? comment,
+    String? category,
   }) {
     return WorklogDocument.create(
       clock: clock,
@@ -72,6 +77,7 @@ class WorklogDocument extends CrdtDocument<WorklogDocument> {
       start: start.millisecondsSinceEpoch,
       end: end.millisecondsSinceEpoch,
       comment: comment,
+      category: category,
     );
   }
 
@@ -120,17 +126,21 @@ class WorklogDocument extends CrdtDocument<WorklogDocument> {
     setInt(WorklogFields.duration, worklog.duration);
     setString(WorklogFields.date, worklog.date);
     setString(WorklogFields.comment, worklog.comment);
+    setString(WorklogFields.category, worklog.category);
     setString(WorklogFields.jiraWorklogId, worklog.jiraWorklogId);
     setBool(WorklogFields.jiraDirty, worklog.jiraDirty);
     setInt(WorklogFields.created, worklog.created);
     setInt(WorklogFields.updated, worklog.updated);
   }
 
-  /// Backfills fields added in later schema versions (e.g. jiraDirty in v10).
+  /// Backfills fields added in later schema versions (e.g. jiraDirty in v10, category in v12).
   void _backfillFromDrift(WorklogEntry worklog) {
     final keys = fieldKeys.toSet();
     if (!keys.contains(WorklogFields.jiraDirty) && worklog.jiraDirty) {
       setBool(WorklogFields.jiraDirty, worklog.jiraDirty);
+    }
+    if (!keys.contains(WorklogFields.category) && worklog.category != null) {
+      setString(WorklogFields.category, worklog.category);
     }
   }
 
@@ -166,6 +176,13 @@ class WorklogDocument extends CrdtDocument<WorklogDocument> {
   /// Optional comment/note.
   String? get comment => getString(WorklogFields.comment);
   set comment(String? value) => setString(WorklogFields.comment, value);
+
+  /// Category for orphan worklogs (no task required).
+  String? get category => getString(WorklogFields.category);
+  set category(String? value) => setString(WorklogFields.category, value);
+
+  /// Whether this worklog is an orphan (no task assigned).
+  bool get isOrphan => taskId.isEmpty;
 
   /// Created timestamp (Unix ms).
   int get createdMs => getInt(WorklogFields.created) ?? 0;
@@ -266,6 +283,7 @@ class WorklogDocument extends CrdtDocument<WorklogDocument> {
       duration: Value(durationMs),
       date: Value(date),
       comment: Value(comment),
+      category: Value(category),
       jiraWorklogId: Value(jiraWorklogId),
       jiraDirty: Value(jiraDirty),
       created: Value(createdMs),
@@ -285,6 +303,7 @@ class WorklogDocument extends CrdtDocument<WorklogDocument> {
       duration: duration,
       date: date,
       comment: comment,
+      category: category,
       isSyncedToJira: isSyncedToJira,
       jiraDirty: jiraDirty,
       isDeleted: isDeleted,
@@ -309,9 +328,13 @@ class WorklogModel {
   final Duration duration;
   final String date;
   final String? comment;
+  final String? category;
   final bool isSyncedToJira;
   final bool jiraDirty;
   final bool isDeleted;
+
+  /// Whether this worklog is an orphan (no task assigned).
+  bool get isOrphan => taskId.isEmpty;
 
   const WorklogModel({
     required this.id,
@@ -321,6 +344,7 @@ class WorklogModel {
     required this.duration,
     required this.date,
     this.comment,
+    this.category,
     required this.isSyncedToJira,
     this.jiraDirty = false,
     required this.isDeleted,

--- a/packages/avodah_core/lib/storage/database.dart
+++ b/packages/avodah_core/lib/storage/database.dart
@@ -42,7 +42,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.executor(QueryExecutor executor) : super(executor);
 
   @override
-  int get schemaVersion => 11;
+  int get schemaVersion => 12;
 
   @override
   MigrationStrategy get migration {
@@ -104,6 +104,15 @@ class AppDatabase extends _$AppDatabase {
         if (from < 11) {
           // Add sync watermarks table for per-node HLC delta sync tracking
           await m.createTable(syncWatermarks);
+        }
+        if (from < 12) {
+          // v0.5.0: orphan worklogs — add category column to worklogEntries
+          // Guard: column may already exist if previous migration partially completed
+          try {
+            await m.addColumn(worklogEntries, worklogEntries.category);
+          } on Exception catch (_) {
+            // Column already exists
+          }
         }
       },
     );

--- a/packages/avodah_core/lib/storage/database.dart
+++ b/packages/avodah_core/lib/storage/database.dart
@@ -106,10 +106,15 @@ class AppDatabase extends _$AppDatabase {
           await m.createTable(syncWatermarks);
         }
         if (from < 12) {
-          // v0.5.0: orphan worklogs — add category column to worklogEntries
+          // v0.5.0: orphan worklogs — add category column to worklogEntries and timerEntries
           // Guard: column may already exist if previous migration partially completed
           try {
             await m.addColumn(worklogEntries, worklogEntries.category);
+          } on Exception catch (_) {
+            // Column already exists
+          }
+          try {
+            await m.addColumn(timerEntries, timerEntries.category);
           } on Exception catch (_) {
             // Column already exists
           }

--- a/packages/avodah_core/lib/storage/database.dart
+++ b/packages/avodah_core/lib/storage/database.dart
@@ -106,7 +106,7 @@ class AppDatabase extends _$AppDatabase {
           await m.createTable(syncWatermarks);
         }
         if (from < 12) {
-          // v0.5.0: orphan worklogs — add category column to worklogEntries and timerEntries
+          // v12: orphan worklogs — add category column to worklogEntries and timerEntries
           // Guard: column may already exist if previous migration partially completed
           try {
             await m.addColumn(worklogEntries, worklogEntries.category);

--- a/packages/avodah_core/lib/storage/database.g.dart
+++ b/packages/avodah_core/lib/storage/database.g.dart
@@ -3661,6 +3661,17 @@ class $WorklogEntriesTable extends WorklogEntries
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _categoryMeta = const VerificationMeta(
+    'category',
+  );
+  @override
+  late final GeneratedColumn<String> category = GeneratedColumn<String>(
+    'category',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _jiraWorklogIdMeta = const VerificationMeta(
     'jiraWorklogId',
   );
@@ -3742,6 +3753,7 @@ class $WorklogEntriesTable extends WorklogEntries
     duration,
     date,
     comment,
+    category,
     jiraWorklogId,
     jiraDirty,
     created,
@@ -3810,6 +3822,12 @@ class $WorklogEntriesTable extends WorklogEntries
       context.handle(
         _commentMeta,
         comment.isAcceptableOrUnknown(data['comment']!, _commentMeta),
+      );
+    }
+    if (data.containsKey('category')) {
+      context.handle(
+        _categoryMeta,
+        category.isAcceptableOrUnknown(data['category']!, _categoryMeta),
       );
     }
     if (data.containsKey('jira_worklog_id')) {
@@ -3892,6 +3910,10 @@ class $WorklogEntriesTable extends WorklogEntries
         DriftSqlType.string,
         data['${effectivePrefix}comment'],
       ),
+      category: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}category'],
+      ),
       jiraWorklogId: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}jira_worklog_id'],
@@ -3933,6 +3955,7 @@ class WorklogEntry extends DataClass implements Insertable<WorklogEntry> {
   final int duration;
   final String date;
   final String? comment;
+  final String? category;
   final String? jiraWorklogId;
   final bool jiraDirty;
   final int created;
@@ -3947,6 +3970,7 @@ class WorklogEntry extends DataClass implements Insertable<WorklogEntry> {
     required this.duration,
     required this.date,
     this.comment,
+    this.category,
     this.jiraWorklogId,
     required this.jiraDirty,
     required this.created,
@@ -3965,6 +3989,9 @@ class WorklogEntry extends DataClass implements Insertable<WorklogEntry> {
     map['date'] = Variable<String>(date);
     if (!nullToAbsent || comment != null) {
       map['comment'] = Variable<String>(comment);
+    }
+    if (!nullToAbsent || category != null) {
+      map['category'] = Variable<String>(category);
     }
     if (!nullToAbsent || jiraWorklogId != null) {
       map['jira_worklog_id'] = Variable<String>(jiraWorklogId);
@@ -3988,6 +4015,9 @@ class WorklogEntry extends DataClass implements Insertable<WorklogEntry> {
       comment: comment == null && nullToAbsent
           ? const Value.absent()
           : Value(comment),
+      category: category == null && nullToAbsent
+          ? const Value.absent()
+          : Value(category),
       jiraWorklogId: jiraWorklogId == null && nullToAbsent
           ? const Value.absent()
           : Value(jiraWorklogId),
@@ -4012,6 +4042,7 @@ class WorklogEntry extends DataClass implements Insertable<WorklogEntry> {
       duration: serializer.fromJson<int>(json['duration']),
       date: serializer.fromJson<String>(json['date']),
       comment: serializer.fromJson<String?>(json['comment']),
+      category: serializer.fromJson<String?>(json['category']),
       jiraWorklogId: serializer.fromJson<String?>(json['jiraWorklogId']),
       jiraDirty: serializer.fromJson<bool>(json['jiraDirty']),
       created: serializer.fromJson<int>(json['created']),
@@ -4031,6 +4062,7 @@ class WorklogEntry extends DataClass implements Insertable<WorklogEntry> {
       'duration': serializer.toJson<int>(duration),
       'date': serializer.toJson<String>(date),
       'comment': serializer.toJson<String?>(comment),
+      'category': serializer.toJson<String?>(category),
       'jiraWorklogId': serializer.toJson<String?>(jiraWorklogId),
       'jiraDirty': serializer.toJson<bool>(jiraDirty),
       'created': serializer.toJson<int>(created),
@@ -4048,6 +4080,7 @@ class WorklogEntry extends DataClass implements Insertable<WorklogEntry> {
     int? duration,
     String? date,
     Value<String?> comment = const Value.absent(),
+    Value<String?> category = const Value.absent(),
     Value<String?> jiraWorklogId = const Value.absent(),
     bool? jiraDirty,
     int? created,
@@ -4062,6 +4095,7 @@ class WorklogEntry extends DataClass implements Insertable<WorklogEntry> {
     duration: duration ?? this.duration,
     date: date ?? this.date,
     comment: comment.present ? comment.value : this.comment,
+    category: category.present ? category.value : this.category,
     jiraWorklogId: jiraWorklogId.present
         ? jiraWorklogId.value
         : this.jiraWorklogId,
@@ -4080,6 +4114,7 @@ class WorklogEntry extends DataClass implements Insertable<WorklogEntry> {
       duration: data.duration.present ? data.duration.value : this.duration,
       date: data.date.present ? data.date.value : this.date,
       comment: data.comment.present ? data.comment.value : this.comment,
+      category: data.category.present ? data.category.value : this.category,
       jiraWorklogId: data.jiraWorklogId.present
           ? data.jiraWorklogId.value
           : this.jiraWorklogId,
@@ -4101,6 +4136,7 @@ class WorklogEntry extends DataClass implements Insertable<WorklogEntry> {
           ..write('duration: $duration, ')
           ..write('date: $date, ')
           ..write('comment: $comment, ')
+          ..write('category: $category, ')
           ..write('jiraWorklogId: $jiraWorklogId, ')
           ..write('jiraDirty: $jiraDirty, ')
           ..write('created: $created, ')
@@ -4120,6 +4156,7 @@ class WorklogEntry extends DataClass implements Insertable<WorklogEntry> {
     duration,
     date,
     comment,
+    category,
     jiraWorklogId,
     jiraDirty,
     created,
@@ -4138,6 +4175,7 @@ class WorklogEntry extends DataClass implements Insertable<WorklogEntry> {
           other.duration == this.duration &&
           other.date == this.date &&
           other.comment == this.comment &&
+          other.category == this.category &&
           other.jiraWorklogId == this.jiraWorklogId &&
           other.jiraDirty == this.jiraDirty &&
           other.created == this.created &&
@@ -4154,6 +4192,7 @@ class WorklogEntriesCompanion extends UpdateCompanion<WorklogEntry> {
   final Value<int> duration;
   final Value<String> date;
   final Value<String?> comment;
+  final Value<String?> category;
   final Value<String?> jiraWorklogId;
   final Value<bool> jiraDirty;
   final Value<int> created;
@@ -4169,6 +4208,7 @@ class WorklogEntriesCompanion extends UpdateCompanion<WorklogEntry> {
     this.duration = const Value.absent(),
     this.date = const Value.absent(),
     this.comment = const Value.absent(),
+    this.category = const Value.absent(),
     this.jiraWorklogId = const Value.absent(),
     this.jiraDirty = const Value.absent(),
     this.created = const Value.absent(),
@@ -4185,6 +4225,7 @@ class WorklogEntriesCompanion extends UpdateCompanion<WorklogEntry> {
     required int duration,
     required String date,
     this.comment = const Value.absent(),
+    this.category = const Value.absent(),
     this.jiraWorklogId = const Value.absent(),
     this.jiraDirty = const Value.absent(),
     required int created,
@@ -4208,6 +4249,7 @@ class WorklogEntriesCompanion extends UpdateCompanion<WorklogEntry> {
     Expression<int>? duration,
     Expression<String>? date,
     Expression<String>? comment,
+    Expression<String>? category,
     Expression<String>? jiraWorklogId,
     Expression<bool>? jiraDirty,
     Expression<int>? created,
@@ -4224,6 +4266,7 @@ class WorklogEntriesCompanion extends UpdateCompanion<WorklogEntry> {
       if (duration != null) 'duration': duration,
       if (date != null) 'date': date,
       if (comment != null) 'comment': comment,
+      if (category != null) 'category': category,
       if (jiraWorklogId != null) 'jira_worklog_id': jiraWorklogId,
       if (jiraDirty != null) 'jira_dirty': jiraDirty,
       if (created != null) 'created': created,
@@ -4242,6 +4285,7 @@ class WorklogEntriesCompanion extends UpdateCompanion<WorklogEntry> {
     Value<int>? duration,
     Value<String>? date,
     Value<String?>? comment,
+    Value<String?>? category,
     Value<String?>? jiraWorklogId,
     Value<bool>? jiraDirty,
     Value<int>? created,
@@ -4258,6 +4302,7 @@ class WorklogEntriesCompanion extends UpdateCompanion<WorklogEntry> {
       duration: duration ?? this.duration,
       date: date ?? this.date,
       comment: comment ?? this.comment,
+      category: category ?? this.category,
       jiraWorklogId: jiraWorklogId ?? this.jiraWorklogId,
       jiraDirty: jiraDirty ?? this.jiraDirty,
       created: created ?? this.created,
@@ -4291,6 +4336,9 @@ class WorklogEntriesCompanion extends UpdateCompanion<WorklogEntry> {
     }
     if (comment.present) {
       map['comment'] = Variable<String>(comment.value);
+    }
+    if (category.present) {
+      map['category'] = Variable<String>(category.value);
     }
     if (jiraWorklogId.present) {
       map['jira_worklog_id'] = Variable<String>(jiraWorklogId.value);
@@ -4326,6 +4374,7 @@ class WorklogEntriesCompanion extends UpdateCompanion<WorklogEntry> {
           ..write('duration: $duration, ')
           ..write('date: $date, ')
           ..write('comment: $comment, ')
+          ..write('category: $category, ')
           ..write('jiraWorklogId: $jiraWorklogId, ')
           ..write('jiraDirty: $jiraDirty, ')
           ..write('created: $created, ')
@@ -5553,6 +5602,17 @@ class $TimerEntriesTable extends TimerEntries
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _categoryMeta = const VerificationMeta(
+    'category',
+  );
+  @override
+  late final GeneratedColumn<String> category = GeneratedColumn<String>(
+    'category',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _crdtClockMeta = const VerificationMeta(
     'crdtClock',
   );
@@ -5589,6 +5649,7 @@ class $TimerEntriesTable extends TimerEntries
     pausedAt,
     accumulatedMs,
     note,
+    category,
     crdtClock,
     crdtState,
   ];
@@ -5669,6 +5730,12 @@ class $TimerEntriesTable extends TimerEntries
         note.isAcceptableOrUnknown(data['note']!, _noteMeta),
       );
     }
+    if (data.containsKey('category')) {
+      context.handle(
+        _categoryMeta,
+        category.isAcceptableOrUnknown(data['category']!, _categoryMeta),
+      );
+    }
     if (data.containsKey('crdt_clock')) {
       context.handle(
         _crdtClockMeta,
@@ -5730,6 +5797,10 @@ class $TimerEntriesTable extends TimerEntries
         DriftSqlType.string,
         data['${effectivePrefix}note'],
       ),
+      category: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}category'],
+      ),
       crdtClock: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}crdt_clock'],
@@ -5777,6 +5848,9 @@ class TimerEntry extends DataClass implements Insertable<TimerEntry> {
 
   /// Optional note about current work.
   final String? note;
+
+  /// Category for orphan timers (no task required).
+  final String? category;
   final String crdtClock;
   final String crdtState;
   const TimerEntry({
@@ -5790,6 +5864,7 @@ class TimerEntry extends DataClass implements Insertable<TimerEntry> {
     this.pausedAt,
     required this.accumulatedMs,
     this.note,
+    this.category,
     required this.crdtClock,
     required this.crdtState,
   });
@@ -5816,6 +5891,9 @@ class TimerEntry extends DataClass implements Insertable<TimerEntry> {
     if (!nullToAbsent || note != null) {
       map['note'] = Variable<String>(note);
     }
+    if (!nullToAbsent || category != null) {
+      map['category'] = Variable<String>(category);
+    }
     map['crdt_clock'] = Variable<String>(crdtClock);
     map['crdt_state'] = Variable<String>(crdtState);
     return map;
@@ -5841,6 +5919,9 @@ class TimerEntry extends DataClass implements Insertable<TimerEntry> {
           : Value(pausedAt),
       accumulatedMs: Value(accumulatedMs),
       note: note == null && nullToAbsent ? const Value.absent() : Value(note),
+      category: category == null && nullToAbsent
+          ? const Value.absent()
+          : Value(category),
       crdtClock: Value(crdtClock),
       crdtState: Value(crdtState),
     );
@@ -5862,6 +5943,7 @@ class TimerEntry extends DataClass implements Insertable<TimerEntry> {
       pausedAt: serializer.fromJson<int?>(json['pausedAt']),
       accumulatedMs: serializer.fromJson<int>(json['accumulatedMs']),
       note: serializer.fromJson<String?>(json['note']),
+      category: serializer.fromJson<String?>(json['category']),
       crdtClock: serializer.fromJson<String>(json['crdtClock']),
       crdtState: serializer.fromJson<String>(json['crdtState']),
     );
@@ -5880,6 +5962,7 @@ class TimerEntry extends DataClass implements Insertable<TimerEntry> {
       'pausedAt': serializer.toJson<int?>(pausedAt),
       'accumulatedMs': serializer.toJson<int>(accumulatedMs),
       'note': serializer.toJson<String?>(note),
+      'category': serializer.toJson<String?>(category),
       'crdtClock': serializer.toJson<String>(crdtClock),
       'crdtState': serializer.toJson<String>(crdtState),
     };
@@ -5896,6 +5979,7 @@ class TimerEntry extends DataClass implements Insertable<TimerEntry> {
     Value<int?> pausedAt = const Value.absent(),
     int? accumulatedMs,
     Value<String?> note = const Value.absent(),
+    Value<String?> category = const Value.absent(),
     String? crdtClock,
     String? crdtState,
   }) => TimerEntry(
@@ -5909,6 +5993,7 @@ class TimerEntry extends DataClass implements Insertable<TimerEntry> {
     pausedAt: pausedAt.present ? pausedAt.value : this.pausedAt,
     accumulatedMs: accumulatedMs ?? this.accumulatedMs,
     note: note.present ? note.value : this.note,
+    category: category.present ? category.value : this.category,
     crdtClock: crdtClock ?? this.crdtClock,
     crdtState: crdtState ?? this.crdtState,
   );
@@ -5928,6 +6013,7 @@ class TimerEntry extends DataClass implements Insertable<TimerEntry> {
           ? data.accumulatedMs.value
           : this.accumulatedMs,
       note: data.note.present ? data.note.value : this.note,
+      category: data.category.present ? data.category.value : this.category,
       crdtClock: data.crdtClock.present ? data.crdtClock.value : this.crdtClock,
       crdtState: data.crdtState.present ? data.crdtState.value : this.crdtState,
     );
@@ -5946,6 +6032,7 @@ class TimerEntry extends DataClass implements Insertable<TimerEntry> {
           ..write('pausedAt: $pausedAt, ')
           ..write('accumulatedMs: $accumulatedMs, ')
           ..write('note: $note, ')
+          ..write('category: $category, ')
           ..write('crdtClock: $crdtClock, ')
           ..write('crdtState: $crdtState')
           ..write(')'))
@@ -5964,6 +6051,7 @@ class TimerEntry extends DataClass implements Insertable<TimerEntry> {
     pausedAt,
     accumulatedMs,
     note,
+    category,
     crdtClock,
     crdtState,
   );
@@ -5981,6 +6069,7 @@ class TimerEntry extends DataClass implements Insertable<TimerEntry> {
           other.pausedAt == this.pausedAt &&
           other.accumulatedMs == this.accumulatedMs &&
           other.note == this.note &&
+          other.category == this.category &&
           other.crdtClock == this.crdtClock &&
           other.crdtState == this.crdtState);
 }
@@ -5996,6 +6085,7 @@ class TimerEntriesCompanion extends UpdateCompanion<TimerEntry> {
   final Value<int?> pausedAt;
   final Value<int> accumulatedMs;
   final Value<String?> note;
+  final Value<String?> category;
   final Value<String> crdtClock;
   final Value<String> crdtState;
   final Value<int> rowid;
@@ -6010,6 +6100,7 @@ class TimerEntriesCompanion extends UpdateCompanion<TimerEntry> {
     this.pausedAt = const Value.absent(),
     this.accumulatedMs = const Value.absent(),
     this.note = const Value.absent(),
+    this.category = const Value.absent(),
     this.crdtClock = const Value.absent(),
     this.crdtState = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -6025,6 +6116,7 @@ class TimerEntriesCompanion extends UpdateCompanion<TimerEntry> {
     this.pausedAt = const Value.absent(),
     this.accumulatedMs = const Value.absent(),
     this.note = const Value.absent(),
+    this.category = const Value.absent(),
     this.crdtClock = const Value.absent(),
     this.crdtState = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -6040,6 +6132,7 @@ class TimerEntriesCompanion extends UpdateCompanion<TimerEntry> {
     Expression<int>? pausedAt,
     Expression<int>? accumulatedMs,
     Expression<String>? note,
+    Expression<String>? category,
     Expression<String>? crdtClock,
     Expression<String>? crdtState,
     Expression<int>? rowid,
@@ -6055,6 +6148,7 @@ class TimerEntriesCompanion extends UpdateCompanion<TimerEntry> {
       if (pausedAt != null) 'paused_at': pausedAt,
       if (accumulatedMs != null) 'accumulated_ms': accumulatedMs,
       if (note != null) 'note': note,
+      if (category != null) 'category': category,
       if (crdtClock != null) 'crdt_clock': crdtClock,
       if (crdtState != null) 'crdt_state': crdtState,
       if (rowid != null) 'rowid': rowid,
@@ -6072,6 +6166,7 @@ class TimerEntriesCompanion extends UpdateCompanion<TimerEntry> {
     Value<int?>? pausedAt,
     Value<int>? accumulatedMs,
     Value<String?>? note,
+    Value<String?>? category,
     Value<String>? crdtClock,
     Value<String>? crdtState,
     Value<int>? rowid,
@@ -6087,6 +6182,7 @@ class TimerEntriesCompanion extends UpdateCompanion<TimerEntry> {
       pausedAt: pausedAt ?? this.pausedAt,
       accumulatedMs: accumulatedMs ?? this.accumulatedMs,
       note: note ?? this.note,
+      category: category ?? this.category,
       crdtClock: crdtClock ?? this.crdtClock,
       crdtState: crdtState ?? this.crdtState,
       rowid: rowid ?? this.rowid,
@@ -6126,6 +6222,9 @@ class TimerEntriesCompanion extends UpdateCompanion<TimerEntry> {
     if (note.present) {
       map['note'] = Variable<String>(note.value);
     }
+    if (category.present) {
+      map['category'] = Variable<String>(category.value);
+    }
     if (crdtClock.present) {
       map['crdt_clock'] = Variable<String>(crdtClock.value);
     }
@@ -6151,6 +6250,7 @@ class TimerEntriesCompanion extends UpdateCompanion<TimerEntry> {
           ..write('pausedAt: $pausedAt, ')
           ..write('accumulatedMs: $accumulatedMs, ')
           ..write('note: $note, ')
+          ..write('category: $category, ')
           ..write('crdtClock: $crdtClock, ')
           ..write('crdtState: $crdtState, ')
           ..write('rowid: $rowid')
@@ -9105,6 +9205,7 @@ typedef $$WorklogEntriesTableCreateCompanionBuilder =
       required int duration,
       required String date,
       Value<String?> comment,
+      Value<String?> category,
       Value<String?> jiraWorklogId,
       Value<bool> jiraDirty,
       required int created,
@@ -9122,6 +9223,7 @@ typedef $$WorklogEntriesTableUpdateCompanionBuilder =
       Value<int> duration,
       Value<String> date,
       Value<String?> comment,
+      Value<String?> category,
       Value<String?> jiraWorklogId,
       Value<bool> jiraDirty,
       Value<int> created,
@@ -9172,6 +9274,11 @@ class $$WorklogEntriesTableFilterComposer
 
   ColumnFilters<String> get comment => $composableBuilder(
     column: $table.comment,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get category => $composableBuilder(
+    column: $table.category,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -9250,6 +9357,11 @@ class $$WorklogEntriesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get jiraWorklogId => $composableBuilder(
     column: $table.jiraWorklogId,
     builder: (column) => ColumnOrderings(column),
@@ -9310,6 +9422,9 @@ class $$WorklogEntriesTableAnnotationComposer
 
   GeneratedColumn<String> get comment =>
       $composableBuilder(column: $table.comment, builder: (column) => column);
+
+  GeneratedColumn<String> get category =>
+      $composableBuilder(column: $table.category, builder: (column) => column);
 
   GeneratedColumn<String> get jiraWorklogId => $composableBuilder(
     column: $table.jiraWorklogId,
@@ -9372,6 +9487,7 @@ class $$WorklogEntriesTableTableManager
                 Value<int> duration = const Value.absent(),
                 Value<String> date = const Value.absent(),
                 Value<String?> comment = const Value.absent(),
+                Value<String?> category = const Value.absent(),
                 Value<String?> jiraWorklogId = const Value.absent(),
                 Value<bool> jiraDirty = const Value.absent(),
                 Value<int> created = const Value.absent(),
@@ -9387,6 +9503,7 @@ class $$WorklogEntriesTableTableManager
                 duration: duration,
                 date: date,
                 comment: comment,
+                category: category,
                 jiraWorklogId: jiraWorklogId,
                 jiraDirty: jiraDirty,
                 created: created,
@@ -9404,6 +9521,7 @@ class $$WorklogEntriesTableTableManager
                 required int duration,
                 required String date,
                 Value<String?> comment = const Value.absent(),
+                Value<String?> category = const Value.absent(),
                 Value<String?> jiraWorklogId = const Value.absent(),
                 Value<bool> jiraDirty = const Value.absent(),
                 required int created,
@@ -9419,6 +9537,7 @@ class $$WorklogEntriesTableTableManager
                 duration: duration,
                 date: date,
                 comment: comment,
+                category: category,
                 jiraWorklogId: jiraWorklogId,
                 jiraDirty: jiraDirty,
                 created: created,
@@ -9956,6 +10075,7 @@ typedef $$TimerEntriesTableCreateCompanionBuilder =
       Value<int?> pausedAt,
       Value<int> accumulatedMs,
       Value<String?> note,
+      Value<String?> category,
       Value<String> crdtClock,
       Value<String> crdtState,
       Value<int> rowid,
@@ -9972,6 +10092,7 @@ typedef $$TimerEntriesTableUpdateCompanionBuilder =
       Value<int?> pausedAt,
       Value<int> accumulatedMs,
       Value<String?> note,
+      Value<String?> category,
       Value<String> crdtClock,
       Value<String> crdtState,
       Value<int> rowid,
@@ -10033,6 +10154,11 @@ class $$TimerEntriesTableFilterComposer
 
   ColumnFilters<String> get note => $composableBuilder(
     column: $table.note,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get category => $composableBuilder(
+    column: $table.category,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -10106,6 +10232,11 @@ class $$TimerEntriesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get crdtClock => $composableBuilder(
     column: $table.crdtClock,
     builder: (column) => ColumnOrderings(column),
@@ -10160,6 +10291,9 @@ class $$TimerEntriesTableAnnotationComposer
   GeneratedColumn<String> get note =>
       $composableBuilder(column: $table.note, builder: (column) => column);
 
+  GeneratedColumn<String> get category =>
+      $composableBuilder(column: $table.category, builder: (column) => column);
+
   GeneratedColumn<String> get crdtClock =>
       $composableBuilder(column: $table.crdtClock, builder: (column) => column);
 
@@ -10208,6 +10342,7 @@ class $$TimerEntriesTableTableManager
                 Value<int?> pausedAt = const Value.absent(),
                 Value<int> accumulatedMs = const Value.absent(),
                 Value<String?> note = const Value.absent(),
+                Value<String?> category = const Value.absent(),
                 Value<String> crdtClock = const Value.absent(),
                 Value<String> crdtState = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -10222,6 +10357,7 @@ class $$TimerEntriesTableTableManager
                 pausedAt: pausedAt,
                 accumulatedMs: accumulatedMs,
                 note: note,
+                category: category,
                 crdtClock: crdtClock,
                 crdtState: crdtState,
                 rowid: rowid,
@@ -10238,6 +10374,7 @@ class $$TimerEntriesTableTableManager
                 Value<int?> pausedAt = const Value.absent(),
                 Value<int> accumulatedMs = const Value.absent(),
                 Value<String?> note = const Value.absent(),
+                Value<String?> category = const Value.absent(),
                 Value<String> crdtClock = const Value.absent(),
                 Value<String> crdtState = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -10252,6 +10389,7 @@ class $$TimerEntriesTableTableManager
                 pausedAt: pausedAt,
                 accumulatedMs: accumulatedMs,
                 note: note,
+                category: category,
                 crdtClock: crdtClock,
                 crdtState: crdtState,
                 rowid: rowid,

--- a/packages/avodah_core/lib/storage/tables/timer.dart
+++ b/packages/avodah_core/lib/storage/tables/timer.dart
@@ -35,6 +35,9 @@ class TimerEntries extends Table {
   /// Optional note about current work.
   TextColumn get note => text().nullable()();
 
+  /// Category for orphan timers (no task required).
+  TextColumn get category => text().nullable()();
+
   // CRDT metadata
   TextColumn get crdtClock => text().withDefault(const Constant(''))();
   TextColumn get crdtState => text().withDefault(const Constant('{}'))();

--- a/packages/avodah_core/lib/storage/tables/worklogs.dart
+++ b/packages/avodah_core/lib/storage/tables/worklogs.dart
@@ -17,6 +17,9 @@ class WorklogEntries extends Table {
   // Optional comment/note
   TextColumn get comment => text().nullable()();
 
+  // Category for orphan worklogs (no task required)
+  TextColumn get category => text().nullable()();
+
   // External provider sync
   TextColumn get jiraWorklogId => text().nullable()();
   BoolColumn get jiraDirty => boolean().withDefault(const Constant(false))();

--- a/phone/lib/models/snapshot.dart
+++ b/phone/lib/models/snapshot.dart
@@ -48,6 +48,7 @@ class TimerSnapshot {
   final String elapsed;
   final DateTime? startedAt;
   final String? note;
+  final String? category;
 
   /// The snapshot timestamp — needed for live elapsed computation.
   DateTime? _snapshotTimestamp;
@@ -61,6 +62,7 @@ class TimerSnapshot {
     required this.elapsed,
     this.startedAt,
     this.note,
+    this.category,
   });
 
   /// Sets the snapshot timestamp for live elapsed computation.
@@ -88,6 +90,7 @@ class TimerSnapshot {
           ? DateTime.parse(json['startedAt'] as String)
           : null,
       note: json['note'] as String?,
+      category: json['category'] as String?,
     );
   }
 }

--- a/phone/lib/screens/dashboard_screen.dart
+++ b/phone/lib/screens/dashboard_screen.dart
@@ -194,20 +194,52 @@ class _DashboardScreenState extends State<DashboardScreen> {
   }
 
   Future<void> _startCategoryTimer(String category) async {
-    final deltas = <Map<String, dynamic>>[];
+    try {
+      final deltas = <Map<String, dynamic>>[];
 
-    // Stop current timer first (creates worklog) - with confirmation
-    final snapshot = widget.dashboardProvider.snapshot;
-    if (snapshot?.timer != null && snapshot!.timer!.isRunning) {
-      final taskTitle = snapshot.timer!.taskTitle;
-      final confirmed = await showDialog<bool>(
+      // Stop current timer first (creates worklog) - with confirmation
+      final snapshot = widget.dashboardProvider.snapshot;
+      if (snapshot?.timer != null && snapshot!.timer!.isRunning) {
+        final taskTitle = snapshot.timer!.taskTitle;
+        final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('Stop current timer?'),
+            content: Text(
+              'Stop current timer for $taskTitle? '
+              'A worklog will be saved with no comment.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('Stop'),
+              ),
+            ],
+          ),
+        );
+        if (confirmed != true) return;
+
+        final result = await widget.writeService.stopTimerAndLog();
+        final stoppedTimerDelta = await widget.writeService.getTimerDelta();
+        if (stoppedTimerDelta != null) deltas.add(stoppedTimerDelta);
+        if (result.worklogId != null) {
+          final wlDelta =
+              await widget.writeService.getWorklogDelta(result.worklogId!);
+          if (wlDelta != null) deltas.add(wlDelta);
+        }
+      }
+
+      // Confirm before starting timer for category
+      if (!mounted) return;
+      final startConfirmed = await showDialog<bool>(
         context: context,
         builder: (ctx) => AlertDialog(
-          title: const Text('Stop current timer?'),
-          content: Text(
-            'Stop current timer for $taskTitle? '
-            'A worklog will be saved with no comment.',
-          ),
+          title: const Text('Start timer?'),
+          content: Text('Start timer for $category?'),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(ctx, false),
@@ -215,43 +247,42 @@ class _DashboardScreenState extends State<DashboardScreen> {
             ),
             FilledButton(
               onPressed: () => Navigator.pop(ctx, true),
-              child: const Text('Stop'),
+              child: const Text('Start'),
             ),
           ],
         ),
       );
-      if (confirmed != true) return;
+      if (startConfirmed != true) return;
 
-      final result = await widget.writeService.stopTimerAndLog();
-      final stoppedTimerDelta = await widget.writeService.getTimerDelta();
-      if (stoppedTimerDelta != null) deltas.add(stoppedTimerDelta);
-      if (result.worklogId != null) {
-        final wlDelta =
-            await widget.writeService.getWorklogDelta(result.worklogId!);
-        if (wlDelta != null) deltas.add(wlDelta);
-      }
+      // Start timer with category (no task)
+      await widget.writeService.startTimer(
+        taskTitle: category,
+        taskId: null,
+        category: category,
+      );
+      final timerDelta = await widget.writeService.getTimerDelta();
+      if (timerDelta != null) deltas.add(timerDelta);
+
+      // Push all deltas (fire-and-forget)
+      if (deltas.isNotEmpty) widget.onPushDeltas?.call(deltas);
+
+      await widget.dashboardProvider.refresh();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Timer started: $category'),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Error: $e'),
+          duration: const Duration(seconds: 3),
+        ),
+      );
     }
-
-    // Start timer with category (no task)
-    await widget.writeService.startTimer(
-      taskTitle: category,
-      taskId: null,
-      category: category,
-    );
-    final timerDelta = await widget.writeService.getTimerDelta();
-    if (timerDelta != null) deltas.add(timerDelta);
-
-    // Push all deltas (fire-and-forget)
-    if (deltas.isNotEmpty) widget.onPushDeltas?.call(deltas);
-
-    await widget.dashboardProvider.refresh();
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('Timer started: $category'),
-        duration: const Duration(seconds: 2),
-      ),
-    );
   }
 
   Future<void> _onEditPlan() async {

--- a/phone/lib/screens/dashboard_screen.dart
+++ b/phone/lib/screens/dashboard_screen.dart
@@ -196,9 +196,32 @@ class _DashboardScreenState extends State<DashboardScreen> {
   Future<void> _startCategoryTimer(String category) async {
     final deltas = <Map<String, dynamic>>[];
 
-    // Stop current timer first (creates worklog)
+    // Stop current timer first (creates worklog) - with confirmation
     final snapshot = widget.dashboardProvider.snapshot;
     if (snapshot?.timer != null && snapshot!.timer!.isRunning) {
+      final taskTitle = snapshot.timer!.taskTitle;
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Stop current timer?'),
+          content: Text(
+            'Stop current timer for $taskTitle? '
+            'A worklog will be saved with no comment.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Stop'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) return;
+
       final result = await widget.writeService.stopTimerAndLog();
       final stoppedTimerDelta = await widget.writeService.getTimerDelta();
       if (stoppedTimerDelta != null) deltas.add(stoppedTimerDelta);

--- a/phone/lib/screens/dashboard_screen.dart
+++ b/phone/lib/screens/dashboard_screen.dart
@@ -61,7 +61,10 @@ class _DashboardScreenState extends State<DashboardScreen> {
       builder: (_) => StopTimerSheet(
         initialMessage: timer.note,
         taskId: timer.taskId,
-        onSave: (message, markDone) async {
+        category: timer.category,
+        writeService: widget.writeService,
+        apiClient: widget.apiClient,
+        onSave: (message, markDone, taskId) async {
           final result =
               await widget.writeService.stopTimerAndLog(comment: message);
 
@@ -72,10 +75,12 @@ class _DashboardScreenState extends State<DashboardScreen> {
               : null;
           final deltas = [?timerDelta, ?worklogDelta];
 
-          if (markDone && timer.taskId != null) {
-            await widget.writeService.toggleTaskDone(timer.taskId!);
+          // Use taskId from the stop (which may have been updated by the sheet)
+          final effectiveTaskId = taskId ?? timer.taskId;
+          if (markDone && effectiveTaskId != null) {
+            await widget.writeService.toggleTaskDone(effectiveTaskId);
             final taskDelta =
-                await widget.writeService.getTaskDelta(timer.taskId!);
+                await widget.writeService.getTaskDelta(effectiveTaskId);
             if (taskDelta != null) deltas.add(taskDelta);
           }
 
@@ -183,6 +188,44 @@ class _DashboardScreenState extends State<DashboardScreen> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text('Timer started: $taskTitle'),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
+  Future<void> _startCategoryTimer(String category) async {
+    final deltas = <Map<String, dynamic>>[];
+
+    // Stop current timer first (creates worklog)
+    final snapshot = widget.dashboardProvider.snapshot;
+    if (snapshot?.timer != null && snapshot!.timer!.isRunning) {
+      final result = await widget.writeService.stopTimerAndLog();
+      final stoppedTimerDelta = await widget.writeService.getTimerDelta();
+      if (stoppedTimerDelta != null) deltas.add(stoppedTimerDelta);
+      if (result.worklogId != null) {
+        final wlDelta =
+            await widget.writeService.getWorklogDelta(result.worklogId!);
+        if (wlDelta != null) deltas.add(wlDelta);
+      }
+    }
+
+    // Start timer with category (no task)
+    await widget.writeService.startTimer(
+      taskTitle: category,
+      taskId: null,
+      category: category,
+    );
+    final timerDelta = await widget.writeService.getTimerDelta();
+    if (timerDelta != null) deltas.add(timerDelta);
+
+    // Push all deltas (fire-and-forget)
+    if (deltas.isNotEmpty) widget.onPushDeltas?.call(deltas);
+
+    await widget.dashboardProvider.refresh();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('Timer started: $category'),
         duration: const Duration(seconds: 2),
       ),
     );
@@ -302,7 +345,11 @@ class _DashboardScreenState extends State<DashboardScreen> {
           const SizedBox(height: 8),
 
           // Plan vs Actual
-          PlanCategoryTable(plan: s.plan, onEditPlan: _onEditPlan),
+          PlanCategoryTable(
+            plan: s.plan,
+            onEditPlan: _onEditPlan,
+            onCategoryTap: _startCategoryTimer,
+          ),
           const SizedBox(height: 8),
 
           // Planned tasks

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -402,6 +402,20 @@ class AgentApiClient {
     return cats.map((e) => e as String).toList();
   }
 
+  /// Fetch comment chip presets for a specific category.
+  ///
+  /// Calls GET /api/config/category-chips?category=X
+  /// Returns list of chip strings; empty on failure.
+  Future<List<String>> getCategoryChips(String category) async {
+    try {
+      final response = await _get('/api/config/category-chips?category=${Uri.encodeComponent(category)}');
+      final chips = response['chips'] as List? ?? [];
+      return chips.map((e) => e as String).toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
   /// List active PA systemd timers.
   Future<List<TimerInfo>> listTimers() async {
     final response = await _get('/api/timers');

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -416,6 +416,55 @@ class AgentApiClient {
     }
   }
 
+  /// Fetch all category chip presets.
+  ///
+  /// Calls GET /api/config/category-chips
+  /// Returns map of category -> list of chips; empty map on failure.
+  Future<Map<String, List<String>>> getAllCategoryChips() async {
+    try {
+      final response = await _get('/api/config/category-chips');
+      final chipsMap = response['categoryChips'] as Map<String, dynamic>? ?? {};
+      return chipsMap.map((key, value) =>
+          MapEntry(key, (value as List<dynamic>).map((e) => e as String).toList()));
+    } catch (_) {
+      return {};
+    }
+  }
+
+  /// Add a chip preset to a category.
+  ///
+  /// Calls POST /api/config/category-chips with {"action": "add", "category": X, "chip": Y}
+  /// Returns true on success.
+  Future<bool> addCategoryChip(String category, String chip) async {
+    try {
+      await _post('/api/config/category-chips', body: {
+        'action': 'add',
+        'category': category,
+        'chip': chip,
+      });
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Remove a chip preset from a category.
+  ///
+  /// Calls POST /api/config/category-chips with {"action": "remove", "category": X, "chip": Y}
+  /// Returns true on success.
+  Future<bool> removeCategoryChip(String category, String chip) async {
+    try {
+      await _post('/api/config/category-chips', body: {
+        'action': 'remove',
+        'category': category,
+        'chip': chip,
+      });
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   /// List active PA systemd timers.
   Future<List<TimerInfo>> listTimers() async {
     final response = await _get('/api/timers');

--- a/phone/lib/services/local_dashboard_provider.dart
+++ b/phone/lib/services/local_dashboard_provider.dart
@@ -135,6 +135,7 @@ class LocalDashboardProvider extends ChangeNotifier {
           elapsed: _fmt(doc.elapsed),
           startedAt: doc.startedAt,
           note: doc.note,
+          category: doc.category,
         );
         timerSnapshot.snapshotTimestamp = now;
       }

--- a/phone/lib/services/local_write_service.dart
+++ b/phone/lib/services/local_write_service.dart
@@ -10,6 +10,7 @@
 library;
 
 import 'package:avodah_core/avodah_core.dart';
+import 'package:drift/drift.dart';
 import 'package:flutter/foundation.dart';
 
 /// Result of stopping a timer (includes the generated worklog if any).
@@ -34,12 +35,14 @@ class LocalWriteService {
   /// Starts the active timer for [taskId] / [taskTitle].
   ///
   /// If a timer is already running it is silently replaced (last-write-wins).
+  /// [category] is required for orphan timers (no task).
   Future<void> startTimer({
     required String taskTitle,
     String? taskId,
     String? projectId,
     String? projectTitle,
     String? note,
+    String? category,
   }) async {
     final doc = TimerDocument.start(
       clock: clock,
@@ -48,11 +51,35 @@ class LocalWriteService {
       projectId: projectId,
       projectTitle: projectTitle,
       note: note,
+      category: category,
     );
     await db
         .into(db.timerEntries)
         .insertOnConflictUpdate(doc.toDriftCompanion());
-    debugPrint('[LocalWrite] Timer started: "$taskTitle" (id: $taskId)');
+    debugPrint('[LocalWrite] Timer started: "$taskTitle" (id: $taskId, category: $category)');
+  }
+
+  /// Updates the active timer's taskId (for assigning a task before stopping).
+  ///
+  /// If [taskId] is provided, sets taskId and taskTitle from the task.
+  /// If [taskId] is null, clears the taskId (orphan timer).
+  Future<void> updateTimerTask(String? taskId, String? taskTitle) async {
+    final rows = await (db.select(db.timerEntries)
+          ..where((t) => t.id.equals(activeTimerId)))
+        .get();
+
+    if (rows.isEmpty) {
+      debugPrint('[LocalWrite] updateTimerTask: no active timer found');
+      return;
+    }
+
+    final doc = TimerDocument.fromDrift(timer: rows.first, clock: clock);
+    doc.taskId = taskId;
+    doc.taskTitle = taskTitle ?? '';
+    await db
+        .into(db.timerEntries)
+        .insertOnConflictUpdate(doc.toDriftCompanion());
+    debugPrint('[LocalWrite] Timer task updated: id=$taskId, title=$taskTitle');
   }
 
   /// Stops the active timer and creates a worklog entry for the session.
@@ -88,21 +115,25 @@ class LocalWriteService {
         .insertOnConflictUpdate(timerDoc.toDriftCompanion());
 
     // Create worklog if we have a valid task and duration
+    // Also create orphan worklog if we have a category (no task required)
     String? worklogId;
-    if (taskId != null && taskId.isNotEmpty && totalMs > 0 && startedAt != null) {
+    final timerCategory = timerDoc.category;
+    if ((taskId != null && taskId.isNotEmpty || timerCategory != null) &&
+        totalMs > 0 && startedAt != null) {
       final wlDoc = WorklogDocument.fromTimer(
         clock: clock,
         taskId: taskId,
         start: startedAt,
         end: now,
         comment: comment,
+        category: timerCategory,
       );
       await db
           .into(db.worklogEntries)
           .insertOnConflictUpdate(wlDoc.toDriftCompanion());
       worklogId = wlDoc.id;
       debugPrint(
-          '[LocalWrite] Worklog created: ${wlDoc.id} (${wlDoc.formattedDuration})');
+          '[LocalWrite] Worklog created: ${wlDoc.id} (${wlDoc.formattedDuration}, orphan: ${taskId == null || taskId.isEmpty})');
     }
 
     debugPrint('[LocalWrite] Timer stopped. Elapsed: ${totalMs}ms');
@@ -166,6 +197,51 @@ class LocalWriteService {
         .insertOnConflictUpdate(doc.toDriftCompanion());
     debugPrint('[LocalWrite] Manual worklog created: ${doc.id}');
     return doc.id;
+  }
+
+  /// Returns recent worklog comments (up to [limit] entries).
+  Future<List<String>> getRecentComments({int limit = 10}) async {
+    final rows = await (db.select(db.worklogEntries)
+          ..orderBy([(w) => OrderingTerm.desc(w.created)])
+          ..limit(limit))
+        .get();
+    final comments = <String>[];
+    for (final row in rows) {
+      final doc = WorklogDocument.fromDrift(worklog: row, clock: clock);
+      if (doc.comment != null && doc.comment!.isNotEmpty) {
+        comments.add(doc.comment!);
+      }
+    }
+    return comments;
+  }
+
+  /// Returns active tasks filtered by [category].
+  ///
+  /// Returns tasks where category matches (if category is non-null).
+  /// Excludes done tasks.
+  Future<List<Task>> getTasksByCategory(String? category) async {
+    final query = db.select(db.tasks);
+    final rows = await query.get();
+    final tasks = <Task>[];
+    for (final row in rows) {
+      final doc = TaskDocument.fromDrift(task: row, clock: clock);
+      if (doc.isDone || doc.isDeleted) continue;
+      if (category != null && category.isNotEmpty) {
+        if (doc.category == category) {
+          tasks.add(row);
+        }
+      }
+    }
+    return tasks;
+  }
+
+  /// Returns the set of task IDs in today's day plan.
+  Future<Set<String>> getTodayPlannedTaskIds() async {
+    final today = _today();
+    final rows = await (db.select(db.dayPlanTasks)
+          ..where((t) => t.day.equals(today)))
+        .get();
+    return rows.map((r) => r.taskId).toSet();
   }
 
   // ============================================================

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -2,11 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../services/agent_api_client.dart';
+
 const kServerUrlKey = 'sync_server_url';
 const kDefaultServerUrl = 'http://100.64.0.1:9847';
 
 class SettingsScreen extends StatefulWidget {
-  const SettingsScreen({super.key});
+  /// Optional API client for chip management. If not provided, creates one
+  /// using the current saved server URL.
+  final AgentApiClient? apiClient;
+
+  const SettingsScreen({super.key, this.apiClient});
 
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
@@ -34,6 +40,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
   bool _testing = false;
   String? _testResult;
 
+  /// All categories with their chip presets.
+  Map<String, List<String>> _categoryChips = {};
+
+  /// Categories list for the picker.
+  List<String> _categories = [];
+
+  /// Currently selected category for chip management.
+  String? _selectedCategory;
+
+  /// Text controller for adding new chips.
+  final _chipController = TextEditingController();
+
+  /// Whether chip data is being loaded.
+  bool _loadingChips = false;
+
   @override
   void initState() {
     super.initState();
@@ -43,6 +64,81 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _loadUrl() async {
     final url = await SettingsScreen.loadServerUrl();
     _controller.text = url;
+  }
+
+  Future<void> _loadChips() async {
+    // Always use fresh URL for chip operations
+    final url = await SettingsScreen.loadServerUrl();
+    final client = AgentApiClient(baseUrl: url);
+    setState(() => _loadingChips = true);
+    try {
+      final chips = await client.getAllCategoryChips();
+      final categories = await client.getCategories();
+      setState(() {
+        _categoryChips = chips;
+        _categories = categories.isNotEmpty ? categories : _getDefaultCategories();
+        _loadingChips = false;
+      });
+    } catch (e) {
+      setState(() {
+        _categoryChips = {};
+        _categories = _getDefaultCategories();
+        _loadingChips = false;
+      });
+    }
+  }
+
+  List<String> _getDefaultCategories() {
+    return ['Learning', 'Working', 'Side-project', 'Administrative', 'Meetings'];
+  }
+
+  Future<void> _addChip() async {
+    final category = _selectedCategory;
+    final chip = _chipController.text.trim();
+    if (category == null || chip.isEmpty) return;
+
+    // Always use fresh URL
+    final url = await SettingsScreen.loadServerUrl();
+    final client = AgentApiClient(baseUrl: url);
+
+    final success = await client.addCategoryChip(category, chip);
+    if (success) {
+      _chipController.clear();
+      await _loadChips();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Added "$chip" to $category')),
+        );
+      }
+    } else {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to add chip')),
+        );
+      }
+    }
+  }
+
+  Future<void> _removeChip(String category, String chip) async {
+    // Always use fresh URL
+    final url = await SettingsScreen.loadServerUrl();
+    final client = AgentApiClient(baseUrl: url);
+
+    final success = await client.removeCategoryChip(category, chip);
+    if (success) {
+      await _loadChips();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Removed "$chip" from $category')),
+        );
+      }
+    } else {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to remove chip')),
+        );
+      }
+    }
   }
 
   Future<void> _save() async {
@@ -83,6 +179,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   void dispose() {
     _controller.dispose();
+    _chipController.dispose();
     super.dispose();
   }
 
@@ -90,57 +187,184 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('Sync Server URL',
-                style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            TextField(
-              controller: _controller,
-              decoration: const InputDecoration(
-                hintText: kDefaultServerUrl,
-                border: OutlineInputBorder(),
-                helperText: 'Use your Tailscale IP, e.g. http://100.x.y.z:9847',
-              ),
-              keyboardType: TextInputType.url,
-              autocorrect: false,
-            ),
-            const SizedBox(height: 16),
-            Row(
+      body: ListView(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                OutlinedButton(
-                  onPressed: _testing ? null : _testConnection,
-                  child: _testing
-                      ? const SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: CircularProgressIndicator(strokeWidth: 2))
-                      : const Text('Test Connection'),
+                Text('Sync Server URL',
+                    style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                TextField(
+                  controller: _controller,
+                  decoration: const InputDecoration(
+                    hintText: kDefaultServerUrl,
+                    border: OutlineInputBorder(),
+                    helperText: 'Use your Tailscale IP, e.g. http://100.x.y.z:9847',
+                  ),
+                  keyboardType: TextInputType.url,
+                  autocorrect: false,
                 ),
-                const SizedBox(width: 12),
-                FilledButton(
-                  onPressed: _save,
-                  child: const Text('Save'),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    OutlinedButton(
+                      onPressed: _testing ? null : _testConnection,
+                      child: _testing
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2))
+                          : const Text('Test Connection'),
+                    ),
+                    const SizedBox(width: 12),
+                    FilledButton(
+                      onPressed: _save,
+                      child: const Text('Save'),
+                    ),
+                  ],
+                ),
+                if (_testResult != null) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    _testResult!,
+                    style: TextStyle(
+                      color: _testResult!.startsWith('Connected')
+                          ? Colors.green
+                          : Colors.red,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const Divider(),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text('Comment Chip Presets',
+                        style: Theme.of(context).textTheme.titleMedium),
+                    TextButton.icon(
+                      onPressed: () async {
+                        _selectedCategory = null;
+                        await _loadChips();
+                      },
+                      icon: const Icon(Icons.refresh, size: 18),
+                      label: const Text('Refresh'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  'Manage quick comment chips shown when stopping a timer.',
+                  style: TextStyle(color: Colors.grey),
                 ),
               ],
             ),
-            if (_testResult != null) ...[
-              const SizedBox(height: 12),
-              Text(
-                _testResult!,
-                style: TextStyle(
-                  color: _testResult!.startsWith('Connected')
-                      ? Colors.green
-                      : Colors.red,
-                ),
+          ),
+          // Category selector
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: DropdownButtonFormField<String>(
+              decoration: const InputDecoration(
+                labelText: 'Category',
+                border: OutlineInputBorder(),
+                contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
               ),
-            ],
+              value: _selectedCategory,
+              hint: const Text('Select a category'),
+              items: _categories.map((cat) {
+                return DropdownMenuItem(value: cat, child: Text(cat));
+              }).toList(),
+              onChanged: (value) {
+                setState(() => _selectedCategory = value);
+              },
+              onTap: () async {
+                // Load chips when user taps the dropdown if not yet loaded
+                if (_categories.isEmpty) {
+                  await _loadChips();
+                }
+              },
+            ),
+          ),
+          const SizedBox(height: 16),
+          // Add chip row
+          if (_selectedCategory != null) ...[
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _chipController,
+                      decoration: const InputDecoration(
+                        hintText: 'New chip text',
+                        border: OutlineInputBorder(),
+                        contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                      ),
+                      onSubmitted: (_) => _addChip(),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    onPressed: _addChip,
+                    child: const Text('Add'),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            // Chips list for selected category
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: _loadingChips
+                  ? const Center(child: CircularProgressIndicator())
+                  : _buildChipsList(),
+            ),
           ],
-        ),
+          const SizedBox(height: 32),
+        ],
       ),
+    );
+  }
+
+  Widget _buildChipsList() {
+    final chips = _selectedCategory != null
+        ? (_categoryChips[_selectedCategory] ?? [])
+        : <String>[];
+
+    if (chips.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.grey[100],
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: const Text(
+          'No chips for this category yet.\nAdd one using the field above.',
+          textAlign: TextAlign.center,
+          style: TextStyle(color: Colors.grey),
+        ),
+      );
+    }
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: chips.map((chip) {
+        return Chip(
+          label: Text(chip),
+          deleteIcon: const Icon(Icons.close, size: 18),
+          onDeleted: () => _removeChip(_selectedCategory!, chip),
+        );
+      }).toList(),
     );
   }
 }

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -341,10 +341,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
         : <String>[];
 
     if (chips.isEmpty) {
+      final theme = Theme.of(context);
       return Container(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: Colors.grey[100],
+          color: theme.colorScheme.surfaceContainerHighest,
           borderRadius: BorderRadius.circular(8),
         ),
         child: const Text(

--- a/phone/lib/widgets/plan_category_table.dart
+++ b/phone/lib/widgets/plan_category_table.dart
@@ -149,7 +149,7 @@ class _CategoryRow extends StatelessWidget {
             : theme.colorScheme.outline;
 
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
+      padding: const EdgeInsets.symmetric(vertical: 12),
       child: Column(
         children: [
           InkWell(
@@ -175,6 +175,12 @@ class _CategoryRow extends StatelessWidget {
                         textAlign: TextAlign.end,
                         style: theme.textTheme.bodySmall
                             ?.copyWith(color: deltaColor))),
+                const SizedBox(width: 8),
+                Icon(
+                  Icons.play_arrow,
+                  size: 20,
+                  color: theme.colorScheme.primary,
+                ),
               ],
             ),
           ),

--- a/phone/lib/widgets/plan_category_table.dart
+++ b/phone/lib/widgets/plan_category_table.dart
@@ -8,7 +8,15 @@ class PlanCategoryTable extends StatelessWidget {
   /// Called when the user taps the Edit button in the card header.
   final VoidCallback? onEditPlan;
 
-  const PlanCategoryTable({super.key, required this.plan, this.onEditPlan});
+  /// Called when the user taps a category row to start a timer.
+  final void Function(String category)? onCategoryTap;
+
+  const PlanCategoryTable({
+    super.key,
+    required this.plan,
+    this.onEditPlan,
+    this.onCategoryTap,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -90,7 +98,10 @@ class PlanCategoryTable extends StatelessWidget {
             ),
 
             // Category rows
-            ...plan.categories.map((c) => _CategoryRow(category: c)),
+            ...plan.categories.map((c) => _CategoryRow(
+                  category: c,
+                  onTap: onCategoryTap != null ? () => onCategoryTap!(c.category) : null,
+                )),
 
             // Non-categorized
             if (plan.nonCategorized != null) ...[
@@ -124,8 +135,9 @@ class PlanCategoryTable extends StatelessWidget {
 
 class _CategoryRow extends StatelessWidget {
   final PlanCategorySnapshot category;
+  final VoidCallback? onTap;
 
-  const _CategoryRow({required this.category});
+  const _CategoryRow({required this.category, this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -140,27 +152,31 @@ class _CategoryRow extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Column(
         children: [
-          Row(
-            children: [
-              Expanded(
-                  flex: 3,
-                  child: Text(category.category,
-                      style: theme.textTheme.bodyMedium)),
-              Expanded(
-                  child: Text(category.planned,
-                      textAlign: TextAlign.end,
-                      style: theme.textTheme.bodySmall)),
-              Expanded(
-                  child: Text(category.actual,
-                      textAlign: TextAlign.end,
-                      style: theme.textTheme.bodySmall
-                          ?.copyWith(fontWeight: FontWeight.w600))),
-              Expanded(
-                  child: Text(category.delta,
-                      textAlign: TextAlign.end,
-                      style: theme.textTheme.bodySmall
-                          ?.copyWith(color: deltaColor))),
-            ],
+          InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(4),
+            child: Row(
+              children: [
+                Expanded(
+                    flex: 3,
+                    child: Text(category.category,
+                        style: theme.textTheme.bodyMedium)),
+                Expanded(
+                    child: Text(category.planned,
+                        textAlign: TextAlign.end,
+                        style: theme.textTheme.bodySmall)),
+                Expanded(
+                    child: Text(category.actual,
+                        textAlign: TextAlign.end,
+                        style: theme.textTheme.bodySmall
+                            ?.copyWith(fontWeight: FontWeight.w600))),
+                Expanded(
+                    child: Text(category.delta,
+                        textAlign: TextAlign.end,
+                        style: theme.textTheme.bodySmall
+                            ?.copyWith(color: deltaColor))),
+              ],
+            ),
           ),
           // Progress bar
           if (category.plannedMs > 0)

--- a/phone/lib/widgets/stop_timer_sheet.dart
+++ b/phone/lib/widgets/stop_timer_sheet.dart
@@ -1,10 +1,15 @@
+import 'package:avodah_core/avodah_core.dart';
 import 'package:flutter/material.dart';
+
+import '../services/agent_api_client.dart';
+import '../services/local_write_service.dart';
 
 /// A bottom sheet that prompts the user for a worklog message before stopping
 /// the active timer.
 ///
-/// The message field is pre-filled from the timer note and is required —
-/// the Save button is disabled until the field is non-empty.
+/// Shows quick comment chips (recent + per-category presets), a task picker
+/// (planned first, then all active in category), and an option to save as orphan
+/// (no task).
 ///
 /// Usage:
 /// ```dart
@@ -14,7 +19,10 @@ import 'package:flutter/material.dart';
 ///   builder: (_) => StopTimerSheet(
 ///     initialMessage: timer.note,
 ///     taskId: timer.taskId,
-///     onSave: (message, markDone) async { ... },
+///     category: timer.category,
+///     writeService: writeService,
+///     apiClient: apiClient,
+///     onSave: (message, markDone, taskId) async { ... },
 ///   ),
 /// );
 /// ```
@@ -22,16 +30,29 @@ class StopTimerSheet extends StatefulWidget {
   /// Pre-filled message text (from timer note). User can edit before saving.
   final String? initialMessage;
 
-  /// Task ID for the mark-as-done toggle. If null, the toggle is hidden.
+  /// Current task ID from the timer (null for orphan timers).
   final String? taskId;
 
+  /// Category from the timer (required for orphan worklogs).
+  final String? category;
+
+  /// Service for local DB operations (loading comments and tasks).
+  final LocalWriteService writeService;
+
+  /// API client for fetching category chip presets (can be null).
+  final AgentApiClient? apiClient;
+
   /// Called when user taps Save with a non-empty message.
-  final Future<void> Function(String message, bool markDone) onSave;
+  /// [taskId] is null if user chose "No task" (orphan worklog).
+  final Future<void> Function(String message, bool markDone, String? taskId) onSave;
 
   const StopTimerSheet({
     super.key,
     this.initialMessage,
     this.taskId,
+    this.category,
+    required this.writeService,
+    this.apiClient,
     required this.onSave,
   });
 
@@ -43,6 +64,11 @@ class _StopTimerSheetState extends State<StopTimerSheet> {
   late final TextEditingController _messageController;
   bool _markDone = false;
   bool _saving = false;
+  bool _loading = true;
+  String? _selectedTaskId;
+  List<String> _chips = [];
+  List<_TaskOption> _taskOptions = [];
+  String? _selectedTaskTitle;
 
   @override
   void initState() {
@@ -50,6 +76,8 @@ class _StopTimerSheetState extends State<StopTimerSheet> {
     _messageController =
         TextEditingController(text: widget.initialMessage ?? '');
     _messageController.addListener(_onMessageChanged);
+    _selectedTaskId = widget.taskId;
+    _loadData();
   }
 
   @override
@@ -63,6 +91,120 @@ class _StopTimerSheetState extends State<StopTimerSheet> {
   bool get _canSave =>
       _messageController.text.trim().isNotEmpty && !_saving;
 
+  Future<void> _loadData() async {
+    // Load chips from recent comments
+    final recentComments = await widget.writeService.getRecentComments(limit: 10);
+    final allChips = <String>{...recentComments};
+
+    // Load category presets from API
+    if (widget.category != null && widget.apiClient != null) {
+      final categoryChips = await widget.apiClient!.getCategoryChips(widget.category!);
+      allChips.addAll(categoryChips);
+    }
+
+    // Load task options
+    final plannedIds = await widget.writeService.getTodayPlannedTaskIds();
+    final categoryTasks = await widget.writeService.getTasksByCategory(widget.category);
+    final allTasks = await _getAllActiveTasks();
+
+    final options = <_TaskOption>[];
+
+    // "No task" option (orphan)
+    options.add(_TaskOption(
+      id: null,
+      title: 'No task (orphan)',
+      isPlanned: false,
+      isOrphan: true,
+    ));
+
+    // Planned tasks in today's plan
+    for (final task in allTasks) {
+      if (plannedIds.contains(task.id)) {
+        final doc = TaskDocument.fromDrift(task: task, clock: widget.writeService.clock);
+        options.add(_TaskOption(
+          id: task.id,
+          title: doc.title,
+          isPlanned: true,
+          isOrphan: false,
+        ));
+      }
+    }
+
+    // Category tasks (non-planned)
+    for (final task in categoryTasks) {
+      if (!plannedIds.contains(task.id)) {
+        final doc = TaskDocument.fromDrift(task: task, clock: widget.writeService.clock);
+        options.add(_TaskOption(
+          id: task.id,
+          title: doc.title,
+          isPlanned: false,
+          isOrphan: false,
+        ));
+      }
+    }
+
+    // Other active tasks not in this category
+    for (final task in allTasks) {
+      final doc = TaskDocument.fromDrift(task: task, clock: widget.writeService.clock);
+      final isInOptions = options.any((o) => o.id == task.id);
+      if (!isInOptions && !doc.isDone && !doc.isDeleted) {
+        options.add(_TaskOption(
+          id: task.id,
+          title: doc.title,
+          isPlanned: false,
+          isOrphan: false,
+        ));
+      }
+    }
+
+    if (mounted) {
+      setState(() {
+        _chips = allChips.toList();
+        _taskOptions = options;
+        _loading = false;
+        // Set initial selection to current task or orphan
+        if (_selectedTaskId != null) {
+          final opt = options.firstWhere(
+            (o) => o.id == _selectedTaskId,
+            orElse: () => options.first,
+          );
+          _selectedTaskTitle = opt.isOrphan ? null : opt.title;
+        } else {
+          _selectedTaskTitle = null;
+        }
+      });
+    }
+  }
+
+  Future<List<Task>> _getAllActiveTasks() async {
+    final rows = await (widget.writeService.db.select(widget.writeService.db.tasks)).get();
+    return rows.where((t) {
+      final doc = TaskDocument.fromDrift(task: t, clock: widget.writeService.clock);
+      return !doc.isDone && !doc.isDeleted;
+    }).toList();
+  }
+
+  void _onChipTapped(String chip) {
+    final text = _messageController.text;
+    if (text.isEmpty) {
+      _messageController.text = chip;
+    } else if (!text.endsWith(' ') && !text.endsWith('\n')) {
+      _messageController.text = '$text $chip';
+    } else {
+      _messageController.text = '$text$chip';
+    }
+    _messageController.selection = TextSelection.fromPosition(
+      TextPosition(offset: _messageController.text.length),
+    );
+  }
+
+  void _onTaskSelected(_TaskOption option) {
+    setState(() {
+      _selectedTaskId = option.id;
+      _selectedTaskTitle = option.isOrphan ? null : option.title;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -72,7 +214,7 @@ class _StopTimerSheetState extends State<StopTimerSheet> {
         bottom: MediaQuery.of(context).viewInsets.bottom,
       ),
       child: SafeArea(
-        child: Padding(
+        child: SingleChildScrollView(
           padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -92,13 +234,85 @@ class _StopTimerSheetState extends State<StopTimerSheet> {
               ),
 
               Text('Stop Timer', style: theme.textTheme.titleLarge),
+              if (widget.category != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  'Category: ${widget.category}',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+              ],
               const SizedBox(height: 16),
 
+              // Chips section
+              if (!_loading && _chips.isNotEmpty) ...[
+                Text('Quick comments', style: theme.textTheme.labelMedium),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 4,
+                  children: _chips.map((chip) {
+                    return ActionChip(
+                      label: Text(chip, style: theme.textTheme.bodySmall),
+                      onPressed: _saving ? null : () => _onChipTapped(chip),
+                    );
+                  }).toList(),
+                ),
+                const SizedBox(height: 16),
+              ],
+
+              // Task picker
+              if (!_loading) ...[
+                Text('Assign to task', style: theme.textTheme.labelMedium),
+                const SizedBox(height: 8),
+                Container(
+                  constraints: const BoxConstraints(maxHeight: 180),
+                  decoration: BoxDecoration(
+                    border: Border.all(color: theme.colorScheme.outline),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: _taskOptions.length,
+                    itemBuilder: (ctx, index) {
+                      final option = _taskOptions[index];
+                      final isSelected = _selectedTaskId == option.id;
+                      return ListTile(
+                        dense: true,
+                        leading: option.isOrphan
+                            ? const Icon(Icons.block, size: 20)
+                            : (option.isPlanned
+                                ? const Icon(Icons.check_circle_outline, size: 20)
+                                : const Icon(Icons.radio_button_unchecked, size: 20)),
+                        title: Text(
+                          option.title,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontWeight: isSelected ? FontWeight.bold : null,
+                          ),
+                        ),
+                        subtitle: option.isOrphan
+                            ? Text('Save as orphan with category',
+                                style: theme.textTheme.bodySmall)
+                            : (option.isPlanned
+                                ? Text('In today\'s plan',
+                                    style: theme.textTheme.bodySmall)
+                                : null),
+                        selected: isSelected,
+                        onTap: _saving ? null : () => _onTaskSelected(option),
+                      );
+                    },
+                  ),
+                ),
+                const SizedBox(height: 16),
+              ],
+
+              // Worklog message
               Text('Worklog message', style: theme.textTheme.labelMedium),
               const SizedBox(height: 6),
               TextField(
                 controller: _messageController,
-                enabled: !_saving,
+                enabled: !_saving && !_loading,
                 minLines: 2,
                 maxLines: 5,
                 autofocus: true,
@@ -112,7 +326,7 @@ class _StopTimerSheetState extends State<StopTimerSheet> {
                 ),
               ),
 
-              if (widget.taskId != null) ...[
+              if (_selectedTaskId != null) ...[
                 const SizedBox(height: 12),
                 SwitchListTile(
                   contentPadding: EdgeInsets.zero,
@@ -131,7 +345,7 @@ class _StopTimerSheetState extends State<StopTimerSheet> {
               SizedBox(
                 width: double.infinity,
                 child: FilledButton.icon(
-                  onPressed: _canSave ? _save : null,
+                  onPressed: _canSave && !_loading ? _save : null,
                   icon: _saving
                       ? const SizedBox(
                           width: 16,
@@ -153,9 +367,33 @@ class _StopTimerSheetState extends State<StopTimerSheet> {
     if (!_canSave) return;
     setState(() => _saving = true);
     try {
-      await widget.onSave(_messageController.text.trim(), _markDone);
+      // If user selected a task different from current, update timer first
+      if (_selectedTaskId != null && _selectedTaskId != widget.taskId) {
+        await widget.writeService.updateTimerTask(
+          _selectedTaskId,
+          _selectedTaskTitle,
+        );
+      } else if (_selectedTaskId == null && widget.taskId != null) {
+        // User switched from task to orphan
+        await widget.writeService.updateTimerTask(null, null);
+      }
+      await widget.onSave(_messageController.text.trim(), _markDone, _selectedTaskId);
     } finally {
       if (mounted) setState(() => _saving = false);
     }
   }
+}
+
+class _TaskOption {
+  final String? id;
+  final String title;
+  final bool isPlanned;
+  final bool isOrphan;
+
+  _TaskOption({
+    required this.id,
+    required this.title,
+    required this.isPlanned,
+    required this.isOrphan,
+  });
 }

--- a/phone/lib/widgets/stop_timer_sheet.dart
+++ b/phone/lib/widgets/stop_timer_sheet.dart
@@ -245,21 +245,11 @@ class _StopTimerSheetState extends State<StopTimerSheet> {
               ],
               const SizedBox(height: 16),
 
-              // Chips section
-              if (!_loading && _chips.isNotEmpty) ...[
-                Text('Quick comments', style: theme.textTheme.labelMedium),
-                const SizedBox(height: 8),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 4,
-                  children: _chips.map((chip) {
-                    return ActionChip(
-                      label: Text(chip, style: theme.textTheme.bodySmall),
-                      onPressed: _saving ? null : () => _onChipTapped(chip),
-                    );
-                  }).toList(),
-                ),
-                const SizedBox(height: 16),
+              // Loading indicator
+              if (_loading) ...[
+                const SizedBox(height: 48),
+                const Center(child: CircularProgressIndicator()),
+                const SizedBox(height: 48),
               ],
 
               // Task picker
@@ -305,39 +295,56 @@ class _StopTimerSheetState extends State<StopTimerSheet> {
                   ),
                 ),
                 const SizedBox(height: 16),
-              ],
 
-              // Worklog message
-              Text('Worklog message', style: theme.textTheme.labelMedium),
-              const SizedBox(height: 6),
-              TextField(
-                controller: _messageController,
-                enabled: !_saving && !_loading,
-                minLines: 2,
-                maxLines: 5,
-                autofocus: true,
-                decoration: const InputDecoration(
-                  hintText: 'What did you work on?',
-                  border: OutlineInputBorder(),
-                  contentPadding: EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 10,
+                // Worklog message
+                Text('Worklog message', style: theme.textTheme.labelMedium),
+                const SizedBox(height: 6),
+                TextField(
+                  controller: _messageController,
+                  enabled: !_saving && !_loading,
+                  minLines: 2,
+                  maxLines: 5,
+                  autofocus: true,
+                  decoration: const InputDecoration(
+                    hintText: 'What did you work on?',
+                    border: OutlineInputBorder(),
+                    contentPadding: EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 10,
+                    ),
                   ),
                 ),
-              ),
 
-              if (_selectedTaskId != null) ...[
-                const SizedBox(height: 12),
-                SwitchListTile(
-                  contentPadding: EdgeInsets.zero,
-                  title: Text(
-                    'Mark task as done',
-                    style: theme.textTheme.bodyMedium,
+                if (_selectedTaskId != null) ...[
+                  const SizedBox(height: 12),
+                  SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(
+                      'Mark task as done',
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    value: _markDone,
+                    onChanged:
+                        _saving ? null : (v) => setState(() => _markDone = v),
                   ),
-                  value: _markDone,
-                  onChanged:
-                      _saving ? null : (v) => setState(() => _markDone = v),
-                ),
+                ],
+
+                // Chips section
+                if (_chips.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  Text('Quick comments', style: theme.textTheme.labelMedium),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 4,
+                    children: _chips.map((chip) {
+                      return ActionChip(
+                        label: Text(chip, style: theme.textTheme.bodySmall),
+                        onPressed: _saving ? null : () => _onChipTapped(chip),
+                      );
+                    }).toList(),
+                  ),
+                ],
               ],
 
               const SizedBox(height: 20),
@@ -378,6 +385,12 @@ class _StopTimerSheetState extends State<StopTimerSheet> {
         await widget.writeService.updateTimerTask(null, null);
       }
       await widget.onSave(_messageController.text.trim(), _markDone, _selectedTaskId);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error: $e')),
+        );
+      }
     } finally {
       if (mounted) setState(() => _saving = false);
     }

--- a/test/features/worklog/models/worklog_document_test.dart
+++ b/test/features/worklog/models/worklog_document_test.dart
@@ -33,6 +33,20 @@ void main() {
         expect(worklog.createdMs, greaterThan(0));
       });
 
+      test('create() defaults taskId to empty string for orphan worklogs', () {
+        final start = DateTime.now().subtract(const Duration(hours: 1));
+        final end = DateTime.now();
+
+        final worklog = WorklogDocument.create(
+          clock: clock,
+          start: start.millisecondsSinceEpoch,
+          end: end.millisecondsSinceEpoch,
+        );
+
+        expect(worklog.taskId, isEmpty);
+        expect(worklog.isOrphan, isTrue);
+      });
+
       test('fromTimer() creates from DateTime objects', () {
         final start = DateTime(2026, 2, 9, 10, 0);
         final end = DateTime(2026, 2, 9, 11, 30);
@@ -47,6 +61,20 @@ void main() {
         expect(worklog.startTime.hour, equals(10));
         expect(worklog.endTime.hour, equals(11));
         expect(worklog.duration.inMinutes, equals(90));
+      });
+
+      test('fromTimer() can create orphan worklog without taskId', () {
+        final start = DateTime(2026, 2, 9, 10, 0);
+        final end = DateTime(2026, 2, 9, 11, 30);
+
+        final worklog = WorklogDocument.fromTimer(
+          clock: clock,
+          start: start,
+          end: end,
+        );
+
+        expect(worklog.taskId, isEmpty);
+        expect(worklog.isOrphan, isTrue);
       });
 
       test('constructor creates empty document', () {
@@ -119,6 +147,81 @@ void main() {
         );
 
         expect(worklog.date, equals('2026-02-09'));
+      });
+    });
+
+    group('orphan worklogs', () {
+      test('isOrphan returns true when taskId is empty', () {
+        final worklog = WorklogDocument(id: 'wl-1', clock: clock);
+
+        expect(worklog.isOrphan, isTrue);
+      });
+
+      test('isOrphan returns false when taskId is set', () {
+        final worklog = WorklogDocument.create(
+          clock: clock,
+          taskId: 'task-1',
+          start: DateTime.now().millisecondsSinceEpoch - 3600000,
+          end: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(worklog.isOrphan, isFalse);
+      });
+
+      test('orphan worklog can have category', () {
+        final worklog = WorklogDocument.create(
+          clock: clock,
+          start: DateTime.now().millisecondsSinceEpoch - 3600000,
+          end: DateTime.now().millisecondsSinceEpoch,
+          category: 'Working',
+        );
+
+        expect(worklog.isOrphan, isTrue);
+        expect(worklog.category, equals('Working'));
+      });
+    });
+
+    group('category', () {
+      test('category can be set on worklog', () {
+        final worklog = WorklogDocument.create(
+          clock: clock,
+          taskId: 'task-1',
+          start: DateTime.now().millisecondsSinceEpoch - 3600000,
+          end: DateTime.now().millisecondsSinceEpoch,
+          category: 'Learning',
+        );
+
+        expect(worklog.category, equals('Learning'));
+      });
+
+      test('category can be changed after creation', () {
+        final worklog = WorklogDocument.create(
+          clock: clock,
+          taskId: 'task-1',
+          start: DateTime.now().millisecondsSinceEpoch - 3600000,
+          end: DateTime.now().millisecondsSinceEpoch,
+        );
+
+        expect(worklog.category, isNull);
+
+        worklog.category = 'Meetings';
+
+        expect(worklog.category, equals('Meetings'));
+      });
+
+      test('fromTimer() accepts category', () {
+        final start = DateTime(2026, 2, 9, 10, 0);
+        final end = DateTime(2026, 2, 9, 11, 30);
+
+        final worklog = WorklogDocument.fromTimer(
+          clock: clock,
+          taskId: 'task-1',
+          start: start,
+          end: end,
+          category: 'Working',
+        );
+
+        expect(worklog.category, equals('Working'));
       });
     });
 
@@ -204,6 +307,26 @@ void main() {
         expect(model.isSyncedToJira, isTrue);
         expect(model.isDeleted, isFalse);
         expect(model.formattedDuration, equals('1h 30m'));
+        expect(model.category, isNull);
+        expect(model.isOrphan, isFalse);
+      });
+
+      test('toModel includes category and isOrphan for orphan worklogs', () {
+        final start = DateTime(2026, 2, 9, 10, 0);
+        final end = DateTime(2026, 2, 9, 11, 30);
+
+        final worklog = WorklogDocument.fromTimer(
+          clock: clock,
+          start: start,
+          end: end,
+          category: 'Working',
+        );
+
+        final model = worklog.toModel();
+
+        expect(model.taskId, isEmpty);
+        expect(model.isOrphan, isTrue);
+        expect(model.category, equals('Working'));
       });
     });
   });


### PR DESCRIPTION
## Summary

Implements category-first time tracking with orphan worklog support (AVO-015).

- **Schema v12**: `category` column on `worklogEntries`; empty `taskId` = orphan semantic
- **CRDT layer**: `WorklogDocument` gains `category` field + `isOrphan` getter; `TimerDocument` gains `category` field + backfill
- **TimerService**: `start()` and `stop()` now wire `category` through to the created worklog
- **Worklog service**: `listOrphan()` (with limit), `listByCategory()`, `assignToTask()` (inherits task category, sets jiraDirty for Jira tasks); orphan summary shows `(no task)` instead of blank
- **CLI**: `avo worklog --no-task` for orphan creation, `--orphan` filter flag (respects `--count`), `avo worklog assign <id> <task-id>`, `avo config chips` management (all args registered)
- **AvoConfig**: `categoryChips` map for per-category comment presets; `save()` creates parent directories
- **API**: `GET /api/config/category-chips?category=X` + `POST`/`DELETE` chip endpoints (in-memory config updated on change)
- **Phone dashboard**: tapping a category row shows confirmation dialog → starts timer (no task required); tap targets ≥48dp; play icon affordance; error handling
- **Phone StopTimerSheet**: task picker at top (pre-selected, filtered to today's plan + category), worklog message, mark-done, chips at bottom; loading indicator; confirmation before auto-stopping running timer; catch block in `_save()`
- **Phone settings**: chip preset management UI; dark mode compatible

## Test plan

- [ ] UAT: Tap a category on phone dashboard → confirmation dialog → timer starts (no task)
- [ ] UAT: With running timer, tap another category → confirmation to stop + save → start new
- [ ] UAT: Stop timer → StopTimerSheet shows task picker at top, chips at bottom
- [ ] UAT: Save with "No task" → orphan worklog saved with category
- [ ] UAT: Assign orphan to a Jira task → jiraDirty set, Jira syncs
- [ ] UAT: CLI `avo worklog --no-task --category Working --comment "standup"`
- [ ] UAT: CLI `avo config chips add Working standup`
- [ ] All 419 MCP/Dart tests pass (`cd mcp && dart test`)
- [ ] Flutter analyze clean (`flutter analyze phone/lib/`)

## Related

Closes #AVO-015
Requirements: `agent-teams/requirements/artifacts/2026-03-26-category-first-orphan-worklogs.md`
Implementation: `agent-teams/builder/artifacts/2026-03-26-avo-015-category-first.md`
UAT Review: `agent-teams/requirements/artifacts/2026-03-26-review-avodah-avo015.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)