### PR TITLE
feat(avo-020): enrich deployment tiles and header with ticket_id, objective, repo

### DIFF
--- a/phone/lib/models/deployment.dart
+++ b/phone/lib/models/deployment.dart
@@ -16,6 +16,9 @@ class Deployment {
   final String? primerPath;
   final String? provider;
   final int? pid;
+  final String? ticketId;
+  final String? objective;
+  final String? repo;
 
   const Deployment({
     required this.deploymentId,
@@ -34,6 +37,9 @@ class Deployment {
     this.primerPath,
     this.provider,
     this.pid,
+    this.ticketId,
+    this.objective,
+    this.repo,
   });
 
   factory Deployment.fromJson(Map<String, dynamic> json) {
@@ -55,6 +61,9 @@ class Deployment {
       primerPath: json['primer_path'] as String?,
       provider: json['provider'] as String?,
       pid: json['pid'] as int?,
+      ticketId: json['ticket_id'] as String?,
+      objective: json['objective'] as String?,
+      repo: json['repo'] as String?,
     );
   }
 

--- a/phone/lib/screens/activity_timeline_screen.dart
+++ b/phone/lib/screens/activity_timeline_screen.dart
@@ -310,8 +310,11 @@ class _DeploymentHeader extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
             ),
           ],
-          // PID + Provider row
-          if (deployment.pid != null || deployment.provider != null) ...[
+          // PID + Provider + ticketId + repo row
+          if (deployment.pid != null ||
+              deployment.provider != null ||
+              deployment.ticketId != null ||
+              deployment.repo != null) ...[
             const SizedBox(height: 6),
             Wrap(
               spacing: 12,
@@ -329,6 +332,18 @@ class _DeploymentHeader extends StatelessWidget {
                     label: deployment.provider!,
                     theme: theme,
                   ),
+                if (deployment.ticketId != null)
+                  _InfoChip(
+                    icon: Icons.confirmation_number_outlined,
+                    label: deployment.ticketId!,
+                    theme: theme,
+                  ),
+                if (deployment.repo != null)
+                  _InfoChip(
+                    icon: Icons.folder_outlined,
+                    label: deployment.repo!,
+                    theme: theme,
+                  ),
               ],
             ),
           ],
@@ -337,6 +352,17 @@ class _DeploymentHeader extends StatelessWidget {
             const SizedBox(height: 6),
             Text(
               deployment.summary!,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+          // Objective (running deployments)
+          if (deployment.objective != null && deployment.objective!.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            Text(
+              deployment.objective!,
               style: theme.textTheme.bodySmall
                   ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
               maxLines: 2,

--- a/phone/lib/screens/deployment_screen.dart
+++ b/phone/lib/screens/deployment_screen.dart
@@ -315,6 +315,11 @@ class _DeploymentTile extends StatelessWidget {
 
   Widget _buildSubtitle(ThemeData theme, Color statusColor) {
     final parts = <InlineSpan>[
+      if (deployment.ticketId != null)
+        TextSpan(
+          text: '${deployment.ticketId} \u00b7 ',
+          style: theme.textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600),
+        ),
       TextSpan(
         text: deployment.team,
         style: theme.textTheme.bodySmall,
@@ -348,8 +353,17 @@ class _DeploymentTile extends StatelessWidget {
       overflow: TextOverflow.ellipsis,
     );
 
+    // For running deployments, show objective; for completed, show summary.
+    final objective = deployment.isRunning ? deployment.objective : null;
     final summary = deployment.summary;
-    if (summary == null || summary.isEmpty) return firstLine;
+
+    if ((objective == null || objective.isEmpty) &&
+        (summary == null || summary.isEmpty)) {
+      return firstLine;
+    }
+
+    final secondLine = deployment.isRunning ? objective : summary;
+    if (secondLine == null || secondLine.isEmpty) return firstLine;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -357,7 +371,7 @@ class _DeploymentTile extends StatelessWidget {
       children: [
         firstLine,
         Text(
-          summary,
+          secondLine,
           maxLines: 2,
           overflow: TextOverflow.ellipsis,
           style: theme.textTheme.bodySmall


### PR DESCRIPTION
## Summary

- Add `ticketId`, `objective`, `repo` fields to `Deployment` model + `fromJson()` parsing
- Enrich running deployment list tiles: show ticketId as bold prefix, objective as 2-line subtitle
- Enrich deployment detail header: ticketId + repo as _InfoChip, objective text section
- All fields null-safe — graceful handling when absent
- No regression on completed deployment summary display

## Ticket

AVO-020 — Enrich running deployment list tiles and detail header

## Dependencies

- PA-1005 (PR #33 on personal-assistant) must be merged for enriched data to appear
- Phone handles missing fields gracefully — no crash without server update

## Files Changed

- `phone/lib/models/deployment.dart` — 3 new optional fields + fromJson
- `phone/lib/screens/deployment_screen.dart` — ticketId prefix + objective in subtitle
- `phone/lib/screens/activity_timeline_screen.dart` — InfoChips for ticketId/repo + objective text

## Test plan

- [x] `flutter analyze` passes (no issues)
- [ ] Visual verification: running deployment with ticket+objective shows enriched tile
- [ ] Visual verification: completed deployment still shows summary (no regression)
- [ ] Visual verification: deployment with no ticket/objective/repo shows cleanly
- [ ] End-to-end: deploy with `--objective` and verify phone shows it (requires PA-1005 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)