### PR TITLE
feat(avo-005): Jira-style inline field editing for ticket detail screen

### DIFF
--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
 import '../models/deploy_routing.dart';
@@ -112,6 +113,12 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
         _ticket = updated;
         _savingFields.remove(field);
       });
+      // NF5: announce to screen reader
+      SemanticsService.sendAnnouncement(
+        View.of(context),
+        '${_fieldLabel(field)} saved',
+        Directionality.of(context),
+      );
       // Brief success feedback via snackbar
       messenger.showSnackBar(
         SnackBar(
@@ -842,28 +849,31 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
           ),
           if (ticket.team != null || ticket.assignee != null) ...[
             const SizedBox(height: 10),
-            // Team row — tappable
+            // Team row — tappable (min 48dp tall for tap target)
             if (ticket.team != null)
-              _FieldSavingIndicator(
-                isSaving: _savingFields.contains('team'),
-                child: Semantics(
-                  label: 'Team: ${ticket.team}. Tap to change.',
-                  button: true,
-                  child: InkWell(
-                    onTap: _savingFields.contains('team')
-                        ? null
-                        : () => _openTeamSheet(ticket),
-                    borderRadius: BorderRadius.circular(8),
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 4),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(Icons.group_outlined,
-                              size: 14, color: theme.colorScheme.outline),
-                          const SizedBox(width: 4),
-                          Text(ticket.team!, style: theme.textTheme.bodySmall),
-                        ],
+              ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 48),
+                child: _FieldSavingIndicator(
+                  isSaving: _savingFields.contains('team'),
+                  child: Semantics(
+                    label: 'Team: ${ticket.team}. Tap to change.',
+                    button: true,
+                    child: InkWell(
+                      onTap: _savingFields.contains('team')
+                          ? null
+                          : () => _openTeamSheet(ticket),
+                      borderRadius: BorderRadius.circular(8),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 4),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.group_outlined,
+                                size: 14, color: theme.colorScheme.outline),
+                            const SizedBox(width: 4),
+                            Text(ticket.team!, style: theme.textTheme.bodySmall),
+                          ],
+                        ),
                       ),
                     ),
                   ),
@@ -871,28 +881,31 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
               ),
             if (ticket.team != null && ticket.assignee != null)
               const SizedBox(width: 16),
-            // Assignee row — tappable
+            // Assignee row — tappable (min 48dp tall for tap target)
             if (ticket.assignee != null)
-              _FieldSavingIndicator(
-                isSaving: _savingFields.contains('assignee'),
-                child: Semantics(
-                  label: 'Assignee: ${ticket.assignee}. Tap to change.',
-                  button: true,
-                  child: InkWell(
-                    onTap: _savingFields.contains('assignee')
-                        ? null
-                        : () => _openAssigneeSheet(ticket),
-                    borderRadius: BorderRadius.circular(8),
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 4),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(Icons.person_outline,
-                              size: 14, color: theme.colorScheme.outline),
-                          const SizedBox(width: 4),
-                          _AssigneeText(assignee: ticket.assignee!),
-                        ],
+              ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 48),
+                child: _FieldSavingIndicator(
+                  isSaving: _savingFields.contains('assignee'),
+                  child: Semantics(
+                    label: 'Assignee: ${ticket.assignee}. Tap to change.',
+                    button: true,
+                    child: InkWell(
+                      onTap: _savingFields.contains('assignee')
+                          ? null
+                          : () => _openAssigneeSheet(ticket),
+                      borderRadius: BorderRadius.circular(8),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 4),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.person_outline,
+                                size: 14, color: theme.colorScheme.outline),
+                            const SizedBox(width: 4),
+                            _AssigneeText(assignee: ticket.assignee!),
+                          ],
+                        ),
                       ),
                     ),
                   ),
@@ -970,12 +983,22 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
               ),
             ),
           ),
-          if (ticket.comments.isNotEmpty) ...[
-            const SizedBox(height: 16),
-            _SectionLabel('Comments'),
-            const SizedBox(height: 6),
+          const SizedBox(height: 16),
+          _SectionLabel('Comments'),
+          const SizedBox(height: 6),
+          if (ticket.comments.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                'No comments yet.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.outline,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            )
+          else
             ...ticket.comments.map((c) => _buildCommentItem(c)),
-          ],
           const SizedBox(height: 16),
           Text(
             'Created ${_formatDate(ticket.createdAt)}'

--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -7,7 +7,10 @@ import '../models/ticket.dart';
 import '../screens/document_viewer_screen.dart';
 import '../services/board_provider.dart';
 import '../widgets/deploy_sheet.dart';
+import '../widgets/estimate_picker_sheet.dart';
+import '../widgets/priority_picker_sheet.dart';
 import '../widgets/status_picker_sheet.dart';
+import '../widgets/text_input_sheet.dart';
 import 'activity_timeline_screen.dart';
 
 /// Full ticket detail view with read and edit modes.
@@ -36,8 +39,6 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
   Ticket? _ticket;
   bool _loading = true;
   String? _error;
-  bool _editMode = false;
-  bool _saving = false;
   bool _submittingComment = false;
 
   // Deploy state
@@ -45,14 +46,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
   DateTime? _deployRoutingFetchedAt;
   bool _fetchingRouting = false;
 
-  // Edit state
-  String _editStatus = '';
-  String _editPriority = 'medium';
-  String _editEstimate = 'S';
-  List<String> _editTags = [];
-  final _teamController = TextEditingController();
-  final _assigneeController = TextEditingController();
-  final _tagInputController = TextEditingController();
+  // Comment input
   final _commentController = TextEditingController();
 
   @override
@@ -63,9 +57,6 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
 
   @override
   void dispose() {
-    _teamController.dispose();
-    _assigneeController.dispose();
-    _tagInputController.dispose();
     _commentController.dispose();
     super.dispose();
   }
@@ -94,50 +85,86 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
     }
   }
 
