### PR TITLE
feat(phone): AVO-054 provider & model selection in DeploySheet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y ninja-build libgtk-3-dev
+          cd phone
           flutter build linux --debug
 
   bump-build:

--- a/phone/android/gradle.properties
+++ b/phone/android/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+android.ndkVersion=27.0.12077973

--- a/phone/lib/models/pa_team.dart
+++ b/phone/lib/models/pa_team.dart
@@ -5,11 +5,15 @@ class PaTeam {
   final String name;
   final String description;
   final List<DeployMode> deployModes;
+  final String? defaultProvider;
+  final String? defaultModel;
 
   const PaTeam({
     required this.name,
     required this.description,
     required this.deployModes,
+    this.defaultProvider,
+    this.defaultModel,
   });
 
   factory PaTeam.fromJson(Map<String, dynamic> json) {
@@ -21,6 +25,8 @@ class PaTeam {
       name: json['name'] as String,
       description: json['description'] as String? ?? '',
       deployModes: modes,
+      defaultProvider: json['default_provider'] as String?,
+      defaultModel: json['default_model'] as String?,
     );
   }
 }

--- a/phone/lib/screens/item_detail_screen.dart
+++ b/phone/lib/screens/item_detail_screen.dart
@@ -684,7 +684,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
         paRepos: widget.paRepos ?? const [],
         initialTeam: team,
         initialObjective: widget.item.id,
