### PR TITLE
feat(phone): Repo detail view in Kanban (AVO-043)

### DIFF
--- a/phone/lib/models/repo_git_info.dart
+++ b/phone/lib/models/repo_git_info.dart
@@ -1,0 +1,169 @@
+/// Data model for repository git information from the agent workflow API.
+///
+/// Represents the response from GET /api/repos/:key/git-info
+class RepoGitInfo {
+  final RepoMeta repo;
+  final String currentBranch;
+  final BranchInfo mainBranch;
+  final BranchInfo developBranch;
+  final MainVsDevelop mainVsDevelop;
+  final List<FeatureBranch> featureBranches;
+  final WorkingDirectoryStatus workingDirectory;
+  final List<String> errors;
+
+  const RepoGitInfo({
+    required this.repo,
+    required this.currentBranch,
+    required this.mainBranch,
+    required this.developBranch,
+    required this.mainVsDevelop,
+    required this.featureBranches,
+    required this.workingDirectory,
+    this.errors = const [],
+  });
+
+  factory RepoGitInfo.fromJson(Map<String, dynamic> json) {
+    return RepoGitInfo(
+      repo: RepoMeta.fromJson(json['repo'] as Map<String, dynamic>),
+      currentBranch: json['current_branch'] as String? ?? '',
+      mainBranch: BranchInfo.fromJson(json['main_branch'] as Map<String, dynamic>),
+      developBranch: BranchInfo.fromJson(json['develop_branch'] as Map<String, dynamic>),
+      mainVsDevelop: MainVsDevelop.fromJson(json['main_vs_develop'] as Map<String, dynamic>),
+      featureBranches: (json['feature_branches'] as List?)
+              ?.map((e) => FeatureBranch.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      workingDirectory: WorkingDirectoryStatus.fromJson(
+          json['working_directory'] as Map<String, dynamic>),
+      errors: (json['errors'] as List?)?.cast<String>() ?? const [],
+    );
+  }
+}
+
+/// Repository metadata (key, path, description, prefix).
+class RepoMeta {
+  final String key;
+  final String path;
+  final String description;
+  final String prefix;
+
+  const RepoMeta({
+    required this.key,
+    required this.path,
+    required this.description,
+    required this.prefix,
+  });
+
+  factory RepoMeta.fromJson(Map<String, dynamic> json) {
+    return RepoMeta(
+      key: json['key'] as String? ?? '',
+      path: json['path'] as String? ?? '',
+      description: json['description'] as String? ?? '',
+      prefix: json['prefix'] as String? ?? '',
+    );
+  }
+}
+
+/// Commit information on a branch.
+class BranchCommit {
+  final String hash;
+  final String? hashShort;
+  final String message;
+  final String date;
+
+  const BranchCommit({
+    required this.hash,
+    this.hashShort,
+    required this.message,
+    required this.date,
+  });
+
+  factory BranchCommit.fromJson(Map<String, dynamic> json) {
+    return BranchCommit(
+      hash: json['hash'] as String? ?? json['hash_short'] as String? ?? '',
+      hashShort: json['hash_short'] as String?,
+      message: json['message'] as String? ?? '',
+      date: json['date'] as String? ?? '',
+    );
+  }
+}
+
+/// Branch information (name, exists, latest commit).
+class BranchInfo {
+  final String name;
+  final bool exists;
+  final BranchCommit? latestCommit;
+
+  const BranchInfo({
+    required this.name,
+    required this.exists,
+    this.latestCommit,
+  });
+
+  factory BranchInfo.fromJson(Map<String, dynamic> json) {
+    return BranchInfo(
+      name: json['name'] as String? ?? '',
+      exists: json['exists'] as bool? ?? false,
+      latestCommit: json['latestCommit'] != null
+          ? BranchCommit.fromJson(json['latestCommit'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// Comparison between main and develop branches.
+class MainVsDevelop {
+  final int mainAhead;
+  final int developAhead;
+  final bool diverged;
+
+  const MainVsDevelop({
+    required this.mainAhead,
+    required this.developAhead,
+    required this.diverged,
+  });
+
+  factory MainVsDevelop.fromJson(Map<String, dynamic> json) {
+    return MainVsDevelop(
+      mainAhead: json['main_ahead'] as int? ?? 0,
+      developAhead: json['develop_ahead'] as int? ?? 0,
+      diverged: json['diverged'] as bool? ?? false,
+    );
+  }
+}
+
+/// A feature branch with its latest commit.
+class FeatureBranch {
+  final String name;
+  final BranchCommit latestCommit;
+
+  const FeatureBranch({
+    required this.name,
+    required this.latestCommit,
+  });
+
+  factory FeatureBranch.fromJson(Map<String, dynamic> json) {
+    return FeatureBranch(
+      name: json['name'] as String? ?? '',
+      latestCommit: BranchCommit.fromJson(json['latestCommit'] as Map<String, dynamic>),
+    );
+  }
+}
+
+/// Working directory status (clean vs dirty).
+class WorkingDirectoryStatus {
+  final bool clean;
+  final int uncommittedCount;
+
+  const WorkingDirectoryStatus({
+    required this.clean,
+    required this.uncommittedCount,
+  });
+
+  factory WorkingDirectoryStatus.fromJson(Map<String, dynamic> json) {
+    return WorkingDirectoryStatus(
+      clean: json['clean'] as bool? ?? true,
+      uncommittedCount: json['uncommitted_count'] as int? ?? 0,
+    );
+  }
+}

--- a/phone/lib/screens/branch_detail_screen.dart
+++ b/phone/lib/screens/branch_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/repo_git_info.dart';
+import '../utils/date_helpers.dart';
 
 /// Read-only screen showing details of a single feature branch.
 ///
@@ -98,7 +99,7 @@ class BranchDetailScreen extends StatelessWidget {
                           size: 16, color: theme.colorScheme.outline),
                       const SizedBox(width: 8),
                       Text(
-                        _formatDate(commit.date),
+                        formatDateLong(commit.date),
                         style: theme.textTheme.bodyMedium,
                       ),
                     ],
@@ -134,20 +135,5 @@ class BranchDetailScreen extends StatelessWidget {
         ],
       ),
     );
-  }
-
-  String _formatDate(String iso) {
-    try {
-      final dt = DateTime.parse(iso).toLocal();
-      final months = [
-        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
-      ];
-      final h = dt.hour.toString().padLeft(2, '0');
-      final m = dt.minute.toString().padLeft(2, '0');
-      return '${months[dt.month - 1]} ${dt.day}, ${dt.year} $h:$m';
-    } catch (_) {
-      return iso;
-    }
   }
 }

--- a/phone/lib/screens/branch_detail_screen.dart
+++ b/phone/lib/screens/branch_detail_screen.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+
+import '../models/repo_git_info.dart';
+
+/// Read-only screen showing details of a single feature branch.
+///
+/// Displays branch name, full commit hash, commit date, and full commit message.
+/// Extensible for future git diff viewing.
+class BranchDetailScreen extends StatelessWidget {
+  final FeatureBranch branch;
+
+  const BranchDetailScreen({super.key, required this.branch});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final commit = branch.latestCommit;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(branch.name),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          // Branch name card
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Icon(Icons.account_tree,
+                          color: theme.colorScheme.primary, size: 20),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          branch.name,
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+
+          // Commit hash card
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Commit Hash',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  SelectableText(
+                    commit.hash,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontFamily: 'monospace',
+                      color: theme.colorScheme.primary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+
+          // Commit date card
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Commit Date',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Icon(Icons.calendar_today,
+                          size: 16, color: theme.colorScheme.outline),
+                      const SizedBox(width: 8),
+                      Text(
+                        _formatDate(commit.date),
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+
+          // Commit message card
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Commit Message',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  SelectableText(
+                    commit.message,
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDate(String iso) {
+    try {
+      final dt = DateTime.parse(iso).toLocal();
+      final months = [
+        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+      ];
+      final h = dt.hour.toString().padLeft(2, '0');
+      final m = dt.minute.toString().padLeft(2, '0');
+      return '${months[dt.month - 1]} ${dt.day}, ${dt.year} $h:$m';
+    } catch (_) {
+      return iso;
+    }
+  }
+}

--- a/phone/lib/screens/kanban_board_screen.dart
+++ b/phone/lib/screens/kanban_board_screen.dart
@@ -14,6 +14,7 @@ import '../settings/settings_screen.dart';
 import 'create_bulletin_screen.dart';
 import 'create_ticket_screen.dart';
 import 'ticket_detail_screen.dart';
+import 'repo_detail_screen.dart';
 
 /// Main Kanban board screen.
 ///
@@ -220,6 +221,31 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
                     if (p != null) provider.setProject(p);
                   },
                 ),