-  void _initEditFields(Ticket ticket) {
-    _editStatus = ticket.status;
-    _editPriority = ticket.priority;
-    _editEstimate = ticket.estimate ?? 'S';
-    _teamController.text = ticket.team ?? '';
-    _assigneeController.text = ticket.assignee ?? '';
-    _editTags = List.from(ticket.tags);
+  // Phase 1: open sheet handlers (save wiring comes in Phase 2)
+
+  void _openStatusPicker(Ticket ticket) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (_) => StatusPickerSheet(
+        currentStatus: ticket.status,
+        onSelect: (newStatus) {
+          Navigator.pop(context);
+          // Phase 2: _saveField('status', newStatus);
+        },
+      ),
+    );
   }
 
-  void _toggleEditMode() {
-    if (_ticket == null) return;
-    setState(() {
-      _editMode = !_editMode;
-      if (_editMode) _initEditFields(_ticket!);
-    });
+  void _openPriorityPicker(Ticket ticket) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (_) => PriorityPickerSheet(
+        currentPriority: ticket.priority,
+        onSelect: (newPriority) {
+          Navigator.pop(context);
+          // Phase 2: _saveField('priority', newPriority);
+        },
+      ),
+    );
   }
 
-  Future<void> _save() async {
-    if (_ticket == null) return;
-    setState(() => _saving = true);
-    try {
-      final updates = <String, dynamic>{
-        'status': _editStatus,
-        'priority': _editPriority,
-        'estimate': _editEstimate,
-        'tags': _editTags,
-      };
-      final team = _teamController.text.trim();
-      final assignee = _assigneeController.text.trim();
-      if (team.isNotEmpty) updates['team'] = team;
-      if (assignee.isNotEmpty) updates['assignee'] = assignee;
+  void _openEstimatePicker(Ticket ticket) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (_) => EstimatePickerSheet(
+        currentEstimate: ticket.estimate ?? 'S',
+        onSelect: (newEstimate) {
+          Navigator.pop(context);
+          // Phase 2: _saveField('estimate', newEstimate);
+        },
+      ),
+    );
+  }
 
-      await widget.boardProvider.client.updateTicket(_ticket!.id, updates);
-      if (mounted) {
-        Navigator.of(context).pop();
-      }
-    } catch (e) {
-      if (mounted) {
-        setState(() => _saving = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Save failed: $e')),
-        );
-      }
-    }
+  void _openTeamSheet(Ticket ticket) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => TextInputSheet(
+        label: 'Team',
+        initialValue: ticket.team,
+        onConfirm: (value) {
+          // Phase 2: _saveField('team', value);
+        },
+      ),
+    );
+  }
+
+  void _openAssigneeSheet(Ticket ticket) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => TextInputSheet(
+        label: 'Assignee',
+        initialValue: ticket.assignee,
+        onConfirm: (value) {
+          // Phase 2: _saveField('assignee', value);
+        },
+      ),
+    );
+  }
+
+  void _openTagSheet(Ticket ticket) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => _TagSheet(
+        tags: List.from(ticket.tags),
+        onConfirm: (tags) {
+          // Phase 2: _saveField('tags', tags);
+        },
+      ),
+    );
   }
 
   Future<void> _onDeploy() async {
@@ -543,28 +570,8 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
                 : IconButton(
                     icon: const Icon(Icons.rocket_launch_outlined),
                     tooltip: 'Deploy agent',
-                    onPressed: _editMode ? null : _onDeploy,
+                    onPressed: _onDeploy,
                   ),
-            IconButton(
-              icon: Icon(_editMode ? Icons.close : Icons.edit_outlined),
-              tooltip: _editMode ? 'Cancel edit' : 'Edit',
-              onPressed: _toggleEditMode,
-            ),
-            if (_editMode)
-              _saving
-                  ? const Padding(
-                      padding: EdgeInsets.symmetric(horizontal: 16),
-                      child: SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      ),
-                    )
-                  : IconButton(
-                      icon: const Icon(Icons.check),
-                      tooltip: 'Save',
-                      onPressed: _save,
-                    ),
           ],
         ],
       ),
@@ -595,7 +602,6 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
       );
     }
     if (_ticket == null) return const SizedBox.shrink();
