### PR TITLE
feat(phone): fix deploy-from-phone objective pre-fill and UX (#AVO-029)

### DIFF
--- a/phone/lib/models/deploy_result.dart
+++ b/phone/lib/models/deploy_result.dart
@@ -1,23 +1,30 @@
 /// Result of a PA deployment trigger (POST /api/deploy).
+///
+/// Pa-serve returns `{status: "pending"|"failed", reason?: string}`.
+/// Dart AgentApiService returns `{started: bool, deployment_id: string}`.
 class DeployResult {
   final String deploymentId;
   final bool started;
   final String team;
   final String mode;
+  final String reason;
 
   const DeployResult({
     required this.deploymentId,
     required this.started,
     required this.team,
     required this.mode,
+    this.reason = '',
   });
 
   factory DeployResult.fromJson(Map<String, dynamic> json) {
     return DeployResult(
-      deploymentId: (json['deployment_id'] ?? json['deploy_id']) as String? ?? '',
-      started: json['started'] as bool? ?? json['status'] == 'launched',
+      deploymentId:
+          (json['deployment_id'] ?? json['deploy_id']) as String? ?? '',
+      started: json['started'] as bool? ?? json['status'] != 'failed',
       team: json['team'] as String? ?? '',
       mode: json['mode'] as String? ?? '',
+      reason: json['reason'] as String? ?? '',
     );
   }
 }

--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -213,9 +213,12 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
             );
             if (!mounted) return;
             if (!result.started) {
+              final detail = result.reason.isNotEmpty
+                  ? result.reason
+                  : 'server did not start deployment';
               messenger.showSnackBar(SnackBar(
                 content: Text(
-                  'Deploy failed: server did not start deployment'
+                  'Deploy failed: $detail'
                   '${result.deploymentId.isNotEmpty ? ' (${result.deploymentId})' : ''}',
                 ),
                 backgroundColor: errorColor,

--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -178,9 +178,12 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
     final routing = _deployRouting!;
     final paTeams = routing.toPaTeams();
 
-    // Auto-suggest team from ticket.assignee.
+    // Auto-suggest team: ticket.team first, then fall back to ticket.assignee.
     String? initialTeam;
-    if (ticket.assignee != null &&
+    if (ticket.team != null &&
+        paTeams.any((t) => t.name == ticket.team)) {
+      initialTeam = ticket.team;
+    } else if (ticket.assignee != null &&
         paTeams.any((t) => t.name == ticket.assignee)) {
       initialTeam = ticket.assignee;
     }

--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -5,6 +5,7 @@ import '../models/deploy_routing.dart';
 import '../models/deployment.dart';
 import '../models/ticket.dart';
 import '../screens/document_viewer_screen.dart';
+import '../services/agent_api_client.dart';
 import '../services/board_provider.dart';
 import '../widgets/deploy_sheet.dart';
 import '../widgets/status_picker_sheet.dart';
@@ -184,8 +185,8 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
       initialTeam = ticket.assignee;
     }
 
-    // Pre-fill objective as "{id}: {title}" and repo from project.
-    final initialObjective = '${ticket.id}: ${ticket.title}';
+    // Pre-fill objective with ticket ID only (avoids validation issues with special chars in title).
+    final initialObjective = ticket.id;
     final initialRepo = ticket.project.isNotEmpty ? ticket.project : null;
 
     showModalBottomSheet<void>(
@@ -278,8 +279,9 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
             ));
           } catch (e) {
             if (mounted) {
+              final message = e is AgentApiException ? e.message : 'Deploy failed: $e';
               messenger.showSnackBar(SnackBar(
-                content: Text('Deploy failed: $e'),
+                content: Text(message),
                 backgroundColor: errorColor,
               ));
             }

--- a/phone/lib/widgets/deploy_sheet.dart
+++ b/phone/lib/widgets/deploy_sheet.dart
@@ -63,6 +63,7 @@ class _DeploySheetState extends State<DeploySheet> {
   String? _selectedMode;
   String? _selectedRepo;
   bool _deploying = false;
+  bool _objectiveTouched = false;
   late final TextEditingController _objectiveController;
 
   @override
@@ -70,6 +71,7 @@ class _DeploySheetState extends State<DeploySheet> {
     super.initState();
     _objectiveController =
         TextEditingController(text: widget.initialObjective ?? '');
+    _objectiveController.addListener(_onObjectiveChanged);
 
     // Pre-select repo if provided and it exists in the list.
     if (widget.initialRepo != null &&
@@ -101,6 +103,27 @@ class _DeploySheetState extends State<DeploySheet> {
     if (paTeam != null && paTeam.deployModes.length == 1) {
       _selectedMode = paTeam.deployModes.first.id;
     }
+  }
+
+  void _onObjectiveChanged() {
+    if (!_objectiveTouched && _objectiveController.text.isNotEmpty) {
+      _objectiveTouched = true;
+    }
+    setState(() {});
+  }
+
+  /// Sanitize objective text: replace & with 'and', strip blocked chars.
+  String _sanitizeObjective(String raw) {
+    return raw
+        .replaceAll('&', 'and')
+        .replaceAll(RegExp(r'[`;|$\\><]'), '')
+        .trim();
+  }
+
+  /// Returns true if the objective text contains any blocked characters.
+  bool get _objectiveHasBlockedChars {
+    final text = _objectiveController.text;
+    return RegExp(r'[&`;|$\\><]').hasMatch(text);
   }
 
   PaTeam? _paTeamFor(String teamName) {
@@ -215,6 +238,9 @@ class _DeploySheetState extends State<DeploySheet> {
                       horizontal: 12,
                       vertical: 10,
                     ),
+                    errorText: _objectiveHasBlockedChars
+                        ? 'Invalid characters detected (will be auto-corrected on send)'
+                        : null,
                   ),
                 ),
                 const SizedBox(height: 20),
@@ -292,10 +318,11 @@ class _DeploySheetState extends State<DeploySheet> {
     if (!_canLaunch) return;
     setState(() => _deploying = true);
     try {
+      final sanitizedObjective = _sanitizeObjective(_objectiveController.text);
       await widget.onDeploy(
         _selectedTeam!,
         _selectedMode!,
-        _objectiveController.text.trim(),
+        sanitizedObjective,
         repo: _selectedRepo,
       );
     } finally {


### PR DESCRIPTION
## Summary
- Pre-fill deploy objective with ticket ID only (instead of `{id}: {title}`) to avoid server-side character validation failures
- Auto-sanitize user-typed objective text (replace `&` with `and`, strip other blocked chars)
- Show real-time validation hint when objective contains blocked characters
- Improve error display with user-friendly messages instead of raw `AgentApiException.toString()`
- Pre-select deploy team from `ticket.team` field when available (falls back to `ticket.assignee`)

## Test plan
- [ ] Deploy ticket AVO-001 (has `&` in title) — should pre-fill objective as `AVO-001` and succeed
- [ ] Manually type `test & deploy` in objective — should auto-sanitize to `test and deploy`
- [ ] Type `test;ls` in objective — validation hint should appear
- [ ] Trigger a deploy failure — error message should be human-readable
- [ ] Deploy ticket with `team: builder` — builder should be pre-selected
- [ ] FAB deploy still works (no regression)

Closes AVO-029

🤖 Generated with [Claude Code](https://claude.com/claude-code)