### PR TITLE
feat(phone): AVO-063 sort activity timeline events chronologically

### DIFF
--- a/phone/lib/screens/activity_timeline_screen.dart
+++ b/phone/lib/screens/activity_timeline_screen.dart
@@ -99,6 +99,14 @@ class _ActivityTimelineScreenState extends State<ActivityTimelineScreen> {
           .getDeploymentActivity(widget.deployment.deploymentId);
       if (mounted) {
         setState(() {
+          events.sort((a, b) {
+            final aTime = a.timestamp;
+            final bTime = b.timestamp;
+            if (aTime == null && bTime == null) return 0;
+            if (aTime == null) return 1;
+            if (bTime == null) return -1;
+            return aTime.compareTo(bTime);
+          });
           _events = events;
           _loading = false;
           _error = null;


### PR DESCRIPTION
## Summary
- Sort activity events by timestamp (ascending, oldest first) in `ActivityTimelineScreen._loadEvents()`
- Null timestamps sort to end of list (nulls-last)
- Applied on every load (initial + 4s polling refresh)

## Changes
- `phone/lib/screens/activity_timeline_screen.dart`: Add `events.sort()` with null-safe `DateTime` comparison before `_events = events`

## Acceptance Criteria
- [x] AC1: Events appear in chronological order (oldest at top, newest at bottom)
- [x] AC2: Refresh maintains chronological order
- [x] AC3: Events with no `ts` don't crash and appear at end
- [x] AC4: Running deployments (4s poll) maintain sorted order across refreshes

## Test plan
- [x] `flutter build web --release` passes
- [ ] Manual verification: open a deployment activity timeline and confirm chronological order

Closes AVO-063