### PR TITLE
feat(avo-013): connection indicator + settings on all tabs, version in settings

### DIFF
--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -19,6 +19,7 @@ import 'services/review_provider.dart';
 import 'services/team_browser_provider.dart';
 import 'settings/settings_screen.dart';
 import 'storage/database.dart';
+import 'widgets/connection_indicator.dart';
 
 void main() {
   runApp(const AvodahViewerApp());
@@ -242,7 +243,7 @@ class _HomeShellState extends State<_HomeShell> {
       body: IndexedStack(
         index: _currentIndex,
         children: [
-          KanbanBoardScreen(boardProvider: widget.boardProvider),
+          KanbanBoardScreen(boardProvider: widget.boardProvider, dashboardProvider: widget.dashboardProvider),
           DashboardScreen(
             dashboardProvider: widget.dashboardProvider,
             writeService: widget.writeService,
@@ -253,6 +254,13 @@ class _HomeShellState extends State<_HomeShell> {
             appBar: AppBar(
               title: const Text('Agent Review'),
               actions: [
+                ValueListenableBuilder<SyncConnectionState>(
+                  valueListenable: widget.dashboardProvider.connectionState,
+                  builder: (_, state, __) => Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    child: ConnectionIndicator(state: state),
+                  ),
+                ),
                 IconButton(
                   icon: const Icon(Icons.settings),
                   onPressed: () => Navigator.push(
@@ -272,6 +280,21 @@ class _HomeShellState extends State<_HomeShell> {
             appBar: AppBar(
               title: const Text('Deployments'),
               actions: [
+                ValueListenableBuilder<SyncConnectionState>(
+                  valueListenable: widget.dashboardProvider.connectionState,
+                  builder: (_, state, __) => Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    child: ConnectionIndicator(state: state),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.settings),
+                  onPressed: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const SettingsScreen()),
+                  ),
+                ),
                 IconButton(
                   icon: const Icon(Icons.refresh),
                   onPressed: () => widget.deploymentProvider.refresh(),
@@ -287,6 +310,21 @@ class _HomeShellState extends State<_HomeShell> {
             appBar: AppBar(
               title: const Text('Teams'),
               actions: [
+                ValueListenableBuilder<SyncConnectionState>(
+                  valueListenable: widget.dashboardProvider.connectionState,
+                  builder: (_, state, __) => Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    child: ConnectionIndicator(state: state),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.settings),
+                  onPressed: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const SettingsScreen()),
+                  ),
+                ),
                 IconButton(
                   icon: const Icon(Icons.timer_outlined),
                   tooltip: 'PA Timers',

--- a/phone/lib/screens/kanban_board_screen.dart
+++ b/phone/lib/screens/kanban_board_screen.dart
@@ -4,9 +4,13 @@ import 'package:flutter/material.dart';
 
 import '../models/ticket.dart';
 import '../services/board_provider.dart';
+import '../services/local_dashboard_provider.dart';
 import '../widgets/board_column.dart';
 import '../widgets/bulletin_banner.dart';
+import '../widgets/connection_indicator.dart';
 import '../widgets/ticket_card.dart';
+import '../services/crdt_sync_service.dart';
+import '../settings/settings_screen.dart';
 import 'create_bulletin_screen.dart';
 import 'create_ticket_screen.dart';
 import 'ticket_detail_screen.dart';
@@ -24,8 +28,9 @@ import 'ticket_detail_screen.dart';
 /// - AppBar overflow menu includes "Create Bulletin" → [CreateBulletinScreen]
 class KanbanBoardScreen extends StatefulWidget {
   final BoardProvider boardProvider;
+  final LocalDashboardProvider dashboardProvider;
 
-  const KanbanBoardScreen({super.key, required this.boardProvider});
+  const KanbanBoardScreen({super.key, required this.boardProvider, required this.dashboardProvider});
 
   @override
   State<KanbanBoardScreen> createState() => _KanbanBoardScreenState();
@@ -105,6 +110,20 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
       appBar: AppBar(
         title: const Text('Kanban Board'),
         actions: [
+          ValueListenableBuilder<SyncConnectionState>(
+            valueListenable: widget.dashboardProvider.connectionState,
+            builder: (_, state, __) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: ConnectionIndicator(state: state),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const SettingsScreen()),
+            ),
+          ),
           IconButton(
             icon: Icon(
               provider.showTerminal

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:avodah_core/version.dart';
 import '../services/agent_api_client.dart';
 
 const kServerUrlKey = 'sync_server_url';
@@ -330,6 +331,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   : _buildChipsList(),
             ),
           ],
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.info_outline),
+            title: const Text('About'),
+            subtitle: Text('Avodah v$avodahVersion'),
+          ),
           const SizedBox(height: 32),
         ],
       ),


### PR DESCRIPTION
## Summary
- Add ConnectionIndicator (green/amber/red sync status dot) to ALL 5 tab AppBars (was only on Dashboard)
- Add Settings gear icon to ALL 5 tab AppBars (was only on Dashboard + Agent Review)
- Add "About" section to Settings screen showing `Avodah v{version}`

## Changes
- `phone/lib/main.dart` — Pass dashboardProvider to KanbanBoardScreen; add ConnectionIndicator + settings to Agent Review, Deployments, Teams tabs
- `phone/lib/screens/kanban_board_screen.dart` — Accept dashboardProvider; add ConnectionIndicator + settings to Kanban AppBar
- `phone/lib/settings/settings_screen.dart` — Add About ListTile with version from avodah_core

## Ticket
AVO-013

## Test plan
- [ ] Verify connection indicator (green dot) appears on all 5 tabs
- [ ] Verify settings icon appears on all 5 tabs and navigates to Settings
- [ ] Verify version string displayed in Settings screen
- [ ] Verify existing tab-specific actions (refresh, timers, search) still work
- [ ] Flutter analyze passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)