### PR TITLE
fix(phone): AVO-036 address code review findings

### DIFF
--- a/phone/lib/screens/create_ticket_screen.dart
+++ b/phone/lib/screens/create_ticket_screen.dart
@@ -6,6 +6,7 @@ import '../services/agent_api_client.dart';
 import '../services/board_provider.dart';
 import '../widgets/guided_summary_fields.dart';
 import '../widgets/image_attachment_picker.dart';
+import '../widgets/no_select_text_field.dart';
 
 /// Form for creating a new ticket.
 ///
@@ -41,10 +42,13 @@ class _CreateTicketScreenState extends State<CreateTicketScreen> {
   static const _priorities = ['critical', 'high', 'medium', 'low'];
   static const _estimates = ['XS', 'S', 'M', 'L', 'XL'];
 
+  late final Future<List<AgentTeam>> _teamsFuture;
+
   @override
   void initState() {
     super.initState();
     _selectedProject = widget.boardProvider.selectedProject;
+    _teamsFuture = widget.boardProvider.client.listAgentTeams();
   }
 
   @override
@@ -194,7 +198,7 @@ class _CreateTicketScreenState extends State<CreateTicketScreen> {
             const SizedBox(height: 16),
 
             // Title
-            _NoSelectTextField(
+            NoSelectTextField(
               controller: _titleController,
               decoration: const InputDecoration(
                 labelText: 'Title *',
@@ -241,7 +245,7 @@ class _CreateTicketScreenState extends State<CreateTicketScreen> {
 
             // Team — dropdown populated from API
             FutureBuilder<List<AgentTeam>>(
-              future: widget.boardProvider.client.listAgentTeams(),
+              future: _teamsFuture,
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
                   return InputDecorator(
@@ -396,7 +400,7 @@ class _CreateTicketScreenState extends State<CreateTicketScreen> {
             const SizedBox(height: 12),
 
             // Freeform additional notes
-            _NoSelectTextField(
+            NoSelectTextField(
               controller: _freeformSummaryController,
               decoration: const InputDecoration(
                 labelText: 'Additional notes (optional)',
@@ -547,129 +551,10 @@ class _TypePickerSheet extends StatelessWidget {
               );
             }),
             const SizedBox(height: 8),
-            const Divider(),
-            ListTile(
-              leading: const Icon(Icons.info_outline),
-              title: const Text('Show all types'),
-              subtitle: const Text('Includes agent types (review-request, work-report, fyi)'),
-              dense: true,
-              onTap: () {
-                Navigator.of(context).pop();
-                _showAllTypesPicker(context);
-              },
-            ),
           ],
         ),
       ),
     );
   }
-
-  void _showAllTypesPicker(BuildContext context) {
-    // Fallback: show original flat dropdown of all 8 types
-    showModalBottomSheet(
-      context: context,
-      builder: (ctx) => SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(
-                  'All Types',
-                  style: Theme.of(context).textTheme.titleLarge,
-                ),
-              ),
-              const SizedBox(height: 8),
-              ...['feature', 'bug', 'task', 'review-request', 'work-report', 'fyi', 'idea', 'question']
-                  .map((t) => ListTile(
-                        title: Text(t),
-                        onTap: () {
-                          Navigator.of(ctx).pop();
-                          // Map back to PhoneTicketType if possible
-                          final mapped = PhoneTicketType.values.where((p) => p.name == t).firstOrNull;
-                          if (mapped != null) {
-                            onChanged(mapped);
-                          }
-                        },
-                      )),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
 }
 
-/// A TextField that places cursor at tap position on single tap,
-/// without selecting text. Preserves double-tap word selection.
-///
-/// Works around flutter/flutter#98720, #105185 where single taps in
-/// TextFields can unexpectedly select words instead of placing cursor.
-class _NoSelectTextField extends StatefulWidget {
-  final TextEditingController controller;
-  final InputDecoration? decoration;
-  final int? maxLines;
-  final ValueChanged<String>? onChanged;
-  final bool autofocus;
-  final TextCapitalization textCapitalization;
-  final FormFieldValidator<String>? validator;
-
-  const _NoSelectTextField({
-    required this.controller,
-    this.decoration,
-    this.maxLines,
-    this.onChanged,
-    this.autofocus = false,
-    this.textCapitalization = TextCapitalization.sentences,
-    this.validator,
-  });
-
-  @override
-  State<_NoSelectTextField> createState() => _NoSelectTextFieldState();
-}
-
-class _NoSelectTextFieldState extends State<_NoSelectTextField> {
-  Offset? _tapPosition;
-
-  void _handleTapDown(TapDownDetails details) {
-    _tapPosition = details.globalPosition;
-  }
-
-  void _handleTap() {
-    if (_tapPosition == null) return;
-    final renderBox = context.findRenderObject() as RenderBox;
-    final localPosition = renderBox.globalToLocal(_tapPosition!);
-
-    final textPainter = TextPainter(
-      text: TextSpan(text: widget.controller.text),
-      textDirection: TextDirection.ltr,
-    );
-    textPainter.layout(maxWidth: renderBox.size.width);
-
-    final textPosition = textPainter.getPositionForOffset(localPosition);
-    widget.controller.selection = TextSelection.collapsed(
-      offset: textPosition.offset,
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTapDown: _handleTapDown,
-      onTap: _handleTap,
-      behavior: HitTestBehavior.opaque,
-      child: TextFormField(
-        controller: widget.controller,
-        autofocus: widget.autofocus,
-        maxLines: widget.maxLines,
-        decoration: widget.decoration,
-        onChanged: widget.onChanged,
-        textCapitalization: widget.textCapitalization,
-        validator: widget.validator,
-      ),
-    );
-  }
-}

--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -13,6 +13,7 @@ import '../widgets/estimate_picker_sheet.dart';
 import '../widgets/priority_picker_sheet.dart';
 import '../widgets/status_picker_sheet.dart';
 import '../widgets/team_picker_sheet.dart';
+import '../widgets/no_select_text_field.dart';
 import '../widgets/text_input_sheet.dart';
 import 'activity_timeline_screen.dart';
 
@@ -678,7 +679,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
             Text('Edit Comment',
                 style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 12),
-            _NoSelectTextField(
+            NoSelectTextFieldRaw(
               controller: editController,
               autofocus: true,
               maxLines: null,
@@ -907,8 +908,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
                 ),
             ],
           ),
-          if (ticket.team != null || ticket.assignee != null) ...[
-            const SizedBox(height: 10),
+          const SizedBox(height: 10),
             // Team row — tappable (min 48dp tall for tap target)
             // Always show (even when null) so user can set a team
             ConstrainedBox(
@@ -980,7 +980,6 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
                   ),
                 ),
               ),
-          ],
           if (ticket.summary != null && ticket.summary!.isNotEmpty) ...[
             const SizedBox(height: 16),
             _SectionLabel('Summary'),
@@ -1110,7 +1109,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
         child: Row(
           children: [
             Expanded(
-              child: _NoSelectTextField(
+              child: NoSelectTextFieldRaw(
                 controller: _commentController,
                 decoration: const InputDecoration(
                   hintText: 'Add a comment…',
@@ -1521,7 +1520,7 @@ class _TagSheetState extends State<_TagSheet> {
                 SizedBox(
                   width: 140,
                   height: 36,
-                  child: _NoSelectTextField(
+                  child: NoSelectTextFieldRaw(
                     controller: _inputController,
                     decoration: const InputDecoration(
                       hintText: 'Add tag…',
@@ -1577,74 +1576,6 @@ class _FieldSavingIndicator extends StatelessWidget {
           child: CircularProgressIndicator(strokeWidth: 2),
         ),
       ],
-    );
-  }
-}
-
-/// A TextField that places cursor at tap position on single tap,
-/// without selecting text. Preserves double-tap word selection.
-///
-/// Works around flutter/flutter#98720, #105185 where single taps in
-/// TextFields can unexpectedly select words instead of placing cursor.
-class _NoSelectTextField extends StatefulWidget {
-  final TextEditingController controller;
-  final InputDecoration? decoration;
-  final int? maxLines;
-  final TextInputAction? textInputAction;
-  final ValueChanged<String>? onSubmitted;
-  final bool autofocus;
-
-  const _NoSelectTextField({
-    required this.controller,
-    this.decoration,
-    this.maxLines,
-    this.textInputAction,
-    this.onSubmitted,
-    this.autofocus = false,
-  });
-
-  @override
-  State<_NoSelectTextField> createState() => _NoSelectTextFieldState();
-}
-
-class _NoSelectTextFieldState extends State<_NoSelectTextField> {
-  Offset? _tapPosition;
-
-  void _handleTapDown(TapDownDetails details) {
-    _tapPosition = details.globalPosition;
-  }
-
-  void _handleTap() {
-    if (_tapPosition == null) return;
-    final renderBox = context.findRenderObject() as RenderBox;
-    final localPosition = renderBox.globalToLocal(_tapPosition!);
-
-    final textPainter = TextPainter(
-      text: TextSpan(text: widget.controller.text),
-      textDirection: TextDirection.ltr,
-    );
-    textPainter.layout(maxWidth: renderBox.size.width);
-
-    final textPosition = textPainter.getPositionForOffset(localPosition);
-    widget.controller.selection = TextSelection.collapsed(
-      offset: textPosition.offset,
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTapDown: _handleTapDown,
-      onTap: _handleTap,
-      behavior: HitTestBehavior.opaque,
-      child: TextField(
-        controller: widget.controller,
-        autofocus: widget.autofocus,
-        maxLines: widget.maxLines,
-        decoration: widget.decoration,
-        textInputAction: widget.textInputAction,
-        onSubmitted: widget.onSubmitted,
-      ),
     );
   }
 }

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -199,7 +199,7 @@ class AgentApiClient {
 
   /// Fetch detailed deployment info including all metadata + activity events.
   ///
-  /// Calls GET /api/deployments/<id> which returns a merged object with
+  /// Calls GET /api/deployments/\<id> which returns a merged object with
   /// full deployment metadata and the activity_events array.
   Future<Deployment> getDeploymentDetail(String id) async {
     final response = await _get('/api/deployments/$id');
@@ -500,7 +500,7 @@ class AgentApiClient {
 
   /// Fetch deployments for a repository.
   ///
-  /// GET /api/repos/:key/deployments?status=X&limit=Y → List<Deployment>
+  /// GET /api/repos/\:key/deployments?status=X&limit=Y → List\<Deployment>
   Future<List<Deployment>> getRepoDeployments(
     String key, {
     String? status,

--- a/phone/lib/widgets/guided_summary_fields.dart
+++ b/phone/lib/widgets/guided_summary_fields.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../config/ticket_type_config.dart';
+import 'no_select_text_field.dart';
 
 /// Widget that renders dynamic guided input fields based on the selected ticket type.
 ///
@@ -101,7 +102,7 @@ class GuidedSummaryFieldsState extends State<GuidedSummaryFields> {
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
-      child: _NoSelectTextField(
+      child: NoSelectTextField(
         controller: controller,
         decoration: InputDecoration(
           labelText: field.label + (field.required ? ' *' : ''),
@@ -131,7 +132,7 @@ class GuidedSummaryFieldsState extends State<GuidedSummaryFields> {
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: DropdownButtonFormField<String>(
-        value: controller!.text.isEmpty ? null : controller.text,
+        initialValue: controller!.text.isEmpty ? null : controller.text,
         decoration: InputDecoration(
           labelText: field.label + (field.required ? ' *' : ''),
           border: const OutlineInputBorder(),
@@ -174,70 +175,3 @@ class GuidedSummaryFieldsState extends State<GuidedSummaryFields> {
   }
 }
 
-/// A TextField that places cursor at tap position on single tap,
-/// without selecting text. Preserves double-tap word selection.
-///
-/// Works around flutter/flutter#98720, #105185 where single taps in
-/// TextFields can unexpectedly select words instead of placing cursor.
-class _NoSelectTextField extends StatefulWidget {
-  final TextEditingController controller;
-  final InputDecoration? decoration;
-  final int? maxLines;
-  final ValueChanged<String>? onChanged;
-  final bool autofocus;
-  final TextCapitalization textCapitalization;
-
-  const _NoSelectTextField({
-    required this.controller,
-    this.decoration,
-    this.maxLines,
-    this.onChanged,
-    this.autofocus = false,
-    this.textCapitalization = TextCapitalization.sentences,
-  });
-
-  @override
-  State<_NoSelectTextField> createState() => _NoSelectTextFieldState();
-}
-
-class _NoSelectTextFieldState extends State<_NoSelectTextField> {
-  Offset? _tapPosition;
-
-  void _handleTapDown(TapDownDetails details) {
-    _tapPosition = details.globalPosition;
-  }
-
-  void _handleTap() {
-    if (_tapPosition == null) return;
-    final renderBox = context.findRenderObject() as RenderBox;
-    final localPosition = renderBox.globalToLocal(_tapPosition!);
-
-    final textPainter = TextPainter(
-      text: TextSpan(text: widget.controller.text),
-      textDirection: TextDirection.ltr,
-    );
-    textPainter.layout(maxWidth: renderBox.size.width);
-
-    final textPosition = textPainter.getPositionForOffset(localPosition);
-    widget.controller.selection = TextSelection.collapsed(
-      offset: textPosition.offset,
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTapDown: _handleTapDown,
-      onTap: _handleTap,
-      behavior: HitTestBehavior.opaque,
-      child: TextFormField(
-        controller: widget.controller,
-        autofocus: widget.autofocus,
-        maxLines: widget.maxLines,
-        decoration: widget.decoration,
-        onChanged: widget.onChanged,
-        textCapitalization: widget.textCapitalization,
-      ),
-    );
-  }
-}

--- a/phone/lib/widgets/no_select_text_field.dart
+++ b/phone/lib/widgets/no_select_text_field.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+
+/// A TextField that places cursor at tap position on single tap,
+/// without selecting text. Preserves double-tap word selection.
+///
+/// Works around flutter/flutter#98720, #105185 where single taps in
+/// TextFields can unexpectedly select words instead of placing cursor.
+class NoSelectTextField extends StatefulWidget {
+  final TextEditingController controller;
+  final InputDecoration? decoration;
+  final int? maxLines;
+  final int? minLines;
+  final TextStyle? style;
+  final TextCapitalization textCapitalization;
+  final TextInputType? keyboardType;
+  final FormFieldValidator<String>? validator;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final TextInputAction? textInputAction;
+  final bool autofocus;
+
+  const NoSelectTextField({
+    super.key,
+    required this.controller,
+    this.decoration,
+    this.maxLines,
+    this.minLines,
+    this.style,
+    this.textCapitalization = TextCapitalization.sentences,
+    this.keyboardType,
+    this.validator,
+    this.onChanged,
+    this.onSubmitted,
+    this.textInputAction,
+    this.autofocus = false,
+  });
+
+  @override
+  State<NoSelectTextField> createState() => _NoSelectTextFieldFormFieldState();
+}
+
+class _NoSelectTextFieldFormFieldState extends State<NoSelectTextField> {
+  Offset? _tapPosition;
+
+  void _handleTapDown(TapDownDetails details) {
+    _tapPosition = details.globalPosition;
+  }
+
+  void _handleTap() {
+    if (_tapPosition == null) return;
+    final renderBox = context.findRenderObject() as RenderBox;
+    final localPosition = renderBox.globalToLocal(_tapPosition!);
+
+    final textPainter = TextPainter(
+      text: TextSpan(text: widget.controller.text),
+      textDirection: TextDirection.ltr,
+    );
+    textPainter.layout(maxWidth: renderBox.size.width);
+
+    final textPosition = textPainter.getPositionForOffset(localPosition);
+    widget.controller.selection = TextSelection.collapsed(
+      offset: textPosition.offset,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: _handleTapDown,
+      onTap: _handleTap,
+      behavior: HitTestBehavior.opaque,
+      child: TextFormField(
+        controller: widget.controller,
+        autofocus: widget.autofocus,
+        maxLines: widget.maxLines,
+        minLines: widget.minLines,
+        style: widget.style,
+        decoration: widget.decoration,
+        onChanged: widget.onChanged,
+        textCapitalization: widget.textCapitalization,
+        keyboardType: widget.keyboardType,
+        validator: widget.validator,
+        onFieldSubmitted: widget.onSubmitted,
+        textInputAction: widget.textInputAction,
+      ),
+    );
+  }
+}
+
+/// A TextField variant that uses [TextField] instead of [TextFormField],
+/// for callers that do not need validation.
+class NoSelectTextFieldRaw extends StatefulWidget {
+  final TextEditingController controller;
+  final InputDecoration? decoration;
+  final int? maxLines;
+  final int? minLines;
+  final TextStyle? style;
+  final TextCapitalization textCapitalization;
+  final TextInputType? keyboardType;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final TextInputAction? textInputAction;
+  final bool autofocus;
+
+  const NoSelectTextFieldRaw({
+    super.key,
+    required this.controller,
+    this.decoration,
+    this.maxLines,
+    this.minLines,
+    this.style,
+    this.textCapitalization = TextCapitalization.sentences,
+    this.keyboardType,
+    this.onChanged,
+    this.onSubmitted,
+    this.textInputAction,
+    this.autofocus = false,
+  });
+
+  @override
+  State<NoSelectTextFieldRaw> createState() => _NoSelectTextFieldRawState();
+}
+
+class _NoSelectTextFieldRawState extends State<NoSelectTextFieldRaw> {
+  Offset? _tapPosition;
+
+  void _handleTapDown(TapDownDetails details) {
+    _tapPosition = details.globalPosition;
+  }
+
+  void _handleTap() {
+    if (_tapPosition == null) return;
+    final renderBox = context.findRenderObject() as RenderBox;
+    final localPosition = renderBox.globalToLocal(_tapPosition!);
+
+    final textPainter = TextPainter(
+      text: TextSpan(text: widget.controller.text),
+      textDirection: TextDirection.ltr,
+    );
+    textPainter.layout(maxWidth: renderBox.size.width);
+
+    final textPosition = textPainter.getPositionForOffset(localPosition);
+    widget.controller.selection = TextSelection.collapsed(
+      offset: textPosition.offset,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: _handleTapDown,
+      onTap: _handleTap,
+      behavior: HitTestBehavior.opaque,
+      child: TextField(
+        controller: widget.controller,
+        autofocus: widget.autofocus,
+        maxLines: widget.maxLines,
+        minLines: widget.minLines,
+        style: widget.style,
+        decoration: widget.decoration,
+        onChanged: widget.onChanged,
+        textCapitalization: widget.textCapitalization,
+        keyboardType: widget.keyboardType,
+        textInputAction: widget.textInputAction,
+        onSubmitted: widget.onSubmitted,
+      ),
+    );
+  }
+}

--- a/phone/lib/widgets/text_input_sheet.dart
+++ b/phone/lib/widgets/text_input_sheet.dart
@@ -1,74 +1,6 @@
 import 'package:flutter/material.dart';
 
-/// A TextField that places cursor at tap position on single tap,
-/// without selecting text. Preserves double-tap word selection.
-///
-/// Works around flutter/flutter#98720, #105185 where single taps in
-/// TextFields can unexpectedly select words instead of placing cursor.
-class _NoSelectTextField extends StatefulWidget {
-  final TextEditingController controller;
-  final InputDecoration? decoration;
-  final int? maxLines;
-  final TextInputAction? textInputAction;
-  final ValueChanged<String>? onSubmitted;
-  final bool autofocus;
-
-  const _NoSelectTextField({
-    required this.controller,
-    this.decoration,
-    this.maxLines,
-    this.textInputAction,
-    this.onSubmitted,
-    this.autofocus = false,
-  });
-
-  @override
-  State<_NoSelectTextField> createState() => _NoSelectTextFieldState();
-}
-
-class _NoSelectTextFieldState extends State<_NoSelectTextField> {
-  Offset? _tapPosition;
-
-  void _handleTapDown(TapDownDetails details) {
-    _tapPosition = details.globalPosition;
-  }
-
-  void _handleTap() {
-    if (_tapPosition == null) return;
-    final renderBox = context.findRenderObject() as RenderBox;
-    final localPosition = renderBox.globalToLocal(_tapPosition!);
-
-    // Calculate cursor offset from tap position
-    final textPainter = TextPainter(
-      text: TextSpan(text: widget.controller.text),
-      textDirection: TextDirection.ltr,
-    );
-    textPainter.layout(maxWidth: renderBox.size.width);
-
-    // Find the character offset nearest to tap position
-    final textPosition = textPainter.getPositionForOffset(localPosition);
-    widget.controller.selection = TextSelection.collapsed(
-      offset: textPosition.offset,
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTapDown: _handleTapDown,
-      onTap: _handleTap,
-      behavior: HitTestBehavior.opaque,
-      child: TextField(
-        controller: widget.controller,
-        autofocus: widget.autofocus,
-        maxLines: widget.maxLines,
-        decoration: widget.decoration,
-        textInputAction: widget.textInputAction,
-        onSubmitted: widget.onSubmitted,
-      ),
-    );
-  }
-}
+import 'no_select_text_field.dart';
 
 /// A reusable bottom sheet for text input with confirm/cancel behavior.
 ///
@@ -144,7 +76,7 @@ class _TextInputSheetState extends State<TextInputSheet> {
                   ?.copyWith(fontWeight: FontWeight.w600),
             ),
             const SizedBox(height: 12),
-            _NoSelectTextField(
+            NoSelectTextFieldRaw(
               controller: _controller,
               autofocus: true,
               maxLines: null,


### PR DESCRIPTION
## Summary
- Fixed team row visibility bug: removed `if` guard so team/assignee section always shows on ticket detail screen
- Removed "Show all types" dead-end UX: agent-only types no longer shown in phone picker
- Extracted `_NoSelectTextField` into single public `NoSelectTextField` widget (was duplicated 4x)
- Cached teams future in `CreateTicketScreen.initState` to prevent refetch on every `setState`
- Fixed flutter analyze warnings: deprecated API usage, unused params, doc comment HTML

## Test plan
- [ ] Verify team row visible on ticket detail even when both team and assignee are null
- [ ] Verify type picker does not show agent-only types (review-request, work-report, fyi)
- [ ] Run `cd phone && flutter analyze` — 0 warnings in changed files
- [ ] Create/edit tickets on phone to verify no regressions

Addresses review findings from: agent-teams/requirements/artifacts/2026-04-04-review-avodah-phone-avo036-037.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)