+              if (projectItems.isNotEmpty) ...[
+                const SizedBox(width: 4),
+                IconButton(
+                  icon: Icon(
+                    Icons.info_outline,
+                    color: provider.selectedProject != null
+                        ? null
+                        : Colors.grey,
+                  ),
+                  tooltip: 'Project info',
+                  onPressed: provider.selectedProject != null
+                      ? () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => RepoDetailScreen(
+                                repoKey: provider.selectedProject!,
+                                apiClient: provider.client,
+                              ),
+                            ),
+                          );
+                        }
+                      : null,
+                ),
+              ],
               if (teams.isNotEmpty) ...[
                 const SizedBox(width: 12),
                 FilterChip(

--- a/phone/lib/screens/repo_detail_screen.dart
+++ b/phone/lib/screens/repo_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/deployment.dart';
 import '../models/repo_git_info.dart';
 import '../services/agent_api_client.dart';
+import '../utils/date_helpers.dart';
 import '../utils/deploy_helpers.dart';
 import 'activity_timeline_screen.dart';
 import 'branch_detail_screen.dart';
@@ -176,21 +177,18 @@ class _RepoDetailScreenState extends State<RepoDetailScreen> {
             _GitInfoSection(gitInfo: gitInfo),
 
             // Feature Branches Section
-            if (gitInfo.featureBranches.isNotEmpty) ...[
-              _FeatureBranchesSection(
-                branches: gitInfo.featureBranches,
-                onBranchTap: (branch) => _navigateToBranch(context, branch),
-              ),
-            ],
+            _FeatureBranchesSection(
+              branches: gitInfo.featureBranches,
+              onBranchTap: (branch) => _navigateToBranch(context, branch),
+            ),
 
             // Deployments Section
-            if (runningDeployments.isNotEmpty || recentDeployments.isNotEmpty)
-              _DeploymentsSection(
-                runningDeployments: runningDeployments,
-                recentDeployments: recentDeployments,
-                onDeploymentTap: (deployment) =>
-                    _navigateToTimeline(context, deployment),
-              ),
+            _DeploymentsSection(
+              runningDeployments: runningDeployments,
+              recentDeployments: recentDeployments,
+              onDeploymentTap: (deployment) =>
+                  _navigateToTimeline(context, deployment),
+            ),
           ],
         ),
       ),
