### PR TITLE
feat(phone): AVO-051 Fix learning repo info display

### DIFF
--- a/phone/lib/models/repo_git_info.dart
+++ b/phone/lib/models/repo_git_info.dart
@@ -22,6 +22,15 @@ class RepoGitInfo {
     this.errors = const [],
   });
 
+  static List<String> _parseErrors(dynamic errors) {
+    if (errors is List) {
+      return errors.cast<String>();
+    } else if (errors is Map) {
+      return errors.values.map((v) => v.toString()).toList();
+    }
+    return const [];
+  }
+
   factory RepoGitInfo.fromJson(Map<String, dynamic> json) {
     return RepoGitInfo(
       repo: RepoMeta.fromJson(json['repo'] as Map<String, dynamic>),
@@ -35,7 +44,7 @@ class RepoGitInfo {
           const [],
       workingDirectory: WorkingDirectoryStatus.fromJson(
           json['working_directory'] as Map<String, dynamic>),
-      errors: (json['errors'] as List?)?.cast<String>() ?? const [],
+      errors: _parseErrors(json['errors']),
     );
   }
 }

--- a/phone/lib/screens/repo_detail_screen.dart
+++ b/phone/lib/screens/repo_detail_screen.dart
@@ -268,20 +268,32 @@ class _GitInfoSection extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   _BranchStatusRow(
-                    label: 'main',
+                    label: gitInfo.mainBranch.name.isNotEmpty
+                        ? gitInfo.mainBranch.name
+                        : 'main',
                     exists: gitInfo.mainBranch.exists,
                     commit: gitInfo.mainBranch.latestCommit,
                     color: theme.colorScheme.primary,
                   ),
                   const Divider(height: 16),
                   _BranchStatusRow(
-                    label: 'develop',
+                    label: gitInfo.developBranch.name.isNotEmpty
+                        ? gitInfo.developBranch.name
+                        : 'develop',
                     exists: gitInfo.developBranch.exists,
                     commit: gitInfo.developBranch.latestCommit,
                     color: theme.colorScheme.secondary,
                   ),
                   const Divider(height: 16),
-                  _AheadBehindIndicator(mainVsDevelop: gitInfo.mainVsDevelop),
+                  _AheadBehindIndicator(
+                    mainVsDevelop: gitInfo.mainVsDevelop,
+                    mainBranchName: gitInfo.mainBranch.name.isNotEmpty
+                        ? gitInfo.mainBranch.name
+                        : 'main',
+                    developBranchName: gitInfo.developBranch.name.isNotEmpty
+                        ? gitInfo.developBranch.name
+                        : 'develop',
+                  ),
                 ],
               ),
             ),
@@ -344,7 +356,7 @@ class _BranchStatusRow extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         SizedBox(
-          width: 60,
+          width: 120,
           child: Text(
             label,
             style: theme.textTheme.bodyMedium?.copyWith(
@@ -389,8 +401,14 @@ class _BranchStatusRow extends StatelessWidget {
 
 class _AheadBehindIndicator extends StatelessWidget {
   final MainVsDevelop mainVsDevelop;
+  final String mainBranchName;
+  final String developBranchName;
 
-  const _AheadBehindIndicator({required this.mainVsDevelop});
+  const _AheadBehindIndicator({
+    required this.mainVsDevelop,
+    required this.mainBranchName,
+    required this.developBranchName,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -416,17 +434,17 @@ class _AheadBehindIndicator extends StatelessWidget {
     return Row(
       children: [
         _AheadBehindBadge(
-          label: 'main',
+          label: mainBranchName,
           count: mainVsDevelop.mainAhead,
           color: theme.colorScheme.primary,
-          tooltip: 'commits ahead of develop',
+          tooltip: 'commits ahead of $developBranchName',
         ),
         const SizedBox(width: 8),
         _AheadBehindBadge(
-          label: 'develop',
+          label: developBranchName,
           count: mainVsDevelop.developAhead,
           color: theme.colorScheme.secondary,
-          tooltip: 'commits ahead of main',
+          tooltip: 'commits ahead of $mainBranchName',
         ),
       ],
     );


### PR DESCRIPTION
## Summary
- **Phase 1**: Fix `RepoGitInfo.fromJson()` crash when backend returns `errors` as Map instead of List
- **Phase 2**: Use `BranchInfo.name` from API for branch labels instead of hardcoded `main`/`develop` strings, handle long branch names (e.g., `monthly/2026-04`)

## Changes
- `phone/lib/models/repo_git_info.dart`: Add `_parseErrors()` helper to handle both List and Map error formats
- `phone/lib/screens/repo_detail_screen.dart`: Dynamic branch labels from API, wider SizedBox for long names, dynamic tooltips

## Test plan
- [x] `flutter analyze` passes with no issues
- [x] Verified PA-1096 backend API returns correct branch names (AC1-AC5 all pass)
- [ ] Visual check: learning repo shows `monthly/2026-04` label instead of `develop: not found`
- [ ] Regression check: avodah repo still shows `develop` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)