### PR TITLE
feat(phone): stop timer chip parity for category/task level (#AVO-028)

### DIFF
--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -64,6 +64,9 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
     // Write service for local CRDT mutations (timer, task, worklog)
     final writeService = LocalWriteService(db: db, clock: clock);
 
+    // One-time backfill: set category on worklogs from task-level timers
+    await writeService.backfillWorklogCategories();
+
     // Load stored server URL (already HTTP format)
     final httpBaseUrl = await SettingsScreen.loadServerUrl();
 

--- a/phone/lib/screens/dashboard_screen.dart
+++ b/phone/lib/screens/dashboard_screen.dart
@@ -132,9 +132,16 @@ class _DashboardScreenState extends State<DashboardScreen> {
       }
     }
 
+    // Look up task category from today's planned tasks
+    final taskCategory = widget.dashboardProvider.snapshot?.plannedTasks
+        .where((t) => t.taskId == taskId)
+        .firstOrNull
+        ?.category;
+
     await widget.writeService.startTimer(
       taskTitle: taskTitle,
       taskId: taskId,
+      category: taskCategory,
     );
     final timerDelta = await widget.writeService.getTimerDelta();
     if (timerDelta != null) deltas.add(timerDelta);

--- a/phone/lib/services/local_write_service.dart
+++ b/phone/lib/services/local_write_service.dart
@@ -211,12 +211,30 @@ class LocalWriteService {
           ..orderBy([(w) => OrderingTerm.desc(w.created)])
           ..limit(limit * 3)) // fetch more to allow for filtering
         .get();
+
+    // Build task category lookup for worklogs missing their own category
+    var taskCategoryMap = <String, String>{};
+    if (category != null && category.isNotEmpty) {
+      final taskRows = await db.select(db.tasks).get();
+      for (final t in taskRows) {
+        final cat = TaskDocument.fromDrift(task: t, clock: clock).category;
+        if (cat != null && cat.isNotEmpty) taskCategoryMap[t.id] = cat;
+      }
+    }
+
     final comments = <String>[];
     for (final row in rows) {
       final doc = WorklogDocument.fromDrift(worklog: row, clock: clock);
       if (doc.comment != null && doc.comment!.isNotEmpty) {
         if (category != null && category.isNotEmpty) {
-          if (doc.category == category) {
+          // Match by worklog category, or fall back to task's category
+          final wlCategory = doc.category;
+          final tid = doc.taskId;
+          String? taskCategory;
+          if (tid.isNotEmpty) {
+            taskCategory = taskCategoryMap[tid];
+          }
+          if (wlCategory == category || taskCategory == category) {
             comments.add(doc.comment!);
           }
         } else {

--- a/phone/lib/services/local_write_service.dart
+++ b/phone/lib/services/local_write_service.dart
@@ -424,6 +424,46 @@ class LocalWriteService {
   }
 
   // ============================================================
+  // Migrations
+  // ============================================================
+
+  /// Backfills category on worklogs that have a taskId but no category.
+  ///
+  /// Older worklogs created by task-level timers had no category set.
+  /// This copies the task's category onto the worklog via CRDT so it
+  /// syncs correctly to the desktop.
+  Future<int> backfillWorklogCategories() async {
+    final worklogs = await db.select(db.worklogEntries).get();
+    final tasks = await db.select(db.tasks).get();
+    final taskCategoryMap = <String, String>{};
+    for (final t in tasks) {
+      final doc = TaskDocument.fromDrift(task: t, clock: clock);
+      final cat = doc.category;
+      if (cat != null && cat.isNotEmpty) taskCategoryMap[t.id] = cat;
+    }
+
+    var updated = 0;
+    for (final wl in worklogs) {
+      final doc = WorklogDocument.fromDrift(worklog: wl, clock: clock);
+      if (doc.taskId.isNotEmpty &&
+          (doc.category == null || doc.category!.isEmpty)) {
+        final cat = taskCategoryMap[doc.taskId];
+        if (cat != null) {
+          doc.category = cat;
+          await db
+              .into(db.worklogEntries)
+              .insertOnConflictUpdate(doc.toDriftCompanion());
+          updated++;
+        }
+      }
+    }
+    if (updated > 0) {
+      debugPrint('[LocalWrite] Backfilled category on $updated worklogs');
+    }
+    return updated;
+  }
+
+  // ============================================================
   // Helpers
   // ============================================================
 

--- a/phone/lib/widgets/stop_timer_sheet.dart
+++ b/phone/lib/widgets/stop_timer_sheet.dart
@@ -136,9 +136,13 @@ class _StopTimerSheetState extends State<StopTimerSheet> {
     }
 
     // F5: Today's planned tasks (excluding orphan and already-added current task)
+    // Filter by category when set (ensures parity between category/task-level stop)
     for (final task in allTasks) {
       if (plannedIds.contains(task.id) && task.id != _selectedTaskId) {
         final doc = TaskDocument.fromDrift(task: task, clock: widget.writeService.clock);
+        if (widget.category != null && widget.category!.isNotEmpty && doc.category != widget.category) {
+          continue;
+        }
         options.add(_TaskOption(
           id: task.id,
           title: doc.title,


### PR DESCRIPTION
## Summary
- Remove cross-category fallback from `getRecentComments()` so chips are category-scoped
- Split multi-line comments into individual chips
- Pass task category when starting task-level timers, ensuring both category and task-level stop sheets show identical chips (presets + recents) and category-filtered task picker
- Fall back to task's category when filtering recent chips for older worklogs missing category
- Backfill category on existing worklogs from their task on app startup via CRDT

## Test plan
- [x] `flutter analyze` — no errors
- [x] `dart test` (mcp) — 424 tests pass
- [ ] Manual: start task-level timer → stop → verify preset + recent chips show for that category only
- [ ] Manual: start category-level timer → stop → verify same chips appear
- [ ] Manual: verify backfill runs on first launch (check debug log for "Backfilled category on N worklogs")

🤖 Generated with [Claude Code](https://claude.com/claude-code)