-    if (_editMode) return _buildEditView(context);
     return Column(
       children: [
         Expanded(child: _buildReadView(context)),
@@ -622,32 +628,88 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
             spacing: 6,
             runSpacing: 6,
             children: [
-              _StatusChip(status: ticket.status),
-              _PriorityChip(priority: ticket.priority),
+              // Status — tappable
+              Semantics(
+                label: 'Status: ${statusLabel(ticket.status)}. Tap to change.',
+                button: true,
+                child: InkWell(
+                  onTap: () => _openStatusPicker(ticket),
+                  borderRadius: BorderRadius.circular(12),
+                  child: _StatusChip(status: ticket.status),
+                ),
+              ),
+              // Priority — tappable
+              Semantics(
+                label: 'Priority: ${priorityLabel(ticket.priority)}. Tap to change.',
+                button: true,
+                child: InkWell(
+                  onTap: () => _openPriorityPicker(ticket),
+                  borderRadius: BorderRadius.circular(12),
+                  child: _PriorityChip(priority: ticket.priority),
+                ),
+              ),
               if (ticket.type != null) _InfoChip(label: ticket.type!),
+              // Estimate — tappable
               if (ticket.estimate != null)
-                _InfoChip(label: ticket.estimate!),
+                Semantics(
+                  label: 'Estimate: ${ticket.estimate}. Tap to change.',
+                  button: true,
+                  child: InkWell(
+                    onTap: () => _openEstimatePicker(ticket),
+                    borderRadius: BorderRadius.circular(12),
+                    child: _InfoChip(label: ticket.estimate!),
+                  ),
+                ),
             ],
           ),
           if (ticket.team != null || ticket.assignee != null) ...[
             const SizedBox(height: 10),
-            Row(
-              children: [
-                if (ticket.team != null) ...[
-                  Icon(Icons.group_outlined,
-                      size: 14, color: theme.colorScheme.outline),
-                  const SizedBox(width: 4),
-                  Text(ticket.team!, style: theme.textTheme.bodySmall),
-                  const SizedBox(width: 16),
-                ],
-                if (ticket.assignee != null) ...[
-                  Icon(Icons.person_outline,
-                      size: 14, color: theme.colorScheme.outline),
-                  const SizedBox(width: 4),
-                  _AssigneeText(assignee: ticket.assignee!),
-                ],
-              ],
-            ),
+            // Team row — tappable
+            if (ticket.team != null)
+              Semantics(
+                label: 'Team: ${ticket.team}. Tap to change.',
+                button: true,
+                child: InkWell(
+                  onTap: () => _openTeamSheet(ticket),
+                  borderRadius: BorderRadius.circular(8),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.group_outlined,
+                            size: 14, color: theme.colorScheme.outline),
+                        const SizedBox(width: 4),
+                        Text(ticket.team!, style: theme.textTheme.bodySmall),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            if (ticket.team != null && ticket.assignee != null)
+              const SizedBox(width: 16),
+            // Assignee row — tappable
+            if (ticket.assignee != null)
+              Semantics(
+                label: 'Assignee: ${ticket.assignee}. Tap to change.',
+                button: true,
+                child: InkWell(
+                  onTap: () => _openAssigneeSheet(ticket),
+                  borderRadius: BorderRadius.circular(8),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.person_outline,
+                            size: 14, color: theme.colorScheme.outline),
+                        const SizedBox(width: 4),
+                        _AssigneeText(assignee: ticket.assignee!),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
           ],
           if (ticket.summary != null && ticket.summary!.isNotEmpty) ...[
             const SizedBox(height: 16),
@@ -681,23 +743,40 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
               ),
             ),
           ],
-          if (ticket.tags.isNotEmpty) ...[
-            const SizedBox(height: 16),
-            _SectionLabel('Tags'),
-            const SizedBox(height: 4),
-            Wrap(
-              spacing: 4,
-              runSpacing: 4,
-              children: ticket.tags
-                  .map((tag) => Chip(
-                        label: Text(tag),
-                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                        visualDensity: VisualDensity.compact,
-                        padding: EdgeInsets.zero,
-                      ))
-                  .toList(),
+          // Tags — tappable
+          Semantics(
+            label: 'Tags: ${ticket.tags.join(", ")}. Tap to change.',
+            button: true,
+            child: InkWell(
+              onTap: () => _openTagSheet(ticket),
+              borderRadius: BorderRadius.circular(8),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (ticket.tags.isNotEmpty) ...[
+                      _SectionLabel('Tags'),
+                      const SizedBox(height: 4),
+                      Wrap(
+                        spacing: 4,
+                        runSpacing: 4,
+                        children: ticket.tags
+                            .map((tag) => Chip(
+                                  label: Text(tag),
+                                  materialTapTargetSize:
+                                      MaterialTapTargetSize.shrinkWrap,
+                                  visualDensity: VisualDensity.compact,
+                                  padding: EdgeInsets.zero,
+                                ))
+                            .toList(),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
             ),
-          ],
+          ),
           if (ticket.comments.isNotEmpty) ...[
             const SizedBox(height: 16),
             _SectionLabel('Comments'),
@@ -752,130 +831,6 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
                   ),
           ],
         ),
-      ),
-    );
-  }
-
-  Widget _buildEditView(BuildContext context) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _SectionLabel('Status'),
-          const SizedBox(height: 6),
-          GestureDetector(
-            onTap: () => showModalBottomSheet<void>(
-              context: context,
-              builder: (_) => StatusPickerSheet(
-                currentStatus: _editStatus,
-                onSelect: (s) {
-                  Navigator.of(context).pop();
-                  setState(() => _editStatus = s);
-                },
-              ),
-            ),
-            child: _StatusChip(status: _editStatus),
-          ),
-          const SizedBox(height: 16),
-          _SectionLabel('Priority'),
-          const SizedBox(height: 6),
-          DropdownButton<String>(
-            value: _editPriority,
-            isDense: true,
-            items: ['critical', 'high', 'medium', 'low']
-                .map((p) => DropdownMenuItem(value: p, child: Text(p)))
-                .toList(),
-            onChanged: (p) {
-              if (p != null) setState(() => _editPriority = p);
-            },
-          ),
-          const SizedBox(height: 16),
-          _SectionLabel('Estimate'),
-          const SizedBox(height: 6),
-          DropdownButton<String>(
-            value: _editEstimate,
-            isDense: true,
-            items: ['XS', 'S', 'M', 'L', 'XL']
-                .map((e) => DropdownMenuItem(value: e, child: Text(e)))
-                .toList(),
-            onChanged: (e) {
-              if (e != null) setState(() => _editEstimate = e);
-            },
-          ),
-          const SizedBox(height: 16),
-          TextField(
-            controller: _teamController,
-            decoration: const InputDecoration(
-              labelText: 'Team',
-              border: OutlineInputBorder(),
-              isDense: true,
-            ),
-          ),
-          const SizedBox(height: 16),
-          TextField(
-            controller: _assigneeController,
-            decoration: const InputDecoration(
-              labelText: 'Assignee',
-              border: OutlineInputBorder(),
-              isDense: true,
-            ),
-          ),
-          const SizedBox(height: 16),
-          _SectionLabel('Tags'),
-          const SizedBox(height: 6),
-          Wrap(
-            spacing: 4,
-            runSpacing: 4,
-            children: [
-              ..._editTags.map(
-                (tag) => Chip(
-                  label: Text(tag),
-                  onDeleted: () => setState(() => _editTags.remove(tag)),
-                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  visualDensity: VisualDensity.compact,
-                  padding: EdgeInsets.zero,
-                ),
-              ),
-              SizedBox(
-                width: 140,
-                height: 36,
-                child: TextField(
-                  controller: _tagInputController,
-                  decoration: const InputDecoration(
-                    hintText: 'Add tag…',
-                    border: OutlineInputBorder(),
-                    isDense: true,
-                    contentPadding:
-                        EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-                  ),
-                  onSubmitted: (tag) {
-                    final trimmed = tag.trim();
-                    if (trimmed.isNotEmpty && !_editTags.contains(trimmed)) {
-                      setState(() => _editTags.add(trimmed));
-                    }
-                    _tagInputController.clear();
-                  },
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 24),
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton(
-              onPressed: _saving ? null : _save,
-              child: _saving
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Text('Save Changes'),
-            ),
-          ),
-          const SizedBox(height: 16),
-        ],
       ),
     );
   }
