### PR TITLE
feat(avo-016): enhance phone deployment detail screen — pa status parity + activity fix

### DIFF
--- a/phone/lib/models/deployment.dart
+++ b/phone/lib/models/deployment.dart
@@ -11,6 +11,11 @@ class Deployment {
   final String? error;
   final int? exitCode;
   final String? logFile;
+  final Map<String, dynamic>? rating;
+  final String? primer;
+  final String? primerPath;
+  final String? provider;
+  final int? pid;
 
   const Deployment({
     required this.deploymentId,
@@ -24,6 +29,11 @@ class Deployment {
     this.error,
     this.exitCode,
     this.logFile,
+    this.rating,
+    this.primer,
+    this.primerPath,
+    this.provider,
+    this.pid,
   });
 
   factory Deployment.fromJson(Map<String, dynamic> json) {
@@ -40,6 +50,11 @@ class Deployment {
       error: json['error'] as String?,
       exitCode: json['exit_code'] as int?,
       logFile: json['log_file'] as String?,
+      rating: json['rating'] as Map<String, dynamic>?,
+      primer: json['primer'] as String?,
+      primerPath: json['primer_path'] as String?,
+      provider: json['provider'] as String?,
+      pid: json['pid'] as int?,
     );
   }
 

--- a/phone/lib/screens/activity_timeline_screen.dart
+++ b/phone/lib/screens/activity_timeline_screen.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import '../models/activity_event.dart';
 import '../models/deployment.dart';
+import '../screens/document_viewer_screen.dart';
 import '../services/agent_api_client.dart';
 import '../utils/deploy_helpers.dart';
 import '../widgets/activity_event_tile.dart';
@@ -33,13 +33,29 @@ class _ActivityTimelineScreenState extends State<ActivityTimelineScreen> {
   String? _error;
   bool _expanded = false;
   Timer? _refreshTimer;
+  Deployment? _enrichedDeployment;
 
   @override
   void initState() {
     super.initState();
+    _loadDeploymentDetail();
     _loadEvents();
     if (widget.deployment.isRunning) {
       _scheduleRefresh();
+    }
+  }
+
+  Future<void> _loadDeploymentDetail() async {
+    try {
+      final detail =
+          await widget.client.getDeploymentDetail(widget.deployment.deploymentId);
+      if (mounted) {
+        setState(() {
+          _enrichedDeployment = detail;
+        });
+      }
+    } catch (e) {
+      // Silently ignore — header will show passed-in deployment with available fields
     }
   }
 
@@ -53,7 +69,8 @@ class _ActivityTimelineScreenState extends State<ActivityTimelineScreen> {
     _refreshTimer?.cancel();
     _refreshTimer = Timer(const Duration(seconds: 4), () async {
       await _loadEvents(background: true);
-      if (mounted && widget.deployment.isRunning) {
+      // Continue polling while the deployment is running (check enriched deployment if available)
+      if (mounted && (_enrichedDeployment?.isRunning ?? widget.deployment.isRunning)) {
         _scheduleRefresh();
       }
     });
@@ -88,7 +105,8 @@ class _ActivityTimelineScreenState extends State<ActivityTimelineScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final deployment = widget.deployment;
+    // Use enriched deployment if available, otherwise fall back to passed-in deployment
+    final deployment = _enrichedDeployment ?? widget.deployment;
 
     return Scaffold(
       appBar: AppBar(
@@ -111,7 +129,7 @@ class _ActivityTimelineScreenState extends State<ActivityTimelineScreen> {
       ),
       body: Column(
         children: [
-          _DeploymentHeader(deployment: deployment),
+          _DeploymentHeader(deployment: deployment, client: widget.client),
           if (_loading && _events.isEmpty)
             const Expanded(
               child: Center(child: CircularProgressIndicator()),
@@ -180,16 +198,27 @@ class _ActivityTimelineScreenState extends State<ActivityTimelineScreen> {
 }
 
 /// Header card with deployment metadata: status, duration, model badges,
+/// PID, provider, summary, primer/log file links, session rating,
 /// and error details section for failed/crashed deployments.
 class _DeploymentHeader extends StatelessWidget {
   final Deployment deployment;
+  final AgentApiClient client;
 
-  const _DeploymentHeader({required this.deployment});
+  const _DeploymentHeader({required this.deployment, required this.client});
+
+  void _openDocument(BuildContext context, String path, String label) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => DocumentViewerScreen(path: path, client: client),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final color = statusColor(context,deployment.status);
+    final color = statusColor(context, deployment.status);
 
     return Container(
       width: double.infinity,
@@ -216,8 +245,7 @@ class _DeploymentHeader extends StatelessWidget {
                   const SizedBox(width: 4),
                   Text(
                     deployment.status,
-                    style:
-                        theme.textTheme.bodyMedium?.copyWith(color: color),
+                    style: theme.textTheme.bodyMedium?.copyWith(color: color),
                   ),
                 ],
               ),
@@ -282,40 +310,70 @@ class _DeploymentHeader extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
             ),
           ],
+          // PID + Provider row
+          if (deployment.pid != null || deployment.provider != null) ...[
+            const SizedBox(height: 6),
+            Wrap(
+              spacing: 12,
+              runSpacing: 4,
+              children: [
+                if (deployment.pid != null)
+                  _InfoChip(
+                    icon: Icons.tag,
+                    label: 'PID: ${deployment.pid}',
+                    theme: theme,
+                  ),
+                if (deployment.provider != null)
+                  _InfoChip(
+                    icon: Icons.cloud_outlined,
+                    label: deployment.provider!,
+                    theme: theme,
+                  ),
+              ],
+            ),
+          ],
+          // Summary
+          if (deployment.summary != null && deployment.summary!.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            Text(
+              deployment.summary!,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+          // Session rating
+          if (deployment.rating != null) ...[
+            const SizedBox(height: 8),
+            _RatingSection(rating: deployment.rating!),
+          ],
           // Error details for failed/crashed
           if (deployment.isFailed &&
               (deployment.error != null || deployment.exitCode != null)) ...[
             const SizedBox(height: 10),
             _ErrorDetailsSection(deployment: deployment),
           ],
-          // Log file link
-          if (deployment.logFile != null) ...[
+          // Primer path (tappable)
+          if (deployment.primerPath != null) ...[
             const SizedBox(height: 8),
-            GestureDetector(
-              onTap: () {
-                Clipboard.setData(ClipboardData(text: deployment.logFile!));
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Log file path copied')),
-                );
-              },
-              child: Row(
-                children: [
-                  Icon(Icons.description_outlined,
-                      size: 14, color: theme.colorScheme.primary),
-                  const SizedBox(width: 4),
-                  Expanded(
-                    child: Text(
-                      deployment.logFile!,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.primary,
-                        decoration: TextDecoration.underline,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ],
-              ),
+            _DocumentLink(
+              icon: Icons.article_outlined,
+              label: 'Primer',
+              path: deployment.primerPath!,
+              theme: theme,
+              onTap: () => _openDocument(context, deployment.primerPath!, 'Primer'),
+            ),
+          ],
+          // Log file link (tappable → DocumentViewerScreen)
+          if (deployment.logFile != null) ...[
+            const SizedBox(height: 6),
+            _DocumentLink(
+              icon: Icons.description_outlined,
+              label: 'Log',
+              path: deployment.logFile!,
+              theme: theme,
+              onTap: () => _openDocument(context, deployment.logFile!, 'Log'),
             ),
           ],
         ],
@@ -344,6 +402,180 @@ class _ModelBadge extends StatelessWidget {
         style: theme.textTheme.labelSmall?.copyWith(
           color: theme.colorScheme.onSecondaryContainer,
         ),
+      ),
+    );
+  }
+}
+
+/// Compact info chip for PID, provider, etc.
+class _InfoChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final ThemeData theme;
+
+  const _InfoChip({
+    required this.icon,
+    required this.label,
+    required this.theme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 14, color: theme.colorScheme.outline),
+        const SizedBox(width: 4),
+        Text(
+          label,
+          style: theme.textTheme.bodySmall
+              ?.copyWith(color: theme.colorScheme.outline),
+        ),
+      ],
+    );
+  }
+}
+
+/// Session rating display: overall score + optional dimension breakdown.
+class _RatingSection extends StatelessWidget {
+  final Map<String, dynamic> rating;
+
+  const _RatingSection({required this.rating});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final overall = rating['overall'];
+    final productivity = rating['productivity'];
+    final quality = rating['quality'];
+    final efficiency = rating['efficiency'];
+    final insight = rating['insight'];
+
+    final hasBreakdown =
+        productivity != null || quality != null || efficiency != null || insight != null;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.tertiaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.star, size: 16, color: theme.colorScheme.onTertiaryContainer),
+              const SizedBox(width: 4),
+              Text(
+                overall != null ? '$overall/5' : 'No rating',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.onTertiaryContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              if (rating['source'] != null) ...[
+                const SizedBox(width: 6),
+                Text(
+                  '(${rating['source']})',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onTertiaryContainer.withValues(alpha: 0.7),
+                  ),
+                ),
+              ],
+            ],
+          ),
+          if (hasBreakdown) ...[
+            const SizedBox(height: 4),
+            Wrap(
+              spacing: 8,
+              runSpacing: 2,
+              children: [
+                if (productivity != null)
+                  _RatingDim(label: 'prod', value: productivity.toString(), theme: theme),
+                if (quality != null)
+                  _RatingDim(label: 'qual', value: quality.toString(), theme: theme),
+                if (efficiency != null)
+                  _RatingDim(label: 'eff', value: efficiency.toString(), theme: theme),
+                if (insight != null)
+                  _RatingDim(label: 'ins', value: insight.toString(), theme: theme),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _RatingDim extends StatelessWidget {
+  final String label;
+  final String value;
+  final ThemeData theme;
+
+  const _RatingDim({
+    required this.label,
+    required this.value,
+    required this.theme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      '$label:$value',
+      style: theme.textTheme.labelSmall?.copyWith(
+        color: theme.colorScheme.onTertiaryContainer.withValues(alpha: 0.8),
+        fontFamily: 'monospace',
+      ),
+    );
+  }
+}
+
+/// Tappable document link that opens DocumentViewerScreen.
+class _DocumentLink extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String path;
+  final ThemeData theme;
+  final VoidCallback onTap;
+
+  const _DocumentLink({
+    required this.icon,
+    required this.label,
+    required this.path,
+    required this.theme,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Row(
+        children: [
+          Icon(icon, size: 14, color: theme.colorScheme.primary),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              path,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.primary,
+                decoration: TextDecoration.underline,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          Icon(Icons.chevron_right, size: 14, color: theme.colorScheme.outline),
+        ],
       ),
     );
   }

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -188,10 +188,21 @@ class AgentApiClient {
   }) async {
     final params = since != null ? '?since=${Uri.encodeComponent(since)}' : '';
     final response = await _get('/api/deployments/$id/activity$params');
-    final events = response['events'] as List;
+    // New servers return 'activity_events'; older servers return 'events'.
+    final events = (response['activity_events'] ?? response['events']) as List;
     return events
         .map((e) => ActivityEvent.fromJson(e as Map<String, dynamic>))
         .toList();
+  }
+
+  /// Fetch detailed deployment info including all metadata + activity events.
+  ///
+  /// Calls GET /api/deployments/<id> which returns a merged object with
+  /// full deployment metadata and the activity_events array.
+  Future<Deployment> getDeploymentDetail(String id) async {
+    final response = await _get('/api/deployments/$id');
+    // The response is the deployment object directly (not wrapped in a key).
+    return Deployment.fromJson(response);
   }
 
   // --- Teams ---


### PR DESCRIPTION
## Summary

- **Fix activity timeline**: read `activity_events` key (with fallback to `events` for older servers) so timeline shows full activity log instead of 2-3 registry events
- **Enrich Deployment model**: add optional fields (`rating`, `primer`, `primerPath`, `provider`, `pid`)
- **New `getDeploymentDetail` API method**: calls `GET /api/deployments/<id>` (PA-984 server endpoint)
- **Enhanced deployment header**: shows PID, provider, models, rating (overall + dimensions) when available
- **Document viewer**: tap log file or primer path to view content inline via documents API
- **ActivityTimelineScreen**: fetches full detail on init, passes enriched Deployment to header

## Prerequisites

- PA-984 (server side) is in `review-uat` — `GET /api/deployments/<id>` endpoint implemented
- All new fields are optional; graceful degradation for older PA server versions

## Test plan

- [ ] Run `flutter analyze` — passes with no errors
- [ ] Run `flutter test` — all tests pass
- [ ] Integration test: navigate to deployment detail on phone, verify full activity timeline visible
- [ ] Integration test: tap log file path, verify content viewer opens
- [ ] Integration test: tap primer path, verify primer content displayed
- [ ] Test with older PA server: verify no crash, shows available data

Closes AVO-016

🤖 Generated with [Claude Code](https://claude.com/claude-code)