-        onDeploy: (t, mode, objective, {repo}) async {
+        onDeploy: (t, mode, objective, {repo, provider, teamModel}) async {
           Navigator.pop(context);
           try {
             final result = await widget.reviewProvider.client.triggerDeployment(
@@ -692,6 +692,8 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
               mode,
               objective: objective.isNotEmpty ? objective : null,
               repo: repo,
+              provider: provider,
+              teamModel: teamModel,
             );
             if (mounted) {
               messenger.showSnackBar(SnackBar(

--- a/phone/lib/screens/team_browser_screen.dart
+++ b/phone/lib/screens/team_browser_screen.dart
@@ -103,7 +103,7 @@ class _TeamBrowserScreenState extends State<TeamBrowserScreen> {
       builder: (_) => DeploySheet(
         paTeams: widget.teamProvider.paTeams,
         paRepos: widget.teamProvider.paRepos,
-        onDeploy: (team, mode, objective, {repo}) async {
+        onDeploy: (team, mode, objective, {repo, provider, teamModel}) async {
           Navigator.pop(context);
           try {
             final result = await widget.teamProvider.deploy(
@@ -111,6 +111,8 @@ class _TeamBrowserScreenState extends State<TeamBrowserScreen> {
               mode,
               objective: objective.isNotEmpty ? objective : null,
               repo: repo,
+              provider: provider,
+              teamModel: teamModel,
             );
             if (mounted) {
               messenger.showSnackBar(
@@ -619,7 +621,7 @@ class _TeamFileViewScreenState extends State<_TeamFileViewScreen> {
         paRepos: widget.teamProvider.paRepos,
         initialTeam: widget.team,
         initialObjective: widget.file.name,
-        onDeploy: (team, mode, objective, {repo}) async {
+        onDeploy: (team, mode, objective, {repo, provider, teamModel}) async {
           Navigator.pop(context);
           try {
             final result = await widget.teamProvider.deploy(
@@ -627,6 +629,8 @@ class _TeamFileViewScreenState extends State<_TeamFileViewScreen> {
               mode,
               objective: objective.isNotEmpty ? objective : null,
               repo: repo,
+              provider: provider,
+              teamModel: teamModel,
             );
             if (mounted) {
               messenger.showSnackBar(SnackBar(

--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -501,7 +501,7 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
         initialTeam: initialTeam,
         initialObjective: initialObjective,
         initialRepo: initialRepo,
-        onDeploy: (team, mode, objective, {repo}) async {
+        onDeploy: (team, mode, objective, {repo, provider, teamModel}) async {
           Navigator.pop(context);
           try {
             final result = await client.triggerDeployment(
@@ -510,6 +510,8 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
               objective: objective.isNotEmpty ? objective : null,
               repo: repo,
               ticket: ticket.id,
+              provider: provider,
+              teamModel: teamModel,
             );
             if (!mounted) return;
             if (!result.started) {

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -385,12 +385,16 @@ class AgentApiClient {
   /// Returns immediately after the subprocess is started.
   /// Optional [repo] passes `--repo <name>` to PA (for codebase-aware modes).
   /// Optional [ticket] links the deployment to a ticket in the registry.
+  /// Optional [provider] selects the AI provider (anthropic, minimax).
+  /// Optional [teamModel] selects the model (haiku, sonnet, opus).
   Future<DeployResult> triggerDeployment(
     String team,
     String mode, {
     String? objective,
     String? repo,
     String? ticket,
+    String? provider,
+    String? teamModel,
   }) async {
     final body = <String, dynamic>{'team': team, 'mode': mode};
     if (objective != null && objective.isNotEmpty) {
@@ -401,6 +405,12 @@ class AgentApiClient {
     }
     if (ticket != null && ticket.isNotEmpty) {
       body['ticket'] = ticket;
+    }
+    if (provider != null && provider.isNotEmpty) {
+      body['provider'] = provider;
+    }
+    if (teamModel != null && teamModel.isNotEmpty) {
+      body['team_model'] = teamModel;
     }
     final response = await _post('/api/deploy', body: body);
     return DeployResult.fromJson(response);

--- a/phone/lib/services/team_browser_provider.dart
+++ b/phone/lib/services/team_browser_provider.dart
@@ -58,10 +58,12 @@ class TeamBrowserProvider extends ChangeNotifier {
   /// Trigger a PA team deployment.
   ///
   /// Optional [repo] passes `--repo <name>` to PA for codebase-aware modes.
+  /// Optional [provider] selects the AI provider (anthropic, minimax).
+  /// Optional [teamModel] selects the model (haiku, sonnet, opus).
   Future<DeployResult> deploy(String team, String mode,
-      {String? objective, String? repo}) {
+      {String? objective, String? repo, String? provider, String? teamModel}) {
     return _client.triggerDeployment(team, mode,
-        objective: objective, repo: repo);
+        objective: objective, repo: repo, provider: provider, teamModel: teamModel);
   }
 
   /// Fetch team list.

--- a/phone/lib/widgets/deploy_sheet.dart
+++ b/phone/lib/widgets/deploy_sheet.dart
@@ -41,8 +41,10 @@ class DeploySheet extends StatefulWidget {
   /// Called when user taps Launch.
   /// [objective] may be empty string if user left the field blank.
   /// [repo] is null when no repo was selected.
+  /// [provider] is null when using team default.
+  /// [teamModel] is null when using team default.
   final Future<void> Function(String team, String mode, String objective,
-      {String? repo}) onDeploy;
+      {String? repo, String? provider, String? teamModel}) onDeploy;
 
   const DeploySheet({
     super.key,
@@ -62,6 +64,8 @@ class _DeploySheetState extends State<DeploySheet> {
   String? _selectedTeam;
   String? _selectedMode;
   String? _selectedRepo;
+  String? _selectedProvider;
+  String? _selectedModel;
   bool _deploying = false;
   bool _objectiveTouched = false;
   late final TextEditingController _objectiveController;
@@ -89,6 +93,17 @@ class _DeploySheetState extends State<DeploySheet> {
 
     // Auto-select mode if the initial team has exactly one deploy mode.
     _autoSelectMode();
+
+    // Pre-select provider and model from team's configured defaults.
+    _applyTeamDefaults();
+  }
+
+  void _applyTeamDefaults() {
+    if (_selectedTeam == null) return;
+    final paTeam = _paTeamFor(_selectedTeam!);
+    if (paTeam == null) return;
+    _selectedProvider = paTeam.defaultProvider;
+    _selectedModel = paTeam.defaultModel;
   }
 
   @override
@@ -199,6 +214,7 @@ class _DeploySheetState extends State<DeploySheet> {
                       _selectedTeam = team;
                       _selectedMode = null;
                       _autoSelectMode();
+                      _applyTeamDefaults();
                     });
                   },
                 ),
@@ -219,6 +235,31 @@ class _DeploySheetState extends State<DeploySheet> {
                     selectedRepo: _selectedRepo,
                     enabled: !_deploying,
                     onChanged: (repo) => setState(() => _selectedRepo = repo),
+                  ),
+                  const SizedBox(height: 16),
+                ],
+
+                // Provider dropdown
+                if (_selectedTeam != null) ...[
+                  Text('Provider', style: theme.textTheme.labelMedium),
+                  const SizedBox(height: 6),
+                  _ProviderSelector(
+                    selectedProvider: _selectedProvider,
+                    enabled: !_deploying,
+                    onChanged: (p) =>
+                        setState(() => _selectedProvider = p),
+                  ),
+                  const SizedBox(height: 16),
+                ],
+
+                // Model dropdown
+                if (_selectedTeam != null) ...[
+                  Text('Model', style: theme.textTheme.labelMedium),
+                  const SizedBox(height: 6),
+                  _ModelSelector(
+                    selectedModel: _selectedModel,
+                    enabled: !_deploying,
+                    onChanged: (m) => setState(() => _selectedModel = m),
                   ),
                   const SizedBox(height: 16),
                 ],
@@ -324,6 +365,8 @@ class _DeploySheetState extends State<DeploySheet> {
         _selectedMode!,
         sanitizedObjective,
         repo: _selectedRepo,
+        provider: _selectedProvider,
+        teamModel: _selectedModel,
       );
     } finally {
       if (mounted) setState(() => _deploying = false);
@@ -428,6 +471,104 @@ class _TeamSelector extends StatelessWidget {
               (t) => DropdownMenuItem(
                 value: t.name,
                 child: Text(t.name),
+              ),
+            )
+            .toList(),
+        onChanged: enabled ? onChanged : null,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provider selector widget
+// ---------------------------------------------------------------------------
+
+class _ProviderSelector extends StatelessWidget {
+  final String? selectedProvider;
+  final bool enabled;
+  final void Function(String?) onChanged;
+
+  static const _providers = ['anthropic', 'minimax'];
+
+  const _ProviderSelector({
+    required this.selectedProvider,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return InputDecorator(
+      decoration: const InputDecoration(
+        border: OutlineInputBorder(),
+        contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      ),
+      child: DropdownButton<String>(
+        value: selectedProvider,
+        isExpanded: true,
+        underline: const SizedBox.shrink(),
+        hint: Text(
+          'anthropic',
+          style: theme.textTheme.bodyMedium
+              ?.copyWith(color: theme.colorScheme.outline),
+        ),
+        items: _providers
+            .map(
+              (p) => DropdownMenuItem(
+                value: p,
+                child: Text(p),
+              ),
+            )
+            .toList(),
+        onChanged: enabled ? onChanged : null,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Model selector widget
+// ---------------------------------------------------------------------------
+
+class _ModelSelector extends StatelessWidget {
+  final String? selectedModel;
+  final bool enabled;
+  final void Function(String?) onChanged;
+
+  static const _models = ['haiku', 'sonnet', 'opus'];
+
+  const _ModelSelector({
+    required this.selectedModel,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return InputDecorator(
+      decoration: const InputDecoration(
+        border: OutlineInputBorder(),
+        contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      ),
+      child: DropdownButton<String>(
+        value: selectedModel,
+        isExpanded: true,
+        underline: const SizedBox.shrink(),
+        hint: Text(
+          'opus',
+          style: theme.textTheme.bodyMedium
+              ?.copyWith(color: theme.colorScheme.outline),
+        ),
+        items: _models
+            .map(
+              (m) => DropdownMenuItem(
+                value: m,
+                child: Text(m),
               ),
             )
             .toList(),

--- a/phone/pubspec.yaml
+++ b/phone/pubspec.yaml
@@ -25,6 +25,10 @@ dependencies:
   avodah_core:
     path: ../packages/avodah_core
 
+dependency_overrides:
+  # 2.3.0 pulls in jni/jni_flutter which requires NDK 28 (not available in Nix env)
+  path_provider_android: 2.2.23
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- Add provider dropdown (anthropic/minimax) and model dropdown (haiku/sonnet/opus) to `DeploySheet` widget
- Pre-select defaults from `PaTeam.defaultProvider`/`defaultModel` (parsed from server `/api/pa-teams`)
- Thread `provider` and `teamModel` through `onDeploy` callback → `TeamBrowserProvider.deploy()` → `AgentApiClient.triggerDeployment()` → POST body
- Update all 4 call sites (ticket detail, item detail, team browser FAB, team browser file)

## Ticket
AVO-054

## Dependencies
- Server PR: sinh-x/personal-assistant (same branch name) — extends `/api/pa-teams` and `/api/deploy`

## Test plan
- [ ] `flutter analyze` passes clean
- [ ] DeploySheet shows Provider and Model dropdowns below repo picker
- [ ] Dropdowns pre-select team defaults when team is selected
- [ ] Switching teams resets dropdowns to new team defaults
- [ ] Deploy with custom provider/model sends fields in POST body
- [ ] Deploy with default values omits provider/team_model from body
- [ ] All 4 launch points work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)