@@ -1174,3 +1129,118 @@ class _CommentCard extends StatelessWidget {
     );
   }
 }
+
+/// Bottom sheet for managing ticket tags.
+///
+/// Shows existing tags as removable chips and an input field to add new tags.
+/// [onConfirm] is called with the final tag list when the user dismisses.
+///
+/// Usage:
+/// ```dart
+/// showModalBottomSheet<void>(
+///   context: context,
+///   builder: (_) => _TagSheet(
+///     tags: List.from(ticket.tags),
+///     onConfirm: (tags) { ... },
+///   ),
+/// );
+/// ```
+class _TagSheet extends StatefulWidget {
+  final List<String> tags;
+  final void Function(List<String> tags) onConfirm;
+
+  const _TagSheet({required this.tags, required this.onConfirm});
+
+  @override
+  State<_TagSheet> createState() => _TagSheetState();
+}
+
+class _TagSheetState extends State<_TagSheet> {
+  late List<String> _tags;
+  final _inputController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _tags = List.from(widget.tags);
+  }
+
+  @override
+  void dispose() {
+    _inputController.dispose();
+    super.dispose();
+  }
+
+  void _addTag(String tag) {
+    final trimmed = tag.trim();
+    if (trimmed.isNotEmpty && !_tags.contains(trimmed)) {
+      setState(() => _tags.add(trimmed));
+    }
+    _inputController.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 16,
+          right: 16,
+          top: 16,
+          bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'Tags',
+              style: Theme.of(context).textTheme.titleMedium
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 4,
+              runSpacing: 4,
+              children: [
+                ..._tags.map(
+                  (tag) => Chip(
+                    label: Text(tag),
+                    onDeleted: () => setState(() => _tags.remove(tag)),
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                    padding: EdgeInsets.zero,
+                  ),
+                ),
+                SizedBox(
+                  width: 140,
+                  height: 36,
+                  child: TextField(
+                    controller: _inputController,
+                    decoration: const InputDecoration(
+                      hintText: 'Add tag…',
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                      contentPadding:
+                          EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                    ),
+                    onSubmitted: _addTag,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            FilledButton(
+              onPressed: () {
+                Navigator.pop(context);
+                widget.onConfirm(_tags);
+              },
+              child: const Text('Done'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -5,6 +5,7 @@ import '../models/deploy_routing.dart';
 import '../models/deployment.dart';
 import '../models/ticket.dart';
 import '../screens/document_viewer_screen.dart';
+import '../services/agent_api_client.dart';
 import '../services/board_provider.dart';
 import '../widgets/deploy_sheet.dart';
 import '../widgets/estimate_picker_sheet.dart';
@@ -40,6 +41,9 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
   bool _loading = true;
   String? _error;
   bool _submittingComment = false;
+
+  // Per-field saving state (field name → true while saving)
+  final Set<String> _savingFields = {};
 
   // Deploy state
   DeployRouting? _deployRouting;
@@ -85,6 +89,165 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
     }
   }
 
+  // ─── Per-field save ────────────────────────────────────────────────────────
+
+  /// Saves [field] with [value] via updateTicket(), showing per-field loading
+  /// and handling errors + 409 conflicts.
+  Future<void> _saveField(String field, dynamic value) async {
+    if (_ticket == null) return;
+
+    // Prevent double-saves for the same field
+    if (_savingFields.contains(field)) return;
+
+    final messenger = ScaffoldMessenger.of(context);
+    final errorColor = Theme.of(context).colorScheme.error;
+
+    setState(() => _savingFields.add(field));
+
+    try {
+      final updated = await widget.boardProvider.client
+          .updateTicket(_ticket!.id, {field: value});
+      if (!mounted) return;
+      setState(() {
+        _ticket = updated;
+        _savingFields.remove(field);
+      });
+      // Brief success feedback via snackbar
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('${_fieldLabel(field)} saved'),
+          duration: const Duration(seconds: 1),
+        ),
+      );
+    } on AgentApiException catch (e) {
+      if (!mounted) return;
+      setState(() => _savingFields.remove(field));
+      if (e.statusCode == 409) {
+        // Conflict: fetch server version and show dialog
+        await _showConflictDialog(field, value);
+      } else {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text('Failed to save ${_fieldLabel(field)}: ${e.message}'),
+            backgroundColor: errorColor,
+            duration: const Duration(seconds: 3),
+            action: SnackBarAction(
+              label: 'Retry',
+              onPressed: () => _saveField(field, value),
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _savingFields.remove(field));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('Failed to save ${_fieldLabel(field)}: $e'),
+          backgroundColor: errorColor,
+          duration: const Duration(seconds: 3),
+          action: SnackBarAction(
+            label: 'Retry',
+            onPressed: () => _saveField(field, value),
+          ),
+        ),
+      );
+    }
+  }
+
+  String _fieldLabel(String field) {
+    switch (field) {
+      case 'status':
+        return 'Status';
+      case 'priority':
+        return 'Priority';
+      case 'estimate':
+        return 'Estimate';
+      case 'team':
+        return 'Team';
+      case 'assignee':
+        return 'Assignee';
+      case 'tags':
+        return 'Tags';
+      default:
+        return field;
+    }
+  }
+
+  /// Shows a conflict dialog offering Reload (discard local) or Force save.
+  Future<void> _showConflictDialog(String field, dynamic value) async {
+    final result = await showDialog<String>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Conflict Detected'),
+        content: Text(
+          'This ticket was updated on the server while you were editing. '
+          'What would you like to do?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, 'reload'),
+            child: const Text('Reload'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, 'force'),
+            child: const Text('Force Save'),
+          ),
+        ],
+      ),
+    );
+
+    if (!mounted || result == null) return;
+
+    if (result == 'reload') {
+      await _loadTicket();
+    } else if (result == 'force') {
+      await _forceSaveField(field, value);
+    }
+  }
+
+  /// Force-saves [field] with [value] by re-fetching the latest ticket and
+  /// retrying the update.
+  Future<void> _forceSaveField(String field, dynamic value) async {
+    if (_ticket == null) return;
+    final messenger = ScaffoldMessenger.of(context);
+    final errorColor = Theme.of(context).colorScheme.error;
+
+    setState(() => _savingFields.add(field));
+
+    try {
+      // Re-fetch latest ticket then save
+      final latest =
+          await widget.boardProvider.client.getTicket(_ticket!.id);
+      if (!mounted) return;
+      final updated = await widget.boardProvider.client.updateTicket(
+        latest.id,
+        {field: value},
+      );
+      if (!mounted) return;
+      setState(() {
+        _ticket = updated;
+        _savingFields.remove(field);
+      });
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('${_fieldLabel(field)} saved (force)'),
+          duration: const Duration(seconds: 1),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _savingFields.remove(field));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('Force save failed: $e'),
+          backgroundColor: errorColor,
+        ),
+      );
+    }
+  }
+
   // Phase 1: open sheet handlers (save wiring comes in Phase 2)
 
   void _openStatusPicker(Ticket ticket) {
@@ -94,7 +257,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
         currentStatus: ticket.status,
         onSelect: (newStatus) {
           Navigator.pop(context);
-          // Phase 2: _saveField('status', newStatus);
+          _saveField('status', newStatus);
         },
       ),
     );