@@ -534,53 +532,61 @@ class _FeatureBranchesSection extends StatelessWidget {
             ],
           ),
         ),
-        ListView.builder(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          itemCount: branches.length,
-          itemBuilder: (context, index) {
-            final branch = branches[index];
-            final commit = branch.latestCommit;
-            return ListTile(
-              onTap: () => onBranchTap(branch),
-              leading: CircleAvatar(
-                backgroundColor:
-                    theme.colorScheme.secondaryContainer,
-                child: Icon(Icons.account_tree,
-                    size: 18, color: theme.colorScheme.onSecondaryContainer),
-              ),
-              title: Text(
-                branch.name,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              subtitle: Text(
-                '${commit.hashShort ?? commit.hash} · ${_formatDate(commit.date)}',
-                style: theme.textTheme.bodySmall?.copyWith(
-                  fontFamily: 'monospace',
+        if (branches.isEmpty)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.account_tree,
+                  size: 20,
                   color: theme.colorScheme.outline,
                 ),
-              ),
-              trailing: const Icon(Icons.chevron_right),
-            );
-          },
-        ),
+                const SizedBox(width: 8),
+                Text(
+                  'No active feature branches',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
+              ],
+            ),
+          )
+        else
+          ListView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: branches.length,
+            itemBuilder: (context, index) {
+              final branch = branches[index];
+              final commit = branch.latestCommit;
+              return ListTile(
+                onTap: () => onBranchTap(branch),
+                leading: CircleAvatar(
+                  backgroundColor:
+                      theme.colorScheme.secondaryContainer,
+                  child: Icon(Icons.account_tree,
+                      size: 18, color: theme.colorScheme.onSecondaryContainer),
+                ),
+                title: Text(
+                  branch.name,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                subtitle: Text(
+                  '${commit.hashShort ?? commit.hash} · ${formatDateShort(commit.date)}',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontFamily: 'monospace',
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
+                trailing: const Icon(Icons.chevron_right),
+              );
+            },
+          ),
       ],
     );
