### PR TITLE
fix(phone): RepoGitInfo errors field type mismatch (PA-1068)

### DIFF
--- a/phone/lib/models/repo_git_info.dart
+++ b/phone/lib/models/repo_git_info.dart
@@ -9,7 +9,7 @@ class RepoGitInfo {
   final MainVsDevelop mainVsDevelop;
   final List<FeatureBranch> featureBranches;
   final WorkingDirectoryStatus workingDirectory;
-  final List<String> errors;
+  final Map<String, String> errors;
 
   const RepoGitInfo({
     required this.repo,
@@ -19,16 +19,17 @@ class RepoGitInfo {
     required this.mainVsDevelop,
     required this.featureBranches,
     required this.workingDirectory,
-    this.errors = const [],
+    this.errors = const {},
   });
 
-  static List<String> _parseErrors(dynamic errors) {
-    if (errors is List) {
-      return errors.cast<String>();
-    } else if (errors is Map) {
-      return errors.values.map((v) => v.toString()).toList();
+  static Map<String, String> _parseErrors(dynamic raw) {
+    if (raw is Map) {
+      return raw.map((k, v) => MapEntry(k.toString(), v.toString()));
     }
-    return const [];
+    if (raw is List) {
+      return { for (var i = 0; i < raw.length; i++) 'error_$i': raw[i].toString() };
+    }
+    return const {};
   }
 
   factory RepoGitInfo.fromJson(Map<String, dynamic> json) {
@@ -46,16 +47,6 @@ class RepoGitInfo {
           json['working_directory'] as Map<String, dynamic>),
       errors: _parseErrors(json['errors']),
     );
-  }
-
-  static List<String> _parseErrors(dynamic raw) {
-    if (raw is Map) {
-      return raw.values.whereType<String>().toList();
-    }
-    if (raw is List) {
-      return raw.whereType<String>().toList();
-    }
-    return const [];
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixed type mismatch in `RepoGitInfo.errors`: changed from `List<String>` to `Map<String, String>` to match PA API response shape
- Removed duplicate `_parseErrors` method that caused Dart compile error
- Updated `_parseErrors` to return `Map<String, String>`, handling both Map and List inputs gracefully

## Bug
The PA API returns `errors` as `Map<String, String>` (e.g., `{"develop": "Branch 'develop' not found"}`), but the Dart model expected `List<String>`. This caused a `_TypeError` crash on the repo detail screen for repos without a `develop` branch (learning, nixos-snowfall, nixos-neve). Additionally, a duplicate `_parseErrors` method definition prevented the app from compiling.

## Changes
- `phone/lib/models/repo_git_info.dart`: 1 file, ~15 lines changed

## Verification
- `flutter analyze` passes
- No other files reference `RepoGitInfo.errors` — change is fully contained

## Ticket
PA-1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)