@@ -107,7 +270,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
         currentPriority: ticket.priority,
         onSelect: (newPriority) {
           Navigator.pop(context);
-          // Phase 2: _saveField('priority', newPriority);
+          _saveField('priority', newPriority);
         },
       ),
     );
@@ -120,7 +283,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
         currentEstimate: ticket.estimate ?? 'S',
         onSelect: (newEstimate) {
           Navigator.pop(context);
-          // Phase 2: _saveField('estimate', newEstimate);
+          _saveField('estimate', newEstimate);
         },
       ),
     );
@@ -134,7 +297,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
         label: 'Team',
         initialValue: ticket.team,
         onConfirm: (value) {
-          // Phase 2: _saveField('team', value);
+          _saveField('team', value);
         },
       ),
     );
@@ -148,7 +311,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
         label: 'Assignee',
         initialValue: ticket.assignee,
         onConfirm: (value) {
-          // Phase 2: _saveField('assignee', value);
+          _saveField('assignee', value);
         },
       ),
     );
@@ -161,7 +324,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
       builder: (_) => _TagSheet(
         tags: List.from(ticket.tags),
         onConfirm: (tags) {
-          // Phase 2: _saveField('tags', tags);
+          _saveField('tags', tags);
         },
       ),
     );
@@ -580,7 +743,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
   }
 
   Widget _buildBody(BuildContext context) {
-    if (_loading) return const Center(child: CircularProgressIndicator());
+    if (_loading) return const _TicketSkeleton();
     if (_error != null) {
       return Center(
         child: Column(
@@ -628,36 +791,51 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
             spacing: 6,
             runSpacing: 6,
             children: [
-              // Status — tappable
-              Semantics(
-                label: 'Status: ${statusLabel(ticket.status)}. Tap to change.',
-                button: true,
-                child: InkWell(
-                  onTap: () => _openStatusPicker(ticket),
-                  borderRadius: BorderRadius.circular(12),
-                  child: _StatusChip(status: ticket.status),
+              // Status — tappable (shows spinner while saving)
+              _FieldSavingIndicator(
+                isSaving: _savingFields.contains('status'),
+                child: Semantics(
+                  label: 'Status: ${statusLabel(ticket.status)}. Tap to change.',
+                  button: true,
+                  child: InkWell(
+                    onTap: _savingFields.contains('status')
+                        ? null
+                        : () => _openStatusPicker(ticket),
+                    borderRadius: BorderRadius.circular(12),
+                    child: _StatusChip(status: ticket.status),
+                  ),
                 ),
               ),
               // Priority — tappable
-              Semantics(
-                label: 'Priority: ${priorityLabel(ticket.priority)}. Tap to change.',
-                button: true,
-                child: InkWell(
-                  onTap: () => _openPriorityPicker(ticket),
-                  borderRadius: BorderRadius.circular(12),
-                  child: _PriorityChip(priority: ticket.priority),
+              _FieldSavingIndicator(
+                isSaving: _savingFields.contains('priority'),
+                child: Semantics(
+                  label: 'Priority: ${priorityLabel(ticket.priority)}. Tap to change.',
+                  button: true,
+                  child: InkWell(
+                    onTap: _savingFields.contains('priority')
+                        ? null
+                        : () => _openPriorityPicker(ticket),
+                    borderRadius: BorderRadius.circular(12),
+                    child: _PriorityChip(priority: ticket.priority),
+                  ),
                 ),
               ),
               if (ticket.type != null) _InfoChip(label: ticket.type!),
               // Estimate — tappable
               if (ticket.estimate != null)
-                Semantics(
-                  label: 'Estimate: ${ticket.estimate}. Tap to change.',
-                  button: true,
-                  child: InkWell(
-                    onTap: () => _openEstimatePicker(ticket),
-                    borderRadius: BorderRadius.circular(12),
-                    child: _InfoChip(label: ticket.estimate!),
+                _FieldSavingIndicator(
+                  isSaving: _savingFields.contains('estimate'),
+                  child: Semantics(
+                    label: 'Estimate: ${ticket.estimate}. Tap to change.',
+                    button: true,
+                    child: InkWell(
+                      onTap: _savingFields.contains('estimate')
+                          ? null
+                          : () => _openEstimatePicker(ticket),
+                      borderRadius: BorderRadius.circular(12),
+                      child: _InfoChip(label: ticket.estimate!),
+                    ),
                   ),
                 ),
             ],
@@ -666,22 +844,27 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
             const SizedBox(height: 10),
             // Team row — tappable
             if (ticket.team != null)
-              Semantics(
-                label: 'Team: ${ticket.team}. Tap to change.',
-                button: true,
-                child: InkWell(
-                  onTap: () => _openTeamSheet(ticket),
-                  borderRadius: BorderRadius.circular(8),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 4),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(Icons.group_outlined,
-                            size: 14, color: theme.colorScheme.outline),
-                        const SizedBox(width: 4),
-                        Text(ticket.team!, style: theme.textTheme.bodySmall),
-                      ],
+              _FieldSavingIndicator(
+                isSaving: _savingFields.contains('team'),
+                child: Semantics(
+                  label: 'Team: ${ticket.team}. Tap to change.',
+                  button: true,
+                  child: InkWell(
+                    onTap: _savingFields.contains('team')
+                        ? null
+                        : () => _openTeamSheet(ticket),
+                    borderRadius: BorderRadius.circular(8),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 4),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(Icons.group_outlined,
+                              size: 14, color: theme.colorScheme.outline),
+                          const SizedBox(width: 4),
+                          Text(ticket.team!, style: theme.textTheme.bodySmall),
+                        ],
+                      ),
                     ),
                   ),
                 ),
@@ -690,22 +873,27 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
               const SizedBox(width: 16),
             // Assignee row — tappable
             if (ticket.assignee != null)
-              Semantics(
-                label: 'Assignee: ${ticket.assignee}. Tap to change.',
-                button: true,
-                child: InkWell(
-                  onTap: () => _openAssigneeSheet(ticket),
-                  borderRadius: BorderRadius.circular(8),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 4),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(Icons.person_outline,
-                            size: 14, color: theme.colorScheme.outline),
-                        const SizedBox(width: 4),
-                        _AssigneeText(assignee: ticket.assignee!),
-                      ],
+              _FieldSavingIndicator(
+                isSaving: _savingFields.contains('assignee'),
+                child: Semantics(
+                  label: 'Assignee: ${ticket.assignee}. Tap to change.',
+                  button: true,
+                  child: InkWell(
+                    onTap: _savingFields.contains('assignee')
+                        ? null
+                        : () => _openAssigneeSheet(ticket),
+                    borderRadius: BorderRadius.circular(8),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 4),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(Icons.person_outline,
+                              size: 14, color: theme.colorScheme.outline),
+                          const SizedBox(width: 4),
+                          _AssigneeText(assignee: ticket.assignee!),
+                        ],
+                      ),
                     ),
                   ),
                 ),
@@ -744,35 +932,40 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
             ),
           ],
           // Tags — tappable
-          Semantics(
-            label: 'Tags: ${ticket.tags.join(", ")}. Tap to change.',
-            button: true,
-            child: InkWell(
-              onTap: () => _openTagSheet(ticket),
-              borderRadius: BorderRadius.circular(8),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 4),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    if (ticket.tags.isNotEmpty) ...[
-                      _SectionLabel('Tags'),
-                      const SizedBox(height: 4),
-                      Wrap(
-                        spacing: 4,
-                        runSpacing: 4,
-                        children: ticket.tags
-                            .map((tag) => Chip(
-                                  label: Text(tag),
-                                  materialTapTargetSize:
-                                      MaterialTapTargetSize.shrinkWrap,
-                                  visualDensity: VisualDensity.compact,
-                                  padding: EdgeInsets.zero,
-                                ))
-                            .toList(),
-                      ),
+          _FieldSavingIndicator(
+            isSaving: _savingFields.contains('tags'),
+            child: Semantics(
+              label: 'Tags: ${ticket.tags.join(", ")}. Tap to change.',
+              button: true,
+              child: InkWell(
+                onTap: _savingFields.contains('tags')
+                    ? null
+                    : () => _openTagSheet(ticket),
+                borderRadius: BorderRadius.circular(8),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      if (ticket.tags.isNotEmpty) ...[
+                        _SectionLabel('Tags'),
+                        const SizedBox(height: 4),
+                        Wrap(
+                          spacing: 4,
+                          runSpacing: 4,
+                          children: ticket.tags
+                              .map((tag) => Chip(
+                                    label: Text(tag),
+                                    materialTapTargetSize:
+                                        MaterialTapTargetSize.shrinkWrap,
+                                    visualDensity: VisualDensity.compact,
+                                    padding: EdgeInsets.zero,
+                                  ))
+                              .toList(),
+                        ),
+                      ],
                     ],
-                  ],
+                  ),
                 ),
               ),
             ),
@@ -1239,6 +1432,119 @@ class _TagSheetState extends State<_TagSheet> {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// Wraps a field widget showing a small spinner overlaid when [isSaving] is true.
+///
+/// When saving, the child is wrapped in a Row with a trailing spinner so the
+/// user can see which field is being saved without blocking the whole screen.
+class _FieldSavingIndicator extends StatelessWidget {
+  final bool isSaving;
+  final Widget child;
+
+  const _FieldSavingIndicator({
+    required this.isSaving,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isSaving) return child;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        child,
+        const SizedBox(width: 6),
+        const SizedBox(
+          width: 14,
+          height: 14,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      ],
+    );
+  }
+}
+
+/// Shimmer skeleton shown while the ticket is initially loading.
+///
+/// Mimics the layout of the ticket detail: title, chip row, team/assignee
+/// rows, and timestamp line.
+class _TicketSkeleton extends StatefulWidget {
+  const _TicketSkeleton();
+
+  @override
+  State<_TicketSkeleton> createState() => _TicketSkeletonState();
+}
+
+class _TicketSkeletonState extends State<_TicketSkeleton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    )..repeat(reverse: true);
+    _animation = CurvedAnimation(parent: _controller, curve: Curves.easeInOut);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.outlineVariant;
+    final bg = theme.colorScheme.surfaceContainerHighest;
+
+    Widget shimmerBox({double width = double.infinity, double height = 16}) {
+      return AnimatedBuilder(
+        animation: _animation,
+        builder: (context, child) => Container(
+          width: width,
+          height: height,
+          decoration: BoxDecoration(
+            color: Color.lerp(bg, muted, _animation.value),
+            borderRadius: BorderRadius.circular(4),
+          ),
+        ),
+      );
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          shimmerBox(height: 24, width: 200),
+          const SizedBox(height: 16),
+          Row(children: [
+            shimmerBox(width: 80, height: 28),
+            const SizedBox(width: 8),
+            shimmerBox(width: 70, height: 28),
+            const SizedBox(width: 8),
+            shimmerBox(width: 50, height: 28),
+          ]),
+          const SizedBox(height: 16),
+          shimmerBox(height: 14, width: 120),
+          const SizedBox(height: 8),
+          shimmerBox(height: 14, width: 80),
+          const SizedBox(height: 16),
+          shimmerBox(height: 14),
+          const SizedBox(height: 8),
+          shimmerBox(height: 14, width: 250),
+          const SizedBox(height: 24),
+          shimmerBox(height: 14, width: 180),
+        ],
       ),
     );
   }