-  }
-
-  String _formatDate(String iso) {
-    try {
-      final dt = DateTime.parse(iso).toLocal();
-      final months = [
-        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
-      ];
-      return '${months[dt.month - 1]} ${dt.day}';
-    } catch (_) {
-      return '';
-    }
   }
 }
 
@@ -599,6 +605,7 @@ class _DeploymentsSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final isEmpty = runningDeployments.isEmpty && recentDeployments.isEmpty;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -612,52 +619,73 @@ class _DeploymentsSection extends StatelessWidget {
             ),
           ),
         ),
-
-        // Running deployments
-        if (runningDeployments.isNotEmpty) ...[
+        if (isEmpty)
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
             child: Row(
               children: [
-                Container(
-                  width: 8,
-                  height: 8,
-                  decoration: BoxDecoration(
-                    color: Colors.blue,
-                    shape: BoxShape.circle,
-                  ),
+                Icon(
+                  Icons.rocket_launch,
+                  size: 20,
+                  color: theme.colorScheme.outline,
                 ),
                 const SizedBox(width: 8),
                 Text(
-                  'Running',
-                  style: theme.textTheme.labelMedium?.copyWith(
+                  'No deployments found',
+                  style: theme.textTheme.bodyMedium?.copyWith(
                     color: theme.colorScheme.outline,
                   ),
                 ),
               ],
             ),
-          ),
-          ...runningDeployments.map((d) => _DeploymentTile(
-                deployment: d,
-                onTap: () => onDeploymentTap(d),
-              )),
-        ],
-
-        // Recent deployments
-        if (recentDeployments.isNotEmpty) ...[
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
-            child: Text(
-              'Recent',
-              style: theme.textTheme.labelMedium?.copyWith(
-                color: theme.colorScheme.outline,
+          )
+        else ...[
+          // Running deployments
+          if (runningDeployments.isNotEmpty) ...[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+              child: Row(
+                children: [
+                  Container(
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: Colors.blue,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    'Running',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
+                  ),
+                ],
               ),
             ),
-          ),
-          ...recentDeployments.map((d) => _DeploymentTile(
-                deployment: d,
-                onTap: () => onDeploymentTap(d),
-              )),
+            ...runningDeployments.map((d) => _DeploymentTile(
+                  deployment: d,
+                  onTap: () => onDeploymentTap(d),
+                )),
+          ],
+
+          // Recent deployments
+          if (recentDeployments.isNotEmpty) ...[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+              child: Text(
+                'Recent',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
+              ),
+            ),
+            ...recentDeployments.map((d) => _DeploymentTile(
+                  deployment: d,
+                  onTap: () => onDeploymentTap(d),
+                )),
+          ],
         ],
       ],
     );
