### PR TITLE
feat(phone): improve stop timer chip UX

### DIFF
--- a/phone/lib/services/local_write_service.dart
+++ b/phone/lib/services/local_write_service.dart
@@ -224,7 +224,14 @@ class LocalWriteService {
         }
       }
     }
-    return comments.take(limit).toList();
+    // Split multi-line comments, trim, filter empty, deduplicate
+    final seen = <String>{};
+    final chips = comments
+        .expand((c) => c.split('\n'))
+        .map((s) => s.trim())
+        .where((s) => s.isNotEmpty && seen.add(s))
+        .toList();
+    return chips.take(limit).toList();
   }
 
   /// Returns active tasks filtered by [category].

--- a/phone/lib/services/local_write_service.dart
+++ b/phone/lib/services/local_write_service.dart
@@ -204,8 +204,8 @@ class LocalWriteService {
   /// Returns recent worklog comments (up to [limit] entries).
   ///
   /// If [category] is provided, only comments from worklogs with matching
-  /// category are returned. If the filtered results are fewer than 3,
-  /// falls back to unfiltered recent comments.
+  /// category are returned. Returns at most [limit] entries; may return
+  /// fewer if the category filter yields fewer results.
   Future<List<String>> getRecentComments({String? category, int limit = 10}) async {
     final rows = await (db.select(db.worklogEntries)
           ..orderBy([(w) => OrderingTerm.desc(w.created)])
@@ -223,10 +223,6 @@ class LocalWriteService {
           comments.add(doc.comment!);
         }
       }
-    }
-    // Fall back to unfiltered if category filter returned too few
-    if (category != null && category.isNotEmpty && comments.length < 3) {
-      return getRecentComments(category: null, limit: limit);
     }
     return comments.take(limit).toList();
   }


### PR DESCRIPTION
## Summary
- Remove cross-category fallback from `getRecentComments()` — recent chips now show only within the current timer's category
- Split multi-line comments into separate chips with deduplication and empty-line filtering
- Ticket: AVO-028

## Changes
- `phone/lib/services/local_write_service.dart` — `getRecentComments()` method:
  - Removed lines 228-229 (cross-category fallback when < 3 results)
  - Added post-processing: split on `\n`, trim, filter empty, deduplicate (preserving order)
  - `limit` now applies to the final deduplicated list

## Test plan
- [ ] Stop timer with category that has 0 recent comments → no chips shown
- [ ] Stop timer with category that has 1-2 recent comments → only those appear
- [ ] Multi-line comment appears as separate chips
- [ ] Empty lines and whitespace filtered out
- [ ] Duplicate comments appear as single chip
- [ ] Preset chips unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)