--- a/phone/lib/widgets/estimate_picker_sheet.dart
+++ b/phone/lib/widgets/estimate_picker_sheet.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+
+/// Ordered list of all estimate sizes for display.
+const _kAllEstimates = ['XS', 'S', 'M', 'L', 'XL'];
+
+/// Human-readable label for an estimate size.
+String estimateLabel(String estimate) {
+  return estimate; // XS, S, M, L, XL are already short labels
+}
+
+/// Color indicator for an estimate size.
+Color estimateColor(String estimate) {
+  switch (estimate) {
+    case 'XS':
+      return Colors.grey;
+    case 'S':
+      return Colors.blue;
+    case 'M':
+      return Colors.green;
+    case 'L':
+      return Colors.orange;
+    case 'XL':
+      return Colors.red;
+    default:
+      return Colors.grey;
+  }
+}
+
+/// A bottom sheet for picking a new ticket estimate.
+///
+/// Shows all estimate sizes with color indicators. The [currentEstimate] is
+/// highlighted. Calls [onSelect] with the chosen estimate string.
+///
+/// Usage:
+/// ```dart
+/// showModalBottomSheet(
+///   context: context,
+///   builder: (_) => EstimatePickerSheet(
+///     currentEstimate: ticket.estimate ?? 'S',
+///     onSelect: (newEstimate) { ... },
+///   ),
+/// );
+/// ```
+class EstimatePickerSheet extends StatelessWidget {
+  final String currentEstimate;
+  final void Function(String estimate) onSelect;
+
+  const EstimatePickerSheet({
+    super.key,
+    required this.currentEstimate,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              margin: const EdgeInsets.symmetric(vertical: 12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.outlineVariant,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: Text(
+              'Change Estimate',
+              style: theme.textTheme.titleMedium
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+          ),
+          const Divider(height: 1),
+          ..._kAllEstimates.map((estimate) {
+            final isSelected = estimate == currentEstimate;
+            final color = estimateColor(estimate);
+            return ListTile(
+              leading: Container(
+                width: 12,
+                height: 12,
+                decoration: BoxDecoration(
+                  color: color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              title: Text(
+                estimateLabel(estimate),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight:
+                      isSelected ? FontWeight.w600 : FontWeight.normal,
+                ),
+              ),
+              trailing: isSelected
+                  ? Icon(Icons.check, color: theme.colorScheme.primary)
+                  : null,
+              selected: isSelected,
+              selectedColor: theme.colorScheme.primary,
+              onTap: () => onSelect(estimate),
+            );
+          }),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}

--- a/phone/lib/widgets/priority_picker_sheet.dart
+++ b/phone/lib/widgets/priority_picker_sheet.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+/// Ordered list of all priority levels for display.
+const _kAllPriorities = ['critical', 'high', 'medium', 'low'];
+
+/// Human-readable label for a priority level.
+String priorityLabel(String priority) {
+  switch (priority) {
+    case 'critical':
+      return 'Critical';
+    case 'high':
+      return 'High';
+    case 'medium':
+      return 'Medium';
+    case 'low':
+      return 'Low';
+    default:
+      return priority;
+  }
+}
+
+/// Color indicator for a priority level.
+Color priorityColor(String priority) {
+  switch (priority) {
+    case 'critical':
+      return Colors.red;
+    case 'high':
+      return Colors.orange;
+    case 'medium':
+      return Colors.blue;
+    case 'low':
+      return Colors.grey;
+    default:
+      return Colors.grey;
+  }
+}
+
+/// A bottom sheet for picking a new ticket priority.
+///
+/// Shows all priorities with color indicators. The [currentPriority] is
+/// highlighted. Calls [onSelect] with the chosen priority string.
+///
+/// Usage:
+/// ```dart
+/// showModalBottomSheet(
+///   context: context,
+///   builder: (_) => PriorityPickerSheet(
+///     currentPriority: ticket.priority,
+///     onSelect: (newPriority) { ... },
+///   ),
+/// );
+/// ```
+class PriorityPickerSheet extends StatelessWidget {
+  final String currentPriority;
+  final void Function(String priority) onSelect;
+
+  const PriorityPickerSheet({
+    super.key,
+    required this.currentPriority,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              margin: const EdgeInsets.symmetric(vertical: 12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.outlineVariant,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: Text(
+              'Change Priority',
+              style: theme.textTheme.titleMedium
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+          ),
+          const Divider(height: 1),
+          ..._kAllPriorities.map((priority) {
+            final isSelected = priority == currentPriority;
+            final color = priorityColor(priority);
+            return ListTile(
+              leading: Container(
+                width: 12,
+                height: 12,
+                decoration: BoxDecoration(
+                  color: color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              title: Text(
+                priorityLabel(priority),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight:
+                      isSelected ? FontWeight.w600 : FontWeight.normal,
+                ),
+              ),
+              trailing: isSelected
+                  ? Icon(Icons.check, color: theme.colorScheme.primary)
+                  : null,
+              selected: isSelected,
+              selectedColor: theme.colorScheme.primary,
+              onTap: () => onSelect(priority),
+            );
+          }),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}

--- a/phone/lib/widgets/text_input_sheet.dart
+++ b/phone/lib/widgets/text_input_sheet.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+/// A reusable bottom sheet for text input with confirm/cancel behavior.
+///
+/// Shows a text field with an optional initial value. On confirm,
+/// calls [onConfirm] with the trimmed text. On cancel/dismiss, calls nothing.
+///
+/// Usage:
+/// ```dart
+/// showModalBottomSheet<void>(
+///   context: context,
+///   isScrollControlled: true,
+///   builder: (_) => TextInputSheet(
+///     label: 'Team',
+///     initialValue: ticket.team,
+///     onConfirm: (value) { ... },
+///   ),
+/// );
+/// ```
+class TextInputSheet extends StatefulWidget {
+  /// Label shown above the text field (e.g. 'Team', 'Assignee').
+  final String label;
+
+  /// Initial value to populate the text field.
+  final String? initialValue;
+
+  /// Called when the user confirms the input (presses the checkmark button).
+  /// Receives the trimmed text value. Not called on cancel/dismiss.
+  final void Function(String value) onConfirm;
+
+  const TextInputSheet({
+    super.key,
+    required this.label,
+    this.initialValue,
+    required this.onConfirm,
+  });
+
+  @override
+  State<TextInputSheet> createState() => _TextInputSheetState();
+}
+
+class _TextInputSheetState extends State<TextInputSheet> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue ?? '');
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 16,
+          right: 16,
+          top: 16,
+          bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              widget.label,
+              style: Theme.of(context).textTheme.titleMedium
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _controller,
+              autofocus: true,
+              maxLines: null,
+              decoration: InputDecoration(
+                border: const OutlineInputBorder(),
+                isDense: true,
+                labelText: widget.label,
+              ),
+              textInputAction: TextInputAction.done,
+              onSubmitted: (_) => _confirm(),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Cancel'),
+                ),
+                const SizedBox(width: 8),
+                FilledButton(
+                  onPressed: _confirm,
+                  child: const Text('Confirm'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _confirm() {
+    final value = _controller.text.trim();
+    Navigator.pop(context);
+    widget.onConfirm(value);
+  }
+}


### PR DESCRIPTION
## Summary
- Scaffold picker sheets for inline field editing, remove editMode toggle
- Wire per-field saves with loading/error states
- Accessibility pass + regression verification

## Test plan
- [ ] Verify inline field editing works on ticket detail screen
- [ ] Confirm per-field saves persist correctly
- [ ] Check loading/error states display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)