@@ -691,7 +719,7 @@ class _DeploymentTile extends StatelessWidget {
           ),
         ),
         subtitle: Text(
-          '${deployment.team} · ${deployment.status}',
+          '${deployment.team} · ${deployment.status} · ${formatRelativeTime(deployment.startedAt)}',
           style: theme.textTheme.bodySmall?.copyWith(color: color),
         ),
         trailing: Row(

--- a/phone/lib/screens/repo_detail_screen.dart
+++ b/phone/lib/screens/repo_detail_screen.dart
@@ -1,0 +1,716 @@
+import 'package:flutter/material.dart';
+
+import '../models/deployment.dart';
+import '../models/repo_git_info.dart';
+import '../services/agent_api_client.dart';
+import '../utils/deploy_helpers.dart';
+import 'activity_timeline_screen.dart';
+import 'branch_detail_screen.dart';
+
+/// Repository detail screen showing git info and deployment history.
+///
+/// Fires both git-info and deployments API calls in parallel on init.
+/// Supports pull-to-refresh, error state with retry, and 404 handling.
+class RepoDetailScreen extends StatefulWidget {
+  final String repoKey;
+  final AgentApiClient apiClient;
+
+  const RepoDetailScreen({
+    super.key,
+    required this.repoKey,
+    required this.apiClient,
+  });
+
+  @override
+  State<RepoDetailScreen> createState() => _RepoDetailScreenState();
+}
+
+class _RepoDetailScreenState extends State<RepoDetailScreen> {
+  RepoGitInfo? _gitInfo;
+  List<Deployment> _deployments = [];
+  bool _loading = true;
+  String? _error;
+  bool _is404 = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+      _is404 = false;
+    });
+
+    try {
+      final results = await Future.wait([
+        widget.apiClient.getRepoGitInfo(widget.repoKey),
+        widget.apiClient.getRepoDeployments(widget.repoKey),
+      ]);
+
+      if (mounted) {
+        setState(() {
+          _gitInfo = results[0] as RepoGitInfo;
+          _deployments = results[1] as List<Deployment>;
+          _loading = false;
+        });
+      }
+    } on AgentApiException catch (e) {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+          if (e.statusCode == 404) {
+            _is404 = true;
+            _error = null;
+          } else {
+            _error = e.message;
+          }
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+          _error = e.toString();
+        });
+      }
+    }
+  }
+
+  Future<void> _onRefresh() async {
+    await _loadData();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading && _gitInfo == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Repository')),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (_is404) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Repository')),
+        body: RefreshIndicator(
+          onRefresh: _onRefresh,
+          child: ListView(
+            children: [
+              const SizedBox(height: 120),
+              Icon(Icons.folder_off, size: 64, color: Theme.of(context).colorScheme.outline),
+              const SizedBox(height: 16),
+              Center(
+                child: Text(
+                  'No repository found',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.outline,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Center(
+                child: Text(
+                  'Project "${widget.repoKey}" has no associated git repository.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.outline,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (_error != null && _gitInfo == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Repository')),
+        body: RefreshIndicator(
+          onRefresh: _onRefresh,
+          child: ListView(
+            children: [
+              const SizedBox(height: 120),
+              Icon(Icons.cloud_off, size: 64, color: Theme.of(context).colorScheme.error),
+              const SizedBox(height: 16),
+              Center(
+                child: Text(
+                  'Unable to connect',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Center(
+                child: OutlinedButton.icon(
+                  onPressed: _onRefresh,
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('Retry'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final gitInfo = _gitInfo!;
+    final runningDeployments = _deployments.where((d) => d.isRunning).toList();
+    final recentDeployments = _deployments.where((d) => !d.isRunning).take(20).toList();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(gitInfo.repo.key),
+      ),
+      body: RefreshIndicator(
+        onRefresh: _onRefresh,
+        child: ListView(
+          padding: const EdgeInsets.only(bottom: 32),
+          children: [
+            // Git Info Section
+            _GitInfoSection(gitInfo: gitInfo),
+
+            // Feature Branches Section
+            if (gitInfo.featureBranches.isNotEmpty) ...[
+              _FeatureBranchesSection(
+                branches: gitInfo.featureBranches,
+                onBranchTap: (branch) => _navigateToBranch(context, branch),
+              ),
+            ],
+
+            // Deployments Section
+            if (runningDeployments.isNotEmpty || recentDeployments.isNotEmpty)
+              _DeploymentsSection(
+                runningDeployments: runningDeployments,
+                recentDeployments: recentDeployments,
+                onDeploymentTap: (deployment) =>
+                    _navigateToTimeline(context, deployment),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _navigateToBranch(BuildContext context, FeatureBranch branch) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => BranchDetailScreen(branch: branch),
+      ),
+    );
+  }
+
+  void _navigateToTimeline(BuildContext context, Deployment deployment) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ActivityTimelineScreen(
+          deployment: deployment,
+          client: widget.apiClient,
+        ),
+      ),
+    );
+  }
+}
+
+/// Git info section with current branch, main/develop comparison, and working directory status.
+class _GitInfoSection extends StatelessWidget {
+  final RepoGitInfo gitInfo;
+
+  const _GitInfoSection({required this.gitInfo});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Text(
+            'Git Info',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+
+        // Current branch chip
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              Chip(
+                avatar: Icon(Icons.account_tree,
+                    size: 16, color: theme.colorScheme.primary),
+                label: Text(gitInfo.currentBranch),
+                backgroundColor: theme.colorScheme.primaryContainer,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+
+        // Main vs Develop comparison card
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Card(
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _BranchStatusRow(
+                    label: 'main',
+                    exists: gitInfo.mainBranch.exists,
+                    commit: gitInfo.mainBranch.latestCommit,
+                    color: theme.colorScheme.primary,
+                  ),
+                  const Divider(height: 16),
+                  _BranchStatusRow(
+                    label: 'develop',
+                    exists: gitInfo.developBranch.exists,
+                    commit: gitInfo.developBranch.latestCommit,
+                    color: theme.colorScheme.secondary,
+                  ),
+                  const Divider(height: 16),
+                  _AheadBehindIndicator(mainVsDevelop: gitInfo.mainVsDevelop),
+                ],
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+
+        // Working directory status
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Card(
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                children: [
+                  Icon(
+                    gitInfo.workingDirectory.clean
+                        ? Icons.check_circle
+                        : Icons.warning_amber,
+                    color: gitInfo.workingDirectory.clean
+                        ? Colors.green
+                        : Colors.orange,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    gitInfo.workingDirectory.clean
+                        ? 'Working directory clean'
+                        : '${gitInfo.workingDirectory.uncommittedCount} uncommitted change${gitInfo.workingDirectory.uncommittedCount == 1 ? '' : 's'}',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _BranchStatusRow extends StatelessWidget {
+  final String label;
+  final bool exists;
+  final BranchCommit? commit;
+  final Color color;
+
+  const _BranchStatusRow({
+    required this.label,
+    required this.exists,
+    required this.commit,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 60,
+          child: Text(
+            label,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: color,
+            ),
+          ),
+        ),
+        if (!exists)
+          Text(
+            'not found',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.outline,
+            ),
+          )
+        else if (commit != null) ...[
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  commit!.hashShort ?? commit!.hash,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontFamily: 'monospace',
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
+                Text(
+                  commit!.message,
+                  style: theme.textTheme.bodySmall,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _AheadBehindIndicator extends StatelessWidget {
+  final MainVsDevelop mainVsDevelop;
+
+  const _AheadBehindIndicator({required this.mainVsDevelop});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    if (!mainVsDevelop.diverged &&
+        mainVsDevelop.mainAhead == 0 &&
+        mainVsDevelop.developAhead == 0) {
+      return Row(
+        children: [
+          Icon(Icons.check, size: 16, color: Colors.green),
+          const SizedBox(width: 8),
+          Text(
+            'Branches are in sync',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.outline,
+            ),
+          ),
+        ],
+      );
+    }
+
+    return Row(
+      children: [
+        _AheadBehindBadge(
+          label: 'main',
+          count: mainVsDevelop.mainAhead,
+          color: theme.colorScheme.primary,
+          tooltip: 'commits ahead of develop',
+        ),
+        const SizedBox(width: 8),
+        _AheadBehindBadge(
+          label: 'develop',
+          count: mainVsDevelop.developAhead,
+          color: theme.colorScheme.secondary,
+          tooltip: 'commits ahead of main',
+        ),
+      ],
+    );
+  }
+}
+
+class _AheadBehindBadge extends StatelessWidget {
+  final String label;
+  final int count;
+  final Color color;
+  final String tooltip;
+
+  const _AheadBehindBadge({
+    required this.label,
+    required this.count,
+    required this.color,
+    required this.tooltip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Tooltip(
+      message: tooltip,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: color.withValues(alpha: 0.3)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              label,
+              style: theme.textTheme.labelSmall?.copyWith(color: color),
+            ),
+            const SizedBox(width: 4),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+              decoration: BoxDecoration(
+                color: color,
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Text(
+                count > 0 ? '+$count' : '0',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Feature branches section with list of branch tiles.
+class _FeatureBranchesSection extends StatelessWidget {
+  final List<FeatureBranch> branches;
+  final void Function(FeatureBranch) onBranchTap;
+
+  const _FeatureBranchesSection({
+    required this.branches,
+    required this.onBranchTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 24, 16, 8),
+          child: Row(
+            children: [
+              Text(
+                'Feature Branches',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.secondaryContainer,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Text(
+                  '${branches.length}',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onSecondaryContainer,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        ListView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: branches.length,
+          itemBuilder: (context, index) {
+            final branch = branches[index];
+            final commit = branch.latestCommit;
+            return ListTile(
+              onTap: () => onBranchTap(branch),
+              leading: CircleAvatar(
+                backgroundColor:
+                    theme.colorScheme.secondaryContainer,
+                child: Icon(Icons.account_tree,
+                    size: 18, color: theme.colorScheme.onSecondaryContainer),
+              ),
+              title: Text(
+                branch.name,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              subtitle: Text(
+                '${commit.hashShort ?? commit.hash} · ${_formatDate(commit.date)}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontFamily: 'monospace',
+                  color: theme.colorScheme.outline,
+                ),
+              ),
+              trailing: const Icon(Icons.chevron_right),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  String _formatDate(String iso) {
+    try {
+      final dt = DateTime.parse(iso).toLocal();
+      final months = [
+        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+      ];
+      return '${months[dt.month - 1]} ${dt.day}';
+    } catch (_) {
+      return '';
+    }
+  }
+}
+
+/// Deployments section with running and recent subsections.
+class _DeploymentsSection extends StatelessWidget {
+  final List<Deployment> runningDeployments;
+  final List<Deployment> recentDeployments;
+  final void Function(Deployment) onDeploymentTap;
+
+  const _DeploymentsSection({
+    required this.runningDeployments,
+    required this.recentDeployments,
+    required this.onDeploymentTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 24, 16, 8),
+          child: Text(
+            'Deployments',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+
+        // Running deployments
+        if (runningDeployments.isNotEmpty) ...[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+            child: Row(
+              children: [
+                Container(
+                  width: 8,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: Colors.blue,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'Running',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          ...runningDeployments.map((d) => _DeploymentTile(
+                deployment: d,
+                onTap: () => onDeploymentTap(d),
+              )),
+        ],
+
+        // Recent deployments
+        if (recentDeployments.isNotEmpty) ...[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+            child: Text(
+              'Recent',
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            ),
+          ),
+          ...recentDeployments.map((d) => _DeploymentTile(
+                deployment: d,
+                onTap: () => onDeploymentTap(d),
+              )),
+        ],
+      ],
+    );
+  }
+}
+
+class _DeploymentTile extends StatelessWidget {
+  final Deployment deployment;
+  final VoidCallback onTap;
+
+  const _DeploymentTile({required this.deployment, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = statusColor(context, deployment.status);
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: ListTile(
+        onTap: onTap,
+        leading: CircleAvatar(
+          backgroundColor: color.withValues(alpha: 0.15),
+          child: Icon(statusIcon(deployment.status), color: color, size: 20),
+        ),
+        title: Text(
+          deployment.deploymentId,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontFamily: 'monospace',
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        subtitle: Text(
+          '${deployment.team} · ${deployment.status}',
+          style: theme.textTheme.bodySmall?.copyWith(color: color),
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (deployment.isRunning)
+              SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: color,
+                ),
+              ),
+            const SizedBox(width: 8),
+            const Icon(Icons.chevron_right),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -9,6 +9,7 @@ import '../models/create_idea_payload.dart';
 import '../models/deploy_result.dart';
 import '../models/deploy_routing.dart';
 import '../models/deployment.dart';
+import '../models/repo_git_info.dart';
 import '../models/feedback_payload.dart';
 import '../models/pa_team.dart';
 import '../models/review_item.dart';
@@ -482,6 +483,38 @@ class AgentApiClient {
     final timers = response['timers'] as List;
     return timers
         .map((e) => TimerInfo.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  // --- Repo Detail ---
+
+  /// Fetch git info for a repository.
+  ///
+  /// GET /api/repos/:key/git-info → RepoGitInfo
+  Future<RepoGitInfo> getRepoGitInfo(String key) async {
+    final encoded = Uri.encodeComponent(key);
+    final response = await _get('/api/repos/$encoded/git-info');
+    return RepoGitInfo.fromJson(response);
+  }
+
+  /// Fetch deployments for a repository.
+  ///
+  /// GET /api/repos/:key/deployments?status=X&limit=Y → List<Deployment>
+  Future<List<Deployment>> getRepoDeployments(
+    String key, {
+    String? status,
+    int? limit,
+  }) async {
+    final params = <String, String>{};
+    if (status != null && status.isNotEmpty) params['status'] = status;
+    if (limit != null) params['limit'] = '$limit';
+    final encoded = Uri.encodeComponent(key);
+    final query =
+        params.isNotEmpty ? '?${Uri(queryParameters: params).query}' : '';
+    final response = await _get('/api/repos/$encoded/deployments$query');
+    final deployments = response['deployments'] as List;
+    return deployments
+        .map((e) => Deployment.fromJson(e as Map<String, dynamic>))
         .toList();
   }
 

--- a/phone/lib/utils/date_helpers.dart
+++ b/phone/lib/utils/date_helpers.dart
@@ -1,0 +1,69 @@
+// Date formatting utilities for the phone app.
+
+/// Formats a date in short format: "Mon D" (e.g., "Apr 4").
+String formatDateShort(String iso) {
+  try {
+    final dt = DateTime.parse(iso).toLocal();
+    const months = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+    return '${months[dt.month - 1]} ${dt.day}';
+  } catch (_) {
+    return '';
+  }
+}
+
+/// Formats a date in long format: "Mon D, YYYY HH:MM" (e.g., "Apr 4, 2026 14:30").
+String formatDateLong(String iso) {
+  try {
+    final dt = DateTime.parse(iso).toLocal();
+    const months = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+    final h = dt.hour.toString().padLeft(2, '0');
+    final m = dt.minute.toString().padLeft(2, '0');
+    return '${months[dt.month - 1]} ${dt.day}, ${dt.year} $h:$m';
+  } catch (_) {
+    return iso;
+  }
+}
+
+/// Formats a date as relative time (e.g., "2h ago", "3d ago").
+String formatRelativeTime(String iso) {
+  try {
+    final dt = DateTime.parse(iso).toLocal();
+    final now = DateTime.now();
+    final diff = now.difference(dt);
+
+    if (diff.isNegative) {
+      // Future date - show absolute
+      return formatDateShort(iso);
+    }
+
+    if (diff.inMinutes < 1) {
+      return 'just now';
+    }
+    if (diff.inMinutes < 60) {
+      final mins = diff.inMinutes;
+      return '${mins}m ago';
+    }
+    if (diff.inHours < 24) {
+      final hours = diff.inHours;
+      return '${hours}h ago';
+    }
+    if (diff.inDays < 7) {
+      final days = diff.inDays;
+      return '${days}d ago';
+    }
+    if (diff.inDays < 30) {
+      final weeks = (diff.inDays / 7).floor();
+      return '${weeks}w ago';
+    }
+
+    return formatDateShort(iso);
+  } catch (_) {
+    return '';
+  }
+}

--- a/phone/lib/utils/deploy_helpers.dart
+++ b/phone/lib/utils/deploy_helpers.dart
@@ -12,6 +12,7 @@ Color statusColor(BuildContext context, String status) {
       return Colors.orange;
     case 'failed':
     case 'crashed':
+    case 'dead':
       return Colors.red;
     default:
       return Theme.of(context).colorScheme.outline;
@@ -30,6 +31,7 @@ IconData statusIcon(String status) {
       return Icons.warning_amber_outlined;
     case 'failed':
     case 'crashed':
+    case 'dead':
       return Icons.error_outline;
     default:
       return Icons.help_outline;


### PR DESCRIPTION
## Summary
- New **RepoDetailScreen** accessible from Kanban board info button next to project dropdown
- Shows git info (current branch, main vs develop ahead/behind, feature branches, working directory status) and deployment history (running + finished) for the selected project's repo
- Includes **BranchDetailScreen** for feature branch drill-down
- Pure read-only, 14 acceptance criteria defined

## Changes
- `phone/lib/models/repo_git_info.dart` — New Dart models: RepoGitInfo, BranchInfo, BranchCommit, MainVsDevelop, WorkingDirectoryStatus, FeatureBranch, RepoMeta
- `phone/lib/services/agent_api_client.dart` — Added getRepoGitInfo() and getRepoDeployments() API client methods
- `phone/lib/screens/branch_detail_screen.dart` — New BranchDetailScreen for branch detail viewing
- `phone/lib/screens/repo_detail_screen.dart` — New RepoDetailScreen with git info + deployment sections
- `phone/lib/screens/kanban_board_screen.dart` — Added info icon button in filter row

## Test plan
- [ ] Verify info button appears next to project dropdown on Kanban board
- [ ] Verify info button is disabled when no project selected
- [ ] Tap info button and verify RepoDetailScreen opens with git info
- [ ] Verify main vs develop comparison shows ahead/behind counts
- [ ] Verify feature branches list with commit info
- [ ] Verify working directory status indicator
- [ ] Verify running and finished deployments sections
- [ ] Tap deployment to verify navigation to ActivityTimelineScreen
- [ ] Tap feature branch to verify navigation to BranchDetailScreen
- [ ] Pull-to-refresh works
- [ ] API unreachable shows error with retry button
- [ ] Non-repo project shows friendly 404 message

Ticket: AVO-043