### PR TITLE
feat(phone): search tickets by key ID in board search (#AVO-034)

### DIFF
--- a/phone/lib/services/board_provider.dart
+++ b/phone/lib/services/board_provider.dart
@@ -235,8 +235,11 @@ class BoardProvider extends ChangeNotifier {
   BoardColumn _applySearch(BoardColumn col) {
     if (_searchQuery.isEmpty) return col;
     final query = _searchQuery.toLowerCase();
-    final filtered =
-        col.tickets.where((t) => t.title.toLowerCase().contains(query)).toList();
+    final filtered = col.tickets
+        .where((t) =>
+            t.title.toLowerCase().contains(query) ||
+            t.id.toLowerCase().contains(query))
+        .toList();
     return BoardColumn(
       status: col.status,
       tickets: filtered,


### PR DESCRIPTION
## Summary
- Board search bar now matches tickets by `id` field (e.g., "AVO-034", "034", "AVO") in addition to title
- Single-line change in `BoardProvider._applySearch` — adds `|| t.id.toLowerCase().contains(query)`
- Preserves existing title search behavior, case-insensitive

## Acceptance Criteria
- [x] AC1: Typing "AVO-034" shows only AVO-034
- [x] AC2: Typing "034" shows tickets with "034" in ID or title
- [x] AC3: Typing "AVO" shows all AVO-prefixed tickets
- [x] AC4: Title search still works as before
- [x] AC5: Case-insensitive ("avo-034" matches "AVO-034")

## Test plan
- [ ] Verify search by full key (e.g., "AVO-034")
- [ ] Verify search by numeric portion (e.g., "034")
- [ ] Verify search by prefix (e.g., "AVO")
- [ ] Verify existing title search is not broken
- [ ] Verify case-insensitivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)