### PR TITLE
fix(phone): AVO-045 handle errors field type mismatch in RepoGitInfo

### DIFF
--- a/phone/lib/models/repo_git_info.dart
+++ b/phone/lib/models/repo_git_info.dart
@@ -35,8 +35,18 @@ class RepoGitInfo {
           const [],
       workingDirectory: WorkingDirectoryStatus.fromJson(
           json['working_directory'] as Map<String, dynamic>),
-      errors: (json['errors'] as List?)?.cast<String>() ?? const [],
+      errors: _parseErrors(json['errors']),
     );
+  }
+
+  static List<String> _parseErrors(dynamic raw) {
+    if (raw is Map) {
+      return raw.values.whereType<String>().toList();
+    }
+    if (raw is List) {
+      return raw.whereType<String>().toList();
+    }
+    return const [];
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix `RepoGitInfo.fromJson` crash when server returns `errors` as a `Map` instead of `List`
- Add defensive `_parseErrors` helper that handles Map, List, null, and absent values
- Resolves AVO-045: "Can't access repo info for learning repo"

## Details
The PA server returns `errors` as `Map<String, String>` (e.g., `{"develop": "Branch 'develop' not found"}`), but the Dart client was parsing it as `List`, causing a `TypeError` that cascaded to "Unable to connect."

The fix uses `_parseErrors(dynamic raw)` which:
- Map → extracts values as strings
- List → casts elements as strings  
- null/other → returns empty list

## Test plan
- [ ] Open repo info for "learning" project (no develop branch) — should not crash
- [ ] Open repo info for "avodah" project — should continue working as before
- [ ] `flutter analyze phone/lib/models/repo_git_info.dart` passes clean

## Related
- AVO-045 (client-side fix)
- PA-1070 (server-side per-repo branch config — separate ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)