### PR TITLE
feat(phone): align image upload client with PA-1069 backend

### DIFF
--- a/phone/lib/screens/create_ticket_screen.dart
+++ b/phone/lib/screens/create_ticket_screen.dart
@@ -103,12 +103,13 @@ class _CreateTicketScreenState extends State<CreateTicketScreen> {
       if (selectedImages.isNotEmpty) {
         imagePicker?.setUploading(true);
         try {
-          final docRefs = await imagePicker!.widget.onUpload(selectedImages, ticketId);
-          // Update ticket with attachment doc_refs
-          if (docRefs.isNotEmpty) {
-            await widget.boardProvider.client.updateTicket(ticketId, {
-              'doc_refs': [...ticket.docRefs, ...docRefs],
-            });
+          final (successes: _, failures: failures) =
+              await imagePicker!.widget.onUpload(selectedImages, ticketId);
+          if (failures.isNotEmpty && mounted) {
+            final names = failures.map((p) => p.split('/').last).join(', ');
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Failed to upload: $names')),
+            );
           }
         } finally {
           imagePicker?.setUploading(false);
@@ -368,16 +369,21 @@ class _CreateTicketScreenState extends State<CreateTicketScreen> {
                     ImageAttachmentPicker(
                       key: _imagePickerKey,
                       onUpload: (images, ticketId) async {
-                        final docRefs = <String>[];
+                        final successes = <String>[];
+                        final failures = <String>[];
                         final picker = _imagePickerKey.currentState!;
                         for (var i = 0; i < images.length; i++) {
                           picker.setUploadProgress((i + 0.5) / images.length);
-                          final docRef = await widget.boardProvider.client
-                              .uploadAttachment(ticketId, images[i]);
-                          docRefs.add(docRef);
+                          try {
+                            final docRef = await widget.boardProvider.client
+                                .uploadAttachment(ticketId, images[i]);
+                            successes.add(docRef);
+                          } catch (_) {
+                            failures.add(images[i].path);
+                          }
                         }
                         picker.setUploadProgress(1.0);
-                        return docRefs;
+                        return (successes: successes, failures: failures);
                       },
                       onUploadingChanged: (uploading) {
                         setState(() {});

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -687,7 +687,7 @@ class AgentApiClient {
       _throwApiException(response.statusCode, response.body);
     }
 
-    // Parse response: {"docRef": "attachment:..."}
+    // Parse response: {"docRef": "attachments/<ticket-id>/<filename>"}
     final json = jsonDecode(response.body) as Map<String, dynamic>;
     final docRef = json['docRef'] as String?;
     if (docRef == null || docRef.isEmpty) {

--- a/phone/lib/widgets/image_attachment_picker.dart
+++ b/phone/lib/widgets/image_attachment_picker.dart
@@ -17,8 +17,9 @@ class UploadedImage {
 /// buttons, and provides upload progress tracking.
 class ImageAttachmentPicker extends StatefulWidget {
   /// Called when images are ready to be uploaded (after ticket is created).
-  /// Returns list of uploaded image doc_refs.
-  final Future<List<String>> Function(List<XFile> images, String ticketId)
+  /// Returns successes and failures separately to support partial upload handling.
+  final Future<({List<String> successes, List<String> failures})> Function(
+          List<XFile> images, String ticketId)
       onUpload;
 
   /// Whether uploads are currently in progress.


### PR DESCRIPTION
## Summary
- **Bug 1**: Remove redundant `updateTicket()` call after image uploads — server's upload endpoint already adds `doc_ref` to ticket via `add_doc_ref`. Client calling `updateTicket` caused duplicate/malformed doc_refs.
- **Bug 2**: Fix misleading response format comment in `uploadAttachment()` — actual response is `"attachments/<ticket-id>/<filename>"`, not `"attachment:..."`.
- **Bug 3**: Add per-image try-catch for partial upload failure handling — if image 2 of 3 fails, images 1 and 3 still upload. User sees SnackBar with failed image names.

## Files Changed
- `phone/lib/screens/create_ticket_screen.dart` — Removed `updateTicket` block, added partial failure SnackBar
- `phone/lib/services/agent_api_client.dart` — Fixed comment on line 690
- `phone/lib/widgets/image_attachment_picker.dart` — Changed `onUpload` return type to record `({successes, failures})`

## Ticket
AVO-037

## Test plan
- [ ] Verify `flutter analyze` passes with no new warnings
- [ ] E2E: Create ticket with 1 image, verify single doc_ref entry (no duplicates)
- [ ] E2E: Create ticket with 3 images where 1 fails, verify 2 succeed and SnackBar shows failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)