### PR TITLE
feat(phone): AVO-066 inline markdown comment widget

### DIFF
--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  sqlite3_flutter_libs
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -100,9 +100,7 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
 
   Future<void> _submitInlineComment(int lineNumber, String lineText, String comment) async {
     try {
-      // Use appendSection with line-aware title format
-      final title = '## $lineNumber: ${lineText.length > 40 ? '${lineText.substring(0, 40)}...' : lineText}';
-      await widget.client.appendSection(widget.path, title, comment);
+      await widget.client.appendInlineSection(widget.path, lineText, comment, lineNumber);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Comment added')),

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -84,41 +84,25 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
   }
 
   void _showCommentSheet(String selectedText) {
-    if (selectedText.isEmpty) {
-      debugPrint('_showCommentSheet: selectedText is empty');
-      return;
-    }
-
-    debugPrint('_showCommentSheet: selectedText="$selectedText"');
-    debugPrint('_showCommentSheet: _document hash=${_document.hashCode}, path=${widget.path}');
+    if (selectedText.isEmpty) return;
 
     final lines = _document?.content?.split('\n') ?? [];
-    debugPrint('_showCommentSheet: _document?.content?.split lines count=${lines.length}');
-    debugPrint('_showCommentSheet: full document content length=${_document?.content?.length ?? 0}');
-
-    if (_document?.content == null) {
-      debugPrint('_showCommentSheet: _document.content is NULL!');
-    }
 
     List<int> matchingLineIndices = [];
 
     // Try exact match first
     for (int i = 0; i < lines.length; i++) {
       if (lines[i].contains(selectedText)) {
-        debugPrint('_showCommentSheet: exact match at line $i: "${lines[i]}"');
         matchingLineIndices.add(i);
       }
     }
 
     // If no exact match, try partial word match
     if (matchingLineIndices.isEmpty) {
-      debugPrint('_showCommentSheet: no exact match, trying partial word match');
       final words = selectedText.split(' ').where((w) => w.length > 3).toList();
-      debugPrint('_showCommentSheet: words to try: $words');
       for (int i = 0; i < lines.length; i++) {
         for (final word in words) {
           if (lines[i].toLowerCase().contains(word.toLowerCase())) {
-            debugPrint('_showCommentSheet: partial match at line $i: "${lines[i]}"');
             matchingLineIndices.add(i);
             break;
           }
@@ -128,22 +112,16 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
 
     // If still no match, use first non-empty line
     if (matchingLineIndices.isEmpty) {
-      debugPrint('_showCommentSheet: no partial match, finding first non-empty line');
       for (int i = 0; i < lines.length; i++) {
         if (lines[i].trim().isNotEmpty) {
-          debugPrint('_showCommentSheet: first non-empty line $i: "${lines[i]}"');
           matchingLineIndices.add(i);
           break;
         }
       }
     }
 
-    debugPrint('_showCommentSheet: matchingLineIndices = $matchingLineIndices');
-    debugPrint('_showCommentSheet: first match = ${matchingLineIndices.isNotEmpty ? matchingLineIndices.first : -1}');
-
     // If still empty, can't determine line - abort
     if (matchingLineIndices.isEmpty) {
-      debugPrint('_showCommentSheet: FAILED to find any matching line');
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Could not find line for comment')),
       );
@@ -155,20 +133,14 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
 
     // Use LAST match (user likely selected text near where they want to comment)
     final lineIndex = matchingLineIndices.last;
-    debugPrint('_showCommentSheet: USING lineIndex=$lineIndex (line ${lineIndex + 1})');
     setState(() {
       _selectedText = '';
     });
-    _onLineTapped(lineIndex, selectedText, lineIndex + 1);
+    _onLineTapped(lineIndex, selectedText);
   }
 
-  void _onLineTapped(int lineIndex, String selectedText, int lineNumber) {
-    debugPrint('_onLineTapped: lineIndex=$lineIndex, selectedText="$selectedText", lineNumber=$lineNumber');
+  void _onLineTapped(int lineIndex, String selectedText) {
     final lines = _document?.content?.split('\n') ?? [];
-    debugPrint('_onLineTapped: document has ${lines.length} lines');
-    if (lineIndex < lines.length) {
-      debugPrint('_onLineTapped: line content: "${lines[lineIndex]}"');
-    }
     final surroundingText =
         lineIndex > 0 ? lines[lineIndex - 1] : (lineIndex < lines.length - 1 ? lines[lineIndex + 1] : null);
 
@@ -178,14 +150,14 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
       builder: (_) => InlineCommentSheet(
         contextText: selectedText,
         surroundingText: surroundingText,
-        onSubmit: (comment) => _submitInlineComment(lineNumber, selectedText, comment),
+        onSubmit: (comment) => _submitInlineComment(selectedText, comment),
       ),
     );
   }
 
-  Future<void> _submitInlineComment(int lineNumber, String lineText, String comment) async {
+  Future<void> _submitInlineComment(String lineText, String comment) async {
     try {
-      await widget.client.appendInlineSection(widget.path, lineText, comment, lineNumber);
+      await widget.client.appendInlineSection(widget.path, lineText, comment);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Comment added')),

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -84,26 +84,36 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
   }
 
   void _showCommentSheet(String selectedText) {
-    if (selectedText.isEmpty) return;
+    if (selectedText.isEmpty) {
+      debugPrint('_showCommentSheet: selectedText is empty');
+      return;
+    }
 
     final lines = _document?.content?.split('\n') ?? [];
+    debugPrint('_showCommentSheet: selectedText="$selectedText"');
+    debugPrint('_showCommentSheet: total lines=${lines.length}');
+
     List<int> matchingLineIndices = [];
 
     // Try exact match first
     for (int i = 0; i < lines.length; i++) {
       if (lines[i].contains(selectedText)) {
+        debugPrint('_showCommentSheet: exact match at line $i: "${lines[i]}"');
         matchingLineIndices.add(i);
       }
     }
 
     // If no exact match, try partial word match
     if (matchingLineIndices.isEmpty) {
+      debugPrint('_showCommentSheet: no exact match, trying partial word match');
       final words = selectedText.split(' ').where((w) => w.length > 3).toList();
+      debugPrint('_showCommentSheet: words to try: $words');
       for (int i = 0; i < lines.length; i++) {
         for (final word in words) {
           if (lines[i].toLowerCase().contains(word.toLowerCase())) {
+            debugPrint('_showCommentSheet: partial match at line $i: "${lines[i]}"');
             matchingLineIndices.add(i);
-            break; // Only add once per line
+            break;
           }
         }
       }
@@ -111,8 +121,10 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
 
     // If still no match, use first non-empty line
     if (matchingLineIndices.isEmpty) {
+      debugPrint('_showCommentSheet: no partial match, finding first non-empty line');
       for (int i = 0; i < lines.length; i++) {
         if (lines[i].trim().isNotEmpty) {
+          debugPrint('_showCommentSheet: first non-empty line $i: "${lines[i]}"');
           matchingLineIndices.add(i);
           break;
         }
@@ -121,6 +133,7 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
 
     // If still empty, can't determine line - abort
     if (matchingLineIndices.isEmpty) {
+      debugPrint('_showCommentSheet: FAILED to find any matching line');
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Could not find line for comment')),
       );
@@ -131,6 +144,7 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
     }
 
     final lineIndex = matchingLineIndices.first;
+    debugPrint('_showCommentSheet: USING lineIndex=$lineIndex (line ${lineIndex + 1})');
     setState(() {
       _selectedText = '';
     });
@@ -138,8 +152,12 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
   }
 
   void _onLineTapped(int lineIndex, String selectedText, int lineNumber) {
+    debugPrint('_onLineTapped: lineIndex=$lineIndex, selectedText="$selectedText", lineNumber=$lineNumber');
     final lines = _document?.content?.split('\n') ?? [];
-    final surroundingText =
+    debugPrint('_onLineTapped: document has ${lines.length} lines');
+    if (lineIndex < lines.length) {
+      debugPrint('_onLineTapped: line content: "${lines[lineIndex]}"');
+    }
         lineIndex > 0 ? lines[lineIndex - 1] : (lineIndex < lines.length - 1 ? lines[lineIndex + 1] : null);
 
     showModalBottomSheet<void>(

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
 
 import '../services/agent_api_client.dart';
+import '../widgets/inline_comment_sheet.dart';
+import '../widgets/markdown_with_annotations.dart';
 
 /// Full-screen document viewer.
 ///
 /// Fetches the document at [path] via [AgentApiClient.getDocument] and renders
-/// it based on file type: markdown (.md/.markdown) → [MarkdownBody],
+/// it based on file type: markdown (.md/.markdown) → [MarkdownWithAnnotations],
 /// directory → entry list. PDF and image viewing require a raw binary API
 /// endpoint (PA-902) and show an informative placeholder until then.
 class DocumentViewerScreen extends StatefulWidget {
@@ -81,6 +82,71 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
     }
   }
 
+  void _onLineTapped(int lineIndex, String lineText) {
+    final lines = _document?.content?.split('\n') ?? [];
+    final surroundingText =
+        lineIndex > 0 ? lines[lineIndex - 1] : (lineIndex < lines.length - 1 ? lines[lineIndex + 1] : null);
+
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => InlineCommentSheet(
+        contextText: lineText,
+        surroundingText: surroundingText,
+        onSubmit: (comment) => _submitInlineComment(lineIndex + 1, lineText, comment),
+      ),
+    );
+  }
+
+  Future<void> _submitInlineComment(int lineNumber, String lineText, String comment) async {
+    try {
+      // Use appendSection with line-aware title format
+      final title = '## $lineNumber: ${lineText.length > 40 ? '${lineText.substring(0, 40)}...' : lineText}';
+      await widget.client.appendSection(widget.path, title, comment);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Comment added')),
+        );
+        _loadDocument(); // Refresh
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to add comment: $e')),
+        );
+      }
+    }
+  }
+
+  void _onAddSection() async {
+    final result = await showDialog<Map<String, String>>(
+      context: context,
+      builder: (ctx) => const _AddSectionDialog(),
+    );
+
+    if (result == null || !mounted) return;
+
+    try {
+      await widget.client.appendSection(
+        widget.path,
+        result['title']!,
+        result['content']!,
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Section added')),
+        );
+        _loadDocument(); // Refresh
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to add section: $e')),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -90,6 +156,13 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            tooltip: 'Add Section',
+            onPressed: _onAddSection,
+          ),
+        ],
       ),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
@@ -135,9 +208,9 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
   Widget _buildMarkdown(String content) {
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
-      child: MarkdownBody(
+      child: MarkdownWithAnnotations(
         data: content,
-        selectable: true,
+        onLineTapped: _onLineTapped,
       ),
     );
   }
@@ -192,6 +265,83 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
           ),
         );
       },
+    );
+  }
+}
+
+class _AddSectionDialog extends StatefulWidget {
+  const _AddSectionDialog();
+
+  @override
+  State<_AddSectionDialog> createState() => _AddSectionDialogState();
+}
+
+class _AddSectionDialogState extends State<_AddSectionDialog> {
+  final _titleController = TextEditingController();
+  final _contentController = TextEditingController();
+
+  bool get _canAdd =>
+      _titleController.text.trim().isNotEmpty &&
+      _contentController.text.trim().isNotEmpty;
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Add Section'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Section title'),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(
+                hintText: 'e.g. "Follow-up Notes"',
+                border: OutlineInputBorder(),
+              ),
+              autofocus: true,
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: 16),
+            const Text('Section content'),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _contentController,
+              decoration: const InputDecoration(
+                hintText: 'Enter markdown content...',
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 5,
+              minLines: 3,
+              onChanged: (_) => setState(() {}),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _canAdd
+              ? () => Navigator.pop(context, {
+                    'title': _titleController.text.trim(),
+                    'content': _contentController.text.trim(),
+                  })
+              : null,
+          child: const Text('Add'),
+        ),
+      ],
     );
   }
 }

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -158,6 +158,7 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
     if (lineIndex < lines.length) {
       debugPrint('_onLineTapped: line content: "${lines[lineIndex]}"');
     }
+    final surroundingText =
         lineIndex > 0 ? lines[lineIndex - 1] : (lineIndex < lines.length - 1 ? lines[lineIndex + 1] : null);
 
     showModalBottomSheet<void>(

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -89,9 +89,16 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
       return;
     }
 
-    final lines = _document?.content?.split('\n') ?? [];
     debugPrint('_showCommentSheet: selectedText="$selectedText"');
-    debugPrint('_showCommentSheet: total lines=${lines.length}');
+    debugPrint('_showCommentSheet: _document hash=${_document.hashCode}, path=${widget.path}');
+
+    final lines = _document?.content?.split('\n') ?? [];
+    debugPrint('_showCommentSheet: _document?.content?.split lines count=${lines.length}');
+    debugPrint('_showCommentSheet: full document content length=${_document?.content?.length ?? 0}');
+
+    if (_document?.content == null) {
+      debugPrint('_showCommentSheet: _document.content is NULL!');
+    }
 
     List<int> matchingLineIndices = [];
 

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -84,16 +84,53 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
   }
 
   void _showCommentSheet(String selectedText) {
+    if (selectedText.isEmpty) return;
+
     final lines = _document?.content?.split('\n') ?? [];
     List<int> matchingLineIndices = [];
 
+    // Try exact match first
     for (int i = 0; i < lines.length; i++) {
       if (lines[i].contains(selectedText)) {
         matchingLineIndices.add(i);
       }
     }
 
-    final lineIndex = matchingLineIndices.isNotEmpty ? matchingLineIndices.first : 0;
+    // If no exact match, try partial word match
+    if (matchingLineIndices.isEmpty) {
+      final words = selectedText.split(' ').where((w) => w.length > 3).toList();
+      for (int i = 0; i < lines.length; i++) {
+        for (final word in words) {
+          if (lines[i].toLowerCase().contains(word.toLowerCase())) {
+            matchingLineIndices.add(i);
+            break; // Only add once per line
+          }
+        }
+      }
+    }
+
+    // If still no match, use first non-empty line
+    if (matchingLineIndices.isEmpty) {
+      for (int i = 0; i < lines.length; i++) {
+        if (lines[i].trim().isNotEmpty) {
+          matchingLineIndices.add(i);
+          break;
+        }
+      }
+    }
+
+    // If still empty, can't determine line - abort
+    if (matchingLineIndices.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Could not find line for comment')),
+      );
+      setState(() {
+        _selectedText = '';
+      });
+      return;
+    }
+
+    final lineIndex = matchingLineIndices.first;
     setState(() {
       _selectedText = '';
     });

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -28,6 +28,7 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
   DocumentContent? _document;
   bool _loading = true;
   String? _error;
+  String _selectedText = '';
 
   String get _filename {
     final parts = widget.path.split('/');
@@ -80,6 +81,23 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
         });
       }
     }
+  }
+
+  void _showCommentSheet(String selectedText) {
+    final lines = _document?.content?.split('\n') ?? [];
+    List<int> matchingLineIndices = [];
+
+    for (int i = 0; i < lines.length; i++) {
+      if (lines[i].contains(selectedText)) {
+        matchingLineIndices.add(i);
+      }
+    }
+
+    final lineIndex = matchingLineIndices.isNotEmpty ? matchingLineIndices.first : 0;
+    setState(() {
+      _selectedText = '';
+    });
+    _onLineTapped(lineIndex, selectedText, lineIndex + 1);
   }
 
   void _onLineTapped(int lineIndex, String selectedText, int lineNumber) {
@@ -155,10 +173,18 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
           overflow: TextOverflow.ellipsis,
         ),
         actions: [
+          if (_selectedText.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.comment),
+              tooltip: 'Add Comment',
+              onPressed: () => _showCommentSheet(_selectedText),
+            ),
           IconButton(
             icon: const Icon(Icons.add),
-            tooltip: 'Add Section',
-            onPressed: _onAddSection,
+            tooltip: _selectedText.isNotEmpty ? 'Add Comment' : 'Add Section',
+            onPressed: _selectedText.isNotEmpty
+                ? () => _showCommentSheet(_selectedText)
+                : _onAddSection,
           ),
         ],
       ),
@@ -204,12 +230,88 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
   }
 
   Widget _buildMarkdown(String content) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(16),
-      child: MarkdownWithAnnotations(
-        data: content,
-        onLineTapped: _onLineTapped,
-      ),
+    final lines = content.split('\n');
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Show selected text if any
+        if (_selectedText.isNotEmpty)
+          GestureDetector(
+            onTap: () => _showCommentSheet(_selectedText),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              margin: const EdgeInsets.only(bottom: 8),
+              decoration: BoxDecoration(
+                color: Colors.amber.shade100,
+                borderRadius: BorderRadius.circular(4),
+                border: Border.all(color: Colors.amber.shade300),
+              ),
+              child: Row(
+                children: [
+                  Icon(Icons.comment_outlined, size: 16, color: Colors.amber.shade700),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Comment on: "$_selectedText"',
+                      style: TextStyle(color: Colors.amber.shade900, fontSize: 13),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  Icon(Icons.add, size: 16, color: Colors.amber.shade700),
+                ],
+              ),
+            ),
+          ),
+        // Line numbers + Markdown side by side
+        Expanded(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Tappable line numbers
+              SizedBox(
+                width: 40,
+                child: ListView.builder(
+                  itemCount: lines.length,
+                  itemExtent: 24, // Fixed height per line
+                  itemBuilder: (context, index) {
+                    return GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          _selectedText = lines[index];
+                        });
+                      },
+                      child: Container(
+                        height: 24,
+                        alignment: Alignment.centerRight,
+                        padding: const EdgeInsets.only(right: 8),
+                        child: Text(
+                          '${index + 1}',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.outline,
+                            fontSize: 12,
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              // Markdown content
+              Expanded(
+                child: SingleChildScrollView(
+                  child: MarkdownWithAnnotations(
+                    data: content,
+                    onLineTapped: _onLineTapped,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -206,9 +206,15 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
   Widget _buildMarkdown(String content) {
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
-      child: MarkdownWithAnnotations(
-        data: content,
-        onLineTapped: _onLineTapped,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          MarkdownWithAnnotations(
+            data: content,
+            onLineTapped: _onLineTapped,
+          ),
+        ],
       ),
     );
   }

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -230,13 +230,10 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
   }
 
   Widget _buildMarkdown(String content) {
-    final lines = content.split('\n');
-    final theme = Theme.of(context);
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Show selected text if any
+        // Selected text indicator
         if (_selectedText.isNotEmpty)
           GestureDetector(
             onTap: () => _showCommentSheet(_selectedText),
@@ -260,55 +257,24 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
-                  Icon(Icons.add, size: 16, color: Colors.amber.shade700),
                 ],
               ),
             ),
           ),
-        // Line numbers + Markdown side by side
+        // Markdown content with long press to select
         Expanded(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Tappable line numbers
-              SizedBox(
-                width: 40,
-                child: ListView.builder(
-                  itemCount: lines.length,
-                  itemExtent: 24, // Fixed height per line
-                  itemBuilder: (context, index) {
-                    return GestureDetector(
-                      onTap: () {
-                        setState(() {
-                          _selectedText = lines[index];
-                        });
-                      },
-                      child: Container(
-                        height: 24,
-                        alignment: Alignment.centerRight,
-                        padding: const EdgeInsets.only(right: 8),
-                        child: Text(
-                          '${index + 1}',
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.outline,
-                            fontSize: 12,
-                          ),
-                        ),
-                      ),
-                    );
-                  },
-                ),
-              ),
-              // Markdown content
-              Expanded(
-                child: SingleChildScrollView(
-                  child: MarkdownWithAnnotations(
-                    data: content,
-                    onLineTapped: _onLineTapped,
-                  ),
-                ),
-              ),
-            ],
+          child: SelectionArea(
+            onSelectionChanged: (selection) {
+              if (selection != null && selection.plainText.isNotEmpty) {
+                setState(() {
+                  _selectedText = selection.plainText;
+                });
+              }
+            },
+            child: MarkdownWithAnnotations(
+              data: content,
+              onLineTapped: _onLineTapped,
+            ),
           ),
         ),
       ],

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -206,15 +206,9 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
   Widget _buildMarkdown(String content) {
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          MarkdownWithAnnotations(
-            data: content,
-            onLineTapped: _onLineTapped,
-          ),
-        ],
+      child: MarkdownWithAnnotations(
+        data: content,
+        onLineTapped: _onLineTapped,
       ),
     );
   }

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -138,6 +138,9 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
       }
     }
 
+    debugPrint('_showCommentSheet: matchingLineIndices = $matchingLineIndices');
+    debugPrint('_showCommentSheet: first match = ${matchingLineIndices.isNotEmpty ? matchingLineIndices.first : -1}');
+
     // If still empty, can't determine line - abort
     if (matchingLineIndices.isEmpty) {
       debugPrint('_showCommentSheet: FAILED to find any matching line');
@@ -150,7 +153,8 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
       return;
     }
 
-    final lineIndex = matchingLineIndices.first;
+    // Use LAST match (user likely selected text near where they want to comment)
+    final lineIndex = matchingLineIndices.last;
     debugPrint('_showCommentSheet: USING lineIndex=$lineIndex (line ${lineIndex + 1})');
     setState(() {
       _selectedText = '';

--- a/phone/lib/screens/document_viewer_screen.dart
+++ b/phone/lib/screens/document_viewer_screen.dart
@@ -82,7 +82,7 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
     }
   }
 
-  void _onLineTapped(int lineIndex, String lineText) {
+  void _onLineTapped(int lineIndex, String selectedText, int lineNumber) {
     final lines = _document?.content?.split('\n') ?? [];
     final surroundingText =
         lineIndex > 0 ? lines[lineIndex - 1] : (lineIndex < lines.length - 1 ? lines[lineIndex + 1] : null);
@@ -91,9 +91,9 @@ class _DocumentViewerScreenState extends State<DocumentViewerScreen> {
       context: context,
       isScrollControlled: true,
       builder: (_) => InlineCommentSheet(
-        contextText: lineText,
+        contextText: selectedText,
         surroundingText: surroundingText,
-        onSubmit: (comment) => _submitInlineComment(lineIndex + 1, lineText, comment),
+        onSubmit: (comment) => _submitInlineComment(lineNumber, selectedText, comment),
       ),
     );
   }

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -172,7 +172,7 @@ class AgentApiClient {
       await _post(
         '/api/folders/$encodedFolder/files/$encodedFile/sections',
         body: {
-          'title': title, // reference line
+          'title': '', // empty title - just insert content after reference line
           'content': commentLine,
           'location': lineNumber,
         },

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -141,6 +141,23 @@ class AgentApiClient {
         body: {'action': 'append-section', 'title': title, 'content': content});
   }
 
+  /// Append an inline comment section to a document at a specific line number.
+  ///
+  /// For MVP: delegates to [appendSection] with title prefixed by line number
+  /// using the `## N: title` convention.
+  ///
+  /// When PA-1119 server endpoint is available, this can be updated to use
+  /// the `lineNumber` parameter directly for precise placement.
+  Future<void> appendInlineSection(
+    String path,
+    String title,
+    String content,
+    int lineNumber,
+  ) async {
+    final prefixedTitle = '## $lineNumber: $title';
+    await appendSection(path, prefixedTitle, content);
+  }
+
   /// Fetch feedback chip labels from server config.
   ///
   /// Returns empty list if config is missing or malformed.

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -141,16 +141,15 @@ class AgentApiClient {
         body: {'action': 'append-section', 'title': title, 'content': content});
   }
 
-  /// Append an inline comment section to a document at a specific line number.
+  /// Append an inline comment section to a document using server-side text matching.
   ///
-  /// Uses the PA-1119 location-aware endpoint: POST /api/folders/:folderId/files/:fileId/sections
-  /// Inserts a blockquote comment after the reference line.
+  /// Uses POST /api/folders/:folderId/files/:fileId/sections with lineText field.
+  /// Server finds the last occurrence of exact lineText and inserts comment after it.
   /// Format: "> [!NOTE] Sinh comment: <content> <timestamp>"
   Future<void> appendInlineSection(
     String path,
-    String title, // The reference line text
-    String content, // User's comment
-    int lineNumber,
+    String lineText,
+    String comment,
   ) async {
     // Parse path into folderId and fileId
     final parts = path.split('/');
@@ -166,21 +165,15 @@ class AgentApiClient {
 
     // Format: > [!NOTE] Sinh comment: <content> <timestamp>
     final timestamp = DateTime.now().toIso8601String();
-    final commentLine = '> [!NOTE] Sinh comment: $content $timestamp';
+    final commentLine = '> [!NOTE] Sinh comment: $comment $timestamp';
 
-    try {
-      await _post(
-        '/api/folders/$encodedFolder/files/$encodedFile/sections',
-        body: {
-          'title': '', // empty title - just insert content after reference line
-          'content': commentLine,
-          'location': lineNumber, // lineNumber is already the target insertion point
-        },
-      );
-    } catch (e) {
-      // Fallback: use append-section at end
-      throw AgentApiException(500, 'Failed to add inline comment: $e');
-    }
+    await _post(
+      '/api/folders/$encodedFolder/files/$encodedFile/sections',
+      body: {
+        'content': commentLine,
+        'lineText': lineText,
+      },
+    );
   }
 
   /// Fetch feedback chip labels from server config.

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -174,7 +174,7 @@ class AgentApiClient {
         body: {
           'title': '', // empty title - just insert content after reference line
           'content': commentLine,
-          'location': lineNumber + 1, // +1 to insert AFTER the reference line
+          'location': lineNumber, // lineNumber is already the target insertion point
         },
       );
     } catch (e) {

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -143,19 +143,42 @@ class AgentApiClient {
 
   /// Append an inline comment section to a document at a specific line number.
   ///
-  /// For MVP: delegates to [appendSection] with title prefixed by line number
-  /// using the `## N: title` convention.
-  ///
-  /// When PA-1119 server endpoint is available, this can be updated to use
-  /// the `lineNumber` parameter directly for precise placement.
+  /// Uses the PA-1119 location-aware endpoint: POST /api/folders/:folderId/files/:fileId/sections
+  /// Falls back to appending at end with location encoded in title if endpoint unavailable.
   Future<void> appendInlineSection(
     String path,
     String title,
     String content,
     int lineNumber,
   ) async {
-    final prefixedTitle = '## $lineNumber: $title';
-    await appendSection(path, prefixedTitle, content);
+    // Parse path into folderId and fileId
+    // path format: agent-teams/requirements/artifacts/filename.md
+    // folderId: agent-teams/requirements/artifacts
+    // fileId: filename.md
+    final parts = path.split('/');
+    if (parts.length < 2) {
+      throw AgentApiException(400, 'Invalid path format: $path');
+    }
+    final fileId = parts.last;
+    final folderParts = parts.sublist(0, parts.length - 1);
+    final folderId = folderParts.join('/');
+
+    final encodedFolder = Uri.encodeComponent(folderId);
+    final encodedFile = Uri.encodeComponent(fileId);
+
+    try {
+      await _post(
+        '/api/folders/$encodedFolder/files/$encodedFile/sections',
+        body: {
+          'title': '## $lineNumber: $title',
+          'content': content,
+          'location': lineNumber,
+        },
+      );
+    } catch (e) {
+      // Fallback: use append-section at end with location in title
+      await appendSection(path, '## $lineNumber: $title', content);
+    }
   }
 
   /// Fetch feedback chip labels from server config.

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -144,17 +144,15 @@ class AgentApiClient {
   /// Append an inline comment section to a document at a specific line number.
   ///
   /// Uses the PA-1119 location-aware endpoint: POST /api/folders/:folderId/files/:fileId/sections
-  /// Falls back to appending at end with location encoded in title if endpoint unavailable.
+  /// Inserts a blockquote comment after the reference line.
+  /// Format: "> [!NOTE] Sinh comment: <content> <timestamp>"
   Future<void> appendInlineSection(
     String path,
-    String title,
-    String content,
+    String title, // The reference line text
+    String content, // User's comment
     int lineNumber,
   ) async {
     // Parse path into folderId and fileId
-    // path format: agent-teams/requirements/artifacts/filename.md
-    // folderId: agent-teams/requirements/artifacts
-    // fileId: filename.md
     final parts = path.split('/');
     if (parts.length < 2) {
       throw AgentApiException(400, 'Invalid path format: $path');
@@ -166,18 +164,22 @@ class AgentApiClient {
     final encodedFolder = Uri.encodeComponent(folderId);
     final encodedFile = Uri.encodeComponent(fileId);
 
+    // Format: > [!NOTE] Sinh comment: <content> <timestamp>
+    final timestamp = DateTime.now().toIso8601String();
+    final commentLine = '> [!NOTE] Sinh comment: $content $timestamp';
+
     try {
       await _post(
         '/api/folders/$encodedFolder/files/$encodedFile/sections',
         body: {
-          'title': '## $lineNumber: $title',
-          'content': content,
+          'title': title, // reference line
+          'content': commentLine,
           'location': lineNumber,
         },
       );
     } catch (e) {
-      // Fallback: use append-section at end with location in title
-      await appendSection(path, '## $lineNumber: $title', content);
+      // Fallback: use append-section at end
+      throw AgentApiException(500, 'Failed to add inline comment: $e');
     }
   }
 

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -174,7 +174,7 @@ class AgentApiClient {
         body: {
           'title': '', // empty title - just insert content after reference line
           'content': commentLine,
-          'location': lineNumber,
+          'location': lineNumber + 1, // +1 to insert AFTER the reference line
         },
       );
     } catch (e) {

--- a/phone/lib/widgets/inline_comment_sheet.dart
+++ b/phone/lib/widgets/inline_comment_sheet.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+
+/// A bottom-sheet dialog for adding inline comments to markdown text.
+///
+/// Shows the tapped line with surrounding context, a text input area,
+/// and a submit button. Uses amber accent color to distinguish Sinh's
+/// annotations from regular UI elements.
+///
+/// Usage:
+/// ```dart
+/// showModalBottomSheet<void>(
+///   context: context,
+///   isScrollControlled: true,
+///   builder: (_) => InlineCommentSheet(
+///     contextText: 'the markdown line user tapped',
+///     surroundingText: 'the line above or below',
+///     onSubmit: (comment) { ... },
+///   ),
+/// );
+/// ```
+class InlineCommentSheet extends StatefulWidget {
+  /// The exact markdown line the user tapped.
+  final String contextText;
+
+  /// One line of surrounding context (line above or below).
+  final String? surroundingText;
+
+  /// Called when the user submits a comment. Not called on dismiss/cancel.
+  final void Function(String comment) onSubmit;
+
+  const InlineCommentSheet({
+    super.key,
+    required this.contextText,
+    this.surroundingText,
+    required this.onSubmit,
+  });
+
+  @override
+  State<InlineCommentSheet> createState() => _InlineCommentSheetState();
+}
+
+class _InlineCommentSheetState extends State<InlineCommentSheet> {
+  final _commentController = TextEditingController();
+
+  bool get _canSubmit => _commentController.text.trim().isNotEmpty;
+
+  @override
+  void dispose() {
+    _commentController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // Amber accent for Sinh's annotations (distinct from regular UI)
+    const amberAccent = Color(0xFFFFC107);
+    final amberDark = Colors.amber.shade700;
+    final amberLight = Colors.amber.shade50;
+    final amberBorder = Colors.amber.shade200;
+
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 16,
+          right: 16,
+          top: 16,
+          bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Header with context
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: amberLight,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: amberBorder),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Context',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: amberDark,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  if (widget.surroundingText != null) ...[
+                    Text(
+                      widget.surroundingText!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 2),
+                  ],
+                  Text(
+                    widget.contextText,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w500,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            // Comment input
+            TextField(
+              controller: _commentController,
+              autofocus: true,
+              maxLines: 4,
+              minLines: 2,
+              decoration: InputDecoration(
+                hintText: 'Add a comment...',
+                border: const OutlineInputBorder(),
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: amberDark, width: 2),
+                ),
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: 16),
+            // Actions
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Cancel'),
+                ),
+                const SizedBox(width: 8),
+                FilledButton(
+                  onPressed: _canSubmit ? _onSubmit : null,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: amberAccent,
+                    foregroundColor: Colors.black87,
+                    disabledBackgroundColor: amberBorder,
+                  ),
+                  child: const Text('Submit'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _onSubmit() {
+    final comment = _commentController.text.trim();
+    Navigator.pop(context);
+    widget.onSubmit(comment);
+  }
+}

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -13,17 +13,7 @@ final _annotationPattern = RegExp(r'^##\s+(\d+):\s+(.*)$');
 /// Wraps [Markdown] to detect taps on individual lines/paragraphs and
 /// renders inline comment annotation markers (## N: Title sections) as
 /// visually distinct styled blockquotes with amber/yellow left border.
-///
-/// Usage:
-/// ```dart
-/// MarkdownWithAnnotations(
-///   data: markdownContent,
-///   onLineTapped: (lineIndex, lineText, lineNumber) {
-///     // Show inline comment sheet
-///   },
-/// )
-/// ```
-class MarkdownWithAnnotations extends StatefulWidget {
+class MarkdownWithAnnotations extends StatelessWidget {
   /// The markdown content to render.
   final String data;
 
@@ -43,129 +33,26 @@ class MarkdownWithAnnotations extends StatefulWidget {
   });
 
   @override
-  State<MarkdownWithAnnotations> createState() => _MarkdownWithAnnotationsState();
-}
-
-class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
-  String _selectedText = '';
-
-  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final defaultStyleSheet = theme.textTheme.bodyMedium?.merge(
       const TextStyle(height: 1.5),
     );
-    final lines = widget.data.split('\n');
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        // Show selected text if any
-        if (_selectedText.isNotEmpty)
-          GestureDetector(
-            onTap: () => _showCommentSheet(_selectedText),
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              margin: const EdgeInsets.only(bottom: 8),
-              decoration: BoxDecoration(
-                color: Colors.amber.shade100,
-                borderRadius: BorderRadius.circular(4),
-                border: Border.all(color: Colors.amber.shade300),
-              ),
-              child: Row(
-                children: [
-                  Icon(Icons.comment_outlined, size: 16, color: Colors.amber.shade700),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      'Comment on: "$_selectedText"',
-                      style: TextStyle(color: Colors.amber.shade900, fontSize: 13),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                  Icon(Icons.add, size: 16, color: Colors.amber.shade700),
-                ],
-              ),
-            ),
-          ),
-        // Line numbers + Markdown (line numbers are tappable)
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Line numbers column - tappable
-            SizedBox(
-              width: 32,
-              child: Padding(
-                padding: const EdgeInsets.only(right: 8),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: List.generate(lines.length, (index) {
-                    return GestureDetector(
-                      onTap: () {
-                        setState(() {
-                          _selectedText = lines[index];
-                        });
-                      },
-                      child: Container(
-                        height: 24, // Fixed height per line
-                        alignment: Alignment.centerRight,
-                        child: Text(
-                          '${index + 1}',
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.outline,
-                            fontSize: 12,
-                          ),
-                        ),
-                      ),
-                    );
-                  }),
-                ),
-              ),
-            ),
-            // Markdown content
-            Expanded(
-              child: Markdown(
-                data: widget.data,
-                shrinkWrap: true,
-                styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
-                builders: {
-                  'blockquote': _AnnotationBlockquoteBuilder(
-                    onLineTapped: widget.onLineTapped,
-                    sourceLines: lines,
-                  ),
-                },
-                onTapLink: (text, href, title) {
-                  // Allow link taps to open URLs
-                },
-              ),
-            ),
-          ],
+    return Markdown(
+      data: data,
+      shrinkWrap: true,
+      styleSheet: styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
+      builders: {
+        'blockquote': _AnnotationBlockquoteBuilder(
+          onLineTapped: onLineTapped,
+          sourceLines: data.split('\n'),
         ),
-      ],
+      },
+      onTapLink: (text, href, title) {
+        // Allow link taps to open URLs
+      },
     );
-  }
-
-  void _showCommentSheet(String selectedText) {
-    // Find ALL occurrences of the selected text in the document
-    final lines = widget.data.split('\n');
-    List<int> matchingLineIndices = [];
-
-    for (int i = 0; i < lines.length; i++) {
-      if (lines[i].contains(selectedText)) {
-        matchingLineIndices.add(i);
-      }
-    }
-
-    // Use first match
-    final lineIndex = matchingLineIndices.isNotEmpty ? matchingLineIndices.first : 0;
-
-    // Clear selection and call onLineTapped
-    setState(() {
-      _selectedText = '';
-    });
-
-    widget.onLineTapped(lineIndex, selectedText, lineIndex + 1);
   }
 
   MarkdownStyleSheet _buildAnnotationStyleSheet(

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -217,12 +217,8 @@ class _TapAwareMarkdownBodyState extends State<_TapAwareMarkdownBody> {
 
   @override
   Widget build(BuildContext context) {
-    // Debug: print data length to confirm content is being received
-    debugPrint('MarkdownWithAnnotations.build: data length = ${widget.data.length}');
-
     return LayoutBuilder(
       builder: (context, constraints) {
-        debugPrint('LayoutBuilder constraints: $constraints');
         return GestureDetector(
           onTapUp: (details) => _handleTap(details.localPosition),
           behavior: HitTestBehavior.opaque,

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -58,15 +58,19 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
       const TextStyle(height: 1.5),
     );
 
-    return _TapAwareMarkdownBody(
+    return Markdown(
       data: widget.data,
       styleSheet: widget.styleSheet ??
           _buildAnnotationStyleSheet(context, defaultStyleSheet),
-      annotationBuilder: _AnnotationBlockquoteBuilder(
-        onLineTapped: widget.onLineTapped,
-        sourceLines: _sourceLines,
-      ),
-      onLineTapped: widget.onLineTapped,
+      builders: {
+        'blockquote': _AnnotationBlockquoteBuilder(
+          onLineTapped: widget.onLineTapped,
+          sourceLines: _sourceLines,
+        ),
+      },
+      onTapLink: (text, href, title) {
+        // Allow link taps to open URLs
+      },
     );
   }
 
@@ -165,83 +169,3 @@ class _AnnotationBlockquoteBuilder extends MarkdownElementBuilder {
   }
 }
 
-/// Internal widget that wraps Markdown with gesture-based tap detection.
-///
-/// Uses [LayoutBuilder] to get constraints and [GestureDetector] to capture
-/// taps, mapping them to line indices based on the text layout.
-class _TapAwareMarkdownBody extends StatefulWidget {
-  final String data;
-  final MarkdownStyleSheet? styleSheet;
-  final MarkdownElementBuilder annotationBuilder;
-  final void Function(int lineIndex, String lineText) onLineTapped;
-
-  const _TapAwareMarkdownBody({
-    required this.data,
-    this.styleSheet,
-    required this.annotationBuilder,
-    required this.onLineTapped,
-  });
-
-  @override
-  State<_TapAwareMarkdownBody> createState() => _TapAwareMarkdownBodyState();
-}
-
-class _TapAwareMarkdownBodyState extends State<_TapAwareMarkdownBody> {
-  final _markdownKey = GlobalKey();
-  double _lineHeight = 0;
-  List<String> get _lines => widget.data.split('\n');
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _computeLineHeight());
-  }
-
-  void _computeLineHeight() {
-    if (_markdownKey.currentContext == null) return;
-    final renderBox = _markdownKey.currentContext!.findRenderObject() as RenderBox?;
-    if (renderBox == null) return;
-
-    final textPainter = TextPainter(
-      text: TextSpan(
-        text: widget.data,
-        style: widget.styleSheet?.p ?? Theme.of(context).textTheme.bodyMedium,
-      ),
-      textDirection: TextDirection.ltr,
-    );
-    textPainter.layout(maxWidth: renderBox.size.width);
-    setState(() {
-      _lineHeight = textPainter.preferredLineHeight;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return GestureDetector(
-          onTapUp: (details) => _handleTap(details.localPosition),
-          behavior: HitTestBehavior.opaque,
-          child: Markdown(
-            key: _markdownKey,
-            data: widget.data,
-            selectable: false,
-            styleSheet: widget.styleSheet,
-            builders: {
-              'blockquote': widget.annotationBuilder,
-            },
-          ),
-        );
-      },
-    );
-  }
-
-  void _handleTap(Offset localPosition) {
-    if (_lineHeight <= 0) return;
-
-    final lineIndex = (localPosition.dy / _lineHeight).floor();
-    if (lineIndex >= 0 && lineIndex < _lines.length) {
-      widget.onLineTapped(lineIndex, _lines[lineIndex]);
-    }
-  }
-}

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -217,8 +217,12 @@ class _TapAwareMarkdownBodyState extends State<_TapAwareMarkdownBody> {
 
   @override
   Widget build(BuildContext context) {
+    // Debug: print data length to confirm content is being received
+    debugPrint('MarkdownWithAnnotations.build: data length = ${widget.data.length}');
+
     return LayoutBuilder(
       builder: (context, constraints) {
+        debugPrint('LayoutBuilder constraints: $constraints');
         return GestureDetector(
           onTapUp: (details) => _handleTap(details.localPosition),
           behavior: HitTestBehavior.opaque,

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -56,66 +56,39 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
     final lines = widget.data.split('\n');
     final lineHeight = theme.textTheme.bodyMedium?.fontSize ?? 16;
 
-    return Stack(
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Line numbers column (display only)
-            SizedBox(
-              width: 32,
-              child: Padding(
-                padding: const EdgeInsets.only(right: 8),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: List.generate(lines.length, (index) {
-                    return Container(
-                      height: lineHeight * 1.5,
-                      alignment: Alignment.centerRight,
-                      child: Text(
-                        '${index + 1}',
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.outline,
-                          fontSize: 12,
-                        ),
-                      ),
-                    );
-                  }),
-                ),
+        // Line numbers column - use RichText with same style as markdown for alignment
+        SizedBox(
+          width: 32,
+          child: Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: RichText(
+              text: TextSpan(
+                style: theme.textTheme.bodyMedium?.copyWith(height: 1.5),
+                children: List.generate(lines.length, (index) {
+                  return TextSpan(text: '${index + 1}\n');
+                }),
               ),
             ),
-            // Markdown content
-            Expanded(
-              child: Markdown(
-                data: widget.data,
-                shrinkWrap: true,
-                styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
-                builders: {
-                  'blockquote': _AnnotationBlockquoteBuilder(
-                    onLineTapped: widget.onLineTapped,
-                    sourceLines: lines,
-                  ),
-                },
-                onTapLink: (text, href, title) {
-                  // Allow link taps to open URLs
-                },
-              ),
-            ),
-          ],
+          ),
         ),
-        // Tap overlay - use IgnorePointer to let taps pass through for scrolling
-        // but capture taps for line selection
-        Positioned.fill(
-          child: GestureDetector(
-            onTapUp: (details) {
-              // Calculate which line was tapped based on Y position
-              final tapY = details.localPosition.dy;
-              final tappedLine = (tapY / (lineHeight * 1.5)).floor();
-              if (tappedLine >= 0 && tappedLine < lines.length) {
-                widget.onLineTapped(tappedLine, lines[tappedLine]);
-              }
+        // Markdown content
+        Expanded(
+          child: Markdown(
+            data: widget.data,
+            shrinkWrap: true,
+            styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
+            builders: {
+              'blockquote': _AnnotationBlockquoteBuilder(
+                onLineTapped: widget.onLineTapped,
+                sourceLines: lines,
+              ),
             },
-            behavior: HitTestBehavior.opaque,
+            onTapLink: (text, href, title) {
+              // Allow link taps to open URLs
+            },
           ),
         ),
       ],

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -109,17 +109,18 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
   }
 
   void _handleTap(Offset localPosition) {
-    if (_textSize == null || _lineHeight <= 0) return;
+    if (_lineHeight <= 0) {
+      // Fallback: use estimated line height
+      final lineIndex = (localPosition.dy / 24).floor();
+      final lines = widget.data.split('\n');
+      if (lineIndex >= 0 && lineIndex < lines.length) {
+        widget.onLineTapped(lineIndex, lines[lineIndex]);
+      }
+      return;
+    }
 
-    // Scale tap position based on actual rendered size vs available width
-    final renderBox = _markdownKey.currentContext?.findRenderObject() as RenderBox?;
-    if (renderBox == null) return;
-
-    final availableWidth = renderBox.size.width;
-    final scale = availableWidth > 0 ? (_textSize!.width / availableWidth) : 1.0;
-    final scaledY = localPosition.dy * scale;
-
-    final lineIndex = (scaledY / _lineHeight).floor();
+    // Use the actual computed line height directly
+    final lineIndex = (localPosition.dy / _lineHeight).floor();
     final lines = widget.data.split('\n');
     if (lineIndex >= 0 && lineIndex < lines.length) {
       widget.onLineTapped(lineIndex, lines[lineIndex]);

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -97,22 +97,56 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
       const TextStyle(height: 1.5),
     );
 
+    final lines = widget.data.split('\n');
+    final lineCount = lines.length;
+    final lineHeight = theme.textTheme.bodyMedium?.fontSize ?? 16 * 1.5;
+
     return Stack(
       children: [
-        Markdown(
-          key: _markdownKey,
-          data: widget.data,
-          shrinkWrap: true,
-          styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
-          builders: {
-            'blockquote': _AnnotationBlockquoteBuilder(
-              onLineTapped: widget.onLineTapped,
-              sourceLines: widget.data.split('\n'),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Line numbers column
+            SizedBox(
+              width: 32,
+              child: Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: List.generate(lineCount, (index) {
+                    return SizedBox(
+                      height: lineHeight,
+                      child: Text(
+                        '${index + 1}',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.outline,
+                          fontSize: 12,
+                        ),
+                      ),
+                    );
+                  }),
+                ),
+              ),
             ),
-          },
-          onTapLink: (text, href, title) {
-            // Allow link taps to open URLs
-          },
+            // Markdown content
+            Expanded(
+              child: Markdown(
+                key: _markdownKey,
+                data: widget.data,
+                shrinkWrap: true,
+                styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
+                builders: {
+                  'blockquote': _AnnotationBlockquoteBuilder(
+                    onLineTapped: widget.onLineTapped,
+                    sourceLines: lines,
+                  ),
+                },
+                onTapLink: (text, href, title) {
+                  // Allow link taps to open URLs
+                },
+              ),
+            ),
+          ],
         ),
         Positioned.fill(
           child: GestureDetector(

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -47,144 +47,63 @@ class MarkdownWithAnnotations extends StatefulWidget {
 }
 
 class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
-  final _markdownKey = GlobalKey();
-  final List<double> _lineOffsets = [];
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _computeLineOffsets());
-  }
-
-  void _computeLineOffsets() {
-    if (_markdownKey.currentContext == null) return;
-    final renderBox = _markdownKey.currentContext!.findRenderObject() as RenderBox?;
-    if (renderBox == null) return;
-
-    final textPainter = TextPainter(
-      text: TextSpan(
-        text: widget.data,
-        style: Theme.of(context).textTheme.bodyMedium?.copyWith(height: 1.5),
-      ),
-      textDirection: TextDirection.ltr,
-    );
-    textPainter.layout(maxWidth: renderBox.size.width);
-
-    // Get exact line offsets using getLineBoundary
-    _lineOffsets.clear();
-    for (int i = 0; i < widget.data.split('\n').length; i++) {
-      final offset = textPainter.getOffsetForCaret(
-        TextPosition(offset: i < widget.data.length ? widget.data.split('\n').take(i + 1).join('\n').length : 0),
-        Rect.zero,
-      );
-      // Use line height directly since getOffsetForCaret gives character position
-    }
-
-    final lineCount = widget.data.split('\n').length;
-    final lineHeight = textPainter.height / lineCount;
-    _lineOffsets.clear();
-    for (int i = 0; i < lineCount; i++) {
-      _lineOffsets.add(i * lineHeight);
-    }
-
-    if (mounted) setState(() {});
-  }
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final defaultStyleSheet = theme.textTheme.bodyMedium?.merge(
       const TextStyle(height: 1.5),
     );
-
     final lines = widget.data.split('\n');
-    final lineCount = lines.length;
-    final lineHeight = theme.textTheme.bodyMedium?.fontSize ?? 16 * 1.5;
+    final lineHeight = theme.textTheme.bodyMedium?.fontSize ?? 16;
 
-    return Stack(
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Line numbers column
-            SizedBox(
-              width: 32,
-              child: Padding(
-                padding: const EdgeInsets.only(right: 8),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: List.generate(lineCount, (index) {
-                    return SizedBox(
-                      height: lineHeight,
-                      child: Text(
-                        '${index + 1}',
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.outline,
-                          fontSize: 12,
-                        ),
+        // Line numbers column
+        SizedBox(
+          width: 32,
+          child: Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: List.generate(lines.length, (index) {
+                return GestureDetector(
+                  onTap: () => widget.onLineTapped(index, lines[index]),
+                  behavior: HitTestBehavior.opaque,
+                  child: SizedBox(
+                    height: lineHeight * 1.5,
+                    child: Text(
+                      '${index + 1}',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.outline,
+                        fontSize: 12,
                       ),
-                    );
-                  }),
-                ),
-              ),
-            ),
-            // Markdown content
-            Expanded(
-              child: Markdown(
-                key: _markdownKey,
-                data: widget.data,
-                shrinkWrap: true,
-                styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
-                builders: {
-                  'blockquote': _AnnotationBlockquoteBuilder(
-                    onLineTapped: widget.onLineTapped,
-                    sourceLines: lines,
+                    ),
                   ),
-                },
-                onTapLink: (text, href, title) {
-                  // Allow link taps to open URLs
-                },
-              ),
+                );
+              }),
             ),
-          ],
+          ),
         ),
-        Positioned.fill(
-          child: GestureDetector(
-            onTapUp: (details) => _handleTap(details.localPosition),
-            behavior: HitTestBehavior.translucent,
-            child: Container(color: Colors.transparent),
+        // Markdown content
+        Expanded(
+          child: Markdown(
+            data: widget.data,
+            shrinkWrap: true,
+            styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
+            builders: {
+              'blockquote': _AnnotationBlockquoteBuilder(
+                onLineTapped: widget.onLineTapped,
+                sourceLines: lines,
+              ),
+            },
+            onTapLink: (text, href, title) {
+              // Allow link taps to open URLs
+            },
           ),
         ),
       ],
     );
-  }
-
-  void _handleTap(Offset localPosition) {
-    if (_lineOffsets.isEmpty) {
-      // Fallback: use estimated line height
-      final lineIndex = (localPosition.dy / 24).floor();
-      final lines = widget.data.split('\n');
-      if (lineIndex >= 0 && lineIndex < lines.length) {
-        widget.onLineTapped(lineIndex, lines[lineIndex]);
-      }
-      return;
-    }
-
-    // Find closest line to tap position using precomputed offsets
-    final tapY = localPosition.dy;
-    int lineIndex = 0;
-    for (int i = 0; i < _lineOffsets.length; i++) {
-      if (tapY >= _lineOffsets[i]) {
-        lineIndex = i;
-      } else {
-        break;
-      }
-    }
-
-    final lines = widget.data.split('\n');
-    if (lineIndex >= 0 && lineIndex < lines.length) {
-      widget.onLineTapped(lineIndex, lines[lineIndex]);
-    }
   }
 
   MarkdownStyleSheet _buildAnnotationStyleSheet(

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -18,7 +18,7 @@ final _annotationPattern = RegExp(r'^##\s+(\d+):\s+(.*)$');
 /// ```dart
 /// MarkdownWithAnnotations(
 ///   data: markdownContent,
-///   onLineTapped: (lineIndex, lineText) {
+///   onLineTapped: (lineIndex, lineText, lineNumber) {
 ///     // Show inline comment sheet
 ///   },
 /// )
@@ -28,8 +28,8 @@ class MarkdownWithAnnotations extends StatefulWidget {
   final String data;
 
   /// Called when the user taps a line or paragraph of rendered markdown.
-  /// Passes the 0-based line index and the text content of that line.
-  final void Function(int lineIndex, String lineText) onLineTapped;
+  /// Passes the 0-based line index, the tapped text, and the 1-based line number.
+  final void Function(int lineIndex, String tappedText, int lineNumber) onLineTapped;
 
   /// Optional style for annotation markers. Falls back to default amber
   /// blockquote styling.
@@ -56,7 +56,6 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
       const TextStyle(height: 1.5),
     );
     final lines = widget.data.split('\n');
-    final lineHeight = theme.textTheme.bodyMedium?.fontSize ?? 16;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -142,20 +141,25 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
   }
 
   void _showCommentSheet(String selectedText) {
-    // Find the line index of the selected text
+    // Find ALL occurrences of the selected text in the document
     final lines = widget.data.split('\n');
-    int lineIndex = 0;
+    List<int> matchingLineIndices = [];
+
     for (int i = 0; i < lines.length; i++) {
-      if (lines[i].contains(selectedText) || selectedText.contains(lines[i])) {
-        lineIndex = i;
-        break;
+      if (lines[i].contains(selectedText)) {
+        matchingLineIndices.add(i);
       }
     }
 
-    widget.onLineTapped(lineIndex, lines[lineIndex]);
+    // Use first match
+    final lineIndex = matchingLineIndices.isNotEmpty ? matchingLineIndices.first : 0;
+
+    // Clear selection and call onLineTapped
     setState(() {
       _selectedText = '';
     });
+
+    widget.onLineTapped(lineIndex, selectedText, lineIndex + 1);
   }
 
   MarkdownStyleSheet _buildAnnotationStyleSheet(
@@ -188,7 +192,7 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
 
 /// Custom builder for blockquote elements that detects annotation markers.
 class _AnnotationBlockquoteBuilder extends MarkdownElementBuilder {
-  final void Function(int lineIndex, String lineText) onLineTapped;
+  final void Function(int lineIndex, String tappedText, int lineNumber) onLineTapped;
   final List<String> sourceLines;
 
   _AnnotationBlockquoteBuilder({
@@ -250,4 +254,3 @@ class _AnnotationBlockquoteBuilder extends MarkdownElementBuilder {
     );
   }
 }
-

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -93,7 +93,7 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
       child: Markdown(
         key: _markdownKey,
         data: widget.data,
-        shrinkWrap: false,
+        shrinkWrap: true,
         styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
         builders: {
           'blockquote': _AnnotationBlockquoteBuilder(

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -23,7 +23,7 @@ final _annotationPattern = RegExp(r'^##\s+(\d+):\s+(.*)$');
 ///   },
 /// )
 /// ```
-class MarkdownWithAnnotations extends StatefulWidget {
+class MarkdownWithAnnotations extends StatelessWidget {
   /// The markdown content to render.
   final String data;
 
@@ -43,35 +43,40 @@ class MarkdownWithAnnotations extends StatefulWidget {
   });
 
   @override
-  State<MarkdownWithAnnotations> createState() =>
-      _MarkdownWithAnnotationsState();
-}
-
-class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
-  /// Cached list of source lines for tap resolution.
-  List<String> get _sourceLines => widget.data.split('\n');
-
-  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final defaultStyleSheet = theme.textTheme.bodyMedium?.merge(
       const TextStyle(height: 1.5),
     );
 
-    return Markdown(
-      data: widget.data,
-      styleSheet: widget.styleSheet ??
-          _buildAnnotationStyleSheet(context, defaultStyleSheet),
-      builders: {
-        'blockquote': _AnnotationBlockquoteBuilder(
-          onLineTapped: widget.onLineTapped,
-          sourceLines: _sourceLines,
-        ),
-      },
-      onTapLink: (text, href, title) {
-        // Allow link taps to open URLs
-      },
+    return GestureDetector(
+      onTapUp: (details) => _handleTap(context, details.localPosition),
+      behavior: HitTestBehavior.opaque,
+      child: Markdown(
+        data: data,
+        shrinkWrap: true,
+        styleSheet: styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
+        builders: {
+          'blockquote': _AnnotationBlockquoteBuilder(
+            onLineTapped: onLineTapped,
+            sourceLines: data.split('\n'),
+          ),
+        },
+        onTapLink: (text, href, title) {
+          // Allow link taps to open URLs
+        },
+      ),
     );
+  }
+
+  void _handleTap(BuildContext context, Offset localPosition) {
+    // Estimate line based on tap position
+    final lineHeight = Theme.of(context).textTheme.bodyMedium?.fontSize ?? 16 * 1.5;
+    final lineIndex = (localPosition.dy / lineHeight).floor();
+    final lines = data.split('\n');
+    if (lineIndex >= 0 && lineIndex < lines.length) {
+      onLineTapped(lineIndex, lines[lineIndex]);
+    }
   }
 
   MarkdownStyleSheet _buildAnnotationStyleSheet(
@@ -79,8 +84,6 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
     TextStyle? baseStyle,
   ) {
     final theme = Theme.of(context);
-
-    // Amber accent for annotation markers (distinct from regular quotes)
     const amberAccent = Color(0xFFFFC107);
     final amberLight = Colors.amber.shade50;
 

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -23,7 +23,7 @@ final _annotationPattern = RegExp(r'^##\s+(\d+):\s+(.*)$');
 ///   },
 /// )
 /// ```
-class MarkdownWithAnnotations extends StatelessWidget {
+class MarkdownWithAnnotations extends StatefulWidget {
   /// The markdown content to render.
   final String data;
 
@@ -43,6 +43,44 @@ class MarkdownWithAnnotations extends StatelessWidget {
   });
 
   @override
+  State<MarkdownWithAnnotations> createState() => _MarkdownWithAnnotationsState();
+}
+
+class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
+  final _markdownKey = GlobalKey();
+  double _lineHeight = 24.0; // Default fallback
+  Size? _textSize;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _computeLineHeight());
+  }
+
+  void _computeLineHeight() {
+    if (_markdownKey.currentContext == null) return;
+    final renderBox = _markdownKey.currentContext!.findRenderObject() as RenderBox?;
+    if (renderBox == null) return;
+
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: widget.data,
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(height: 1.5),
+      ),
+      textDirection: TextDirection.ltr,
+    );
+    textPainter.layout(maxWidth: renderBox.size.width);
+
+    final lineCount = widget.data.split('\n').length;
+    if (lineCount > 0) {
+      setState(() {
+        _textSize = textPainter.size;
+        _lineHeight = textPainter.height / lineCount;
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final defaultStyleSheet = theme.textTheme.bodyMedium?.merge(
@@ -50,16 +88,17 @@ class MarkdownWithAnnotations extends StatelessWidget {
     );
 
     return GestureDetector(
-      onTapUp: (details) => _handleTap(context, details.localPosition),
+      onTapUp: (details) => _handleTap(details.localPosition),
       behavior: HitTestBehavior.opaque,
       child: Markdown(
-        data: data,
-        shrinkWrap: true,
-        styleSheet: styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
+        key: _markdownKey,
+        data: widget.data,
+        shrinkWrap: false,
+        styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
         builders: {
           'blockquote': _AnnotationBlockquoteBuilder(
-            onLineTapped: onLineTapped,
-            sourceLines: data.split('\n'),
+            onLineTapped: widget.onLineTapped,
+            sourceLines: widget.data.split('\n'),
           ),
         },
         onTapLink: (text, href, title) {
@@ -69,13 +108,21 @@ class MarkdownWithAnnotations extends StatelessWidget {
     );
   }
 
-  void _handleTap(BuildContext context, Offset localPosition) {
-    // Estimate line based on tap position
-    final lineHeight = Theme.of(context).textTheme.bodyMedium?.fontSize ?? 16 * 1.5;
-    final lineIndex = (localPosition.dy / lineHeight).floor();
-    final lines = data.split('\n');
+  void _handleTap(Offset localPosition) {
+    if (_textSize == null || _lineHeight <= 0) return;
+
+    // Scale tap position based on actual rendered size vs available width
+    final renderBox = _markdownKey.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox == null) return;
+
+    final availableWidth = renderBox.size.width;
+    final scale = availableWidth > 0 ? (_textSize!.width / availableWidth) : 1.0;
+    final scaledY = localPosition.dy * scale;
+
+    final lineIndex = (scaledY / _lineHeight).floor();
+    final lines = widget.data.split('\n');
     if (lineIndex >= 0 && lineIndex < lines.length) {
-      onLineTapped(lineIndex, lines[lineIndex]);
+      widget.onLineTapped(lineIndex, lines[lineIndex]);
     }
   }
 

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -60,7 +60,6 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
 
     return Markdown(
       data: widget.data,
-      shrinkWrap: true,
       styleSheet: widget.styleSheet ??
           _buildAnnotationStyleSheet(context, defaultStyleSheet),
       builders: {

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -1,0 +1,247 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+
+/// Pattern to detect inline comment annotation sections.
+///
+/// Matches markdown headings with format: ## N: Title
+/// where N is a line/section number.
+final _annotationPattern = RegExp(r'^##\s+(\d+):\s+(.*)$');
+
+/// A markdown widget with tap detection for inline commenting and
+/// annotation marker rendering.
+///
+/// Wraps [Markdown] to detect taps on individual lines/paragraphs and
+/// renders inline comment annotation markers (## N: Title sections) as
+/// visually distinct styled blockquotes with amber/yellow left border.
+///
+/// Usage:
+/// ```dart
+/// MarkdownWithAnnotations(
+///   data: markdownContent,
+///   onLineTapped: (lineIndex, lineText) {
+///     // Show inline comment sheet
+///   },
+/// )
+/// ```
+class MarkdownWithAnnotations extends StatefulWidget {
+  /// The markdown content to render.
+  final String data;
+
+  /// Called when the user taps a line or paragraph of rendered markdown.
+  /// Passes the 0-based line index and the text content of that line.
+  final void Function(int lineIndex, String lineText) onLineTapped;
+
+  /// Optional style for annotation markers. Falls back to default amber
+  /// blockquote styling.
+  final MarkdownStyleSheet? styleSheet;
+
+  const MarkdownWithAnnotations({
+    super.key,
+    required this.data,
+    required this.onLineTapped,
+    this.styleSheet,
+  });
+
+  @override
+  State<MarkdownWithAnnotations> createState() =>
+      _MarkdownWithAnnotationsState();
+}
+
+class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
+  /// Cached list of source lines for tap resolution.
+  List<String> get _sourceLines => widget.data.split('\n');
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final defaultStyleSheet = theme.textTheme.bodyMedium?.merge(
+      const TextStyle(height: 1.5),
+    );
+
+    return _TapAwareMarkdownBody(
+      data: widget.data,
+      styleSheet: widget.styleSheet ??
+          _buildAnnotationStyleSheet(context, defaultStyleSheet),
+      annotationBuilder: _AnnotationBlockquoteBuilder(
+        onLineTapped: widget.onLineTapped,
+        sourceLines: _sourceLines,
+      ),
+      onLineTapped: widget.onLineTapped,
+    );
+  }
+
+  MarkdownStyleSheet _buildAnnotationStyleSheet(
+    BuildContext context,
+    TextStyle? baseStyle,
+  ) {
+    final theme = Theme.of(context);
+
+    // Amber accent for annotation markers (distinct from regular quotes)
+    const amberAccent = Color(0xFFFFC107);
+    final amberLight = Colors.amber.shade50;
+
+    return MarkdownStyleSheet(
+      blockquote: baseStyle?.copyWith(
+        color: theme.colorScheme.onSurface,
+      ),
+      blockquoteDecoration: BoxDecoration(
+        color: amberLight,
+        border: const Border(
+          left: BorderSide(color: amberAccent, width: 4),
+        ),
+      ),
+      blockquotePadding: const EdgeInsets.only(
+        left: 12,
+        top: 8,
+        bottom: 8,
+        right: 12,
+      ),
+    );
+  }
+}
+
+/// Custom builder for blockquote elements that detects annotation markers.
+class _AnnotationBlockquoteBuilder extends MarkdownElementBuilder {
+  final void Function(int lineIndex, String lineText) onLineTapped;
+  final List<String> sourceLines;
+
+  _AnnotationBlockquoteBuilder({
+    required this.onLineTapped,
+    required this.sourceLines,
+  });
+
+  @override
+  Widget? visitElementAfter(element, TextStyle? preferredStyle) {
+    // Get the text content of the blockquote
+    final textContent = element.textContent;
+
+    // Check if this blockquote matches the annotation pattern ## N: Title
+    final match = _annotationPattern.firstMatch(textContent);
+    if (match == null) {
+      // Regular blockquote — return null to use default styling
+      return null;
+    }
+
+    // This is an annotation marker — apply distinct amber styling
+    const amberAccent = Color(0xFFFFC107);
+    final amberDark = Colors.amber.shade700;
+    final amberLight = Colors.amber.shade50;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      padding: const EdgeInsets.only(
+        left: 12,
+        top: 8,
+        bottom: 8,
+        right: 12,
+      ),
+      decoration: BoxDecoration(
+        color: amberLight,
+        border: const Border(
+          left: BorderSide(color: amberAccent, width: 4),
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.comment_outlined,
+            size: 18,
+            color: amberDark,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              textContent,
+              style: preferredStyle?.copyWith(
+                color: amberDark,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Internal widget that wraps Markdown with gesture-based tap detection.
+///
+/// Uses [LayoutBuilder] to get constraints and [GestureDetector] to capture
+/// taps, mapping them to line indices based on the text layout.
+class _TapAwareMarkdownBody extends StatefulWidget {
+  final String data;
+  final MarkdownStyleSheet? styleSheet;
+  final MarkdownElementBuilder annotationBuilder;
+  final void Function(int lineIndex, String lineText) onLineTapped;
+
+  const _TapAwareMarkdownBody({
+    required this.data,
+    this.styleSheet,
+    required this.annotationBuilder,
+    required this.onLineTapped,
+  });
+
+  @override
+  State<_TapAwareMarkdownBody> createState() => _TapAwareMarkdownBodyState();
+}
+
+class _TapAwareMarkdownBodyState extends State<_TapAwareMarkdownBody> {
+  final _markdownKey = GlobalKey();
+  double _lineHeight = 0;
+  List<String> get _lines => widget.data.split('\n');
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _computeLineHeight());
+  }
+
+  void _computeLineHeight() {
+    if (_markdownKey.currentContext == null) return;
+    final renderBox = _markdownKey.currentContext!.findRenderObject() as RenderBox?;
+    if (renderBox == null) return;
+
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: widget.data,
+        style: widget.styleSheet?.p ?? Theme.of(context).textTheme.bodyMedium,
+      ),
+      textDirection: TextDirection.ltr,
+    );
+    textPainter.layout(maxWidth: renderBox.size.width);
+    setState(() {
+      _lineHeight = textPainter.preferredLineHeight;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return GestureDetector(
+          onTapUp: (details) => _handleTap(details.localPosition),
+          behavior: HitTestBehavior.opaque,
+          child: Markdown(
+            key: _markdownKey,
+            data: widget.data,
+            selectable: false,
+            styleSheet: widget.styleSheet,
+            builders: {
+              'blockquote': widget.annotationBuilder,
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  void _handleTap(Offset localPosition) {
+    if (_lineHeight <= 0) return;
+
+    final lineIndex = (localPosition.dy / _lineHeight).floor();
+    if (lineIndex >= 0 && lineIndex < _lines.length) {
+      widget.onLineTapped(lineIndex, _lines[lineIndex]);
+    }
+  }
+}

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -56,50 +56,66 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
     final lines = widget.data.split('\n');
     final lineHeight = theme.textTheme.bodyMedium?.fontSize ?? 16;
 
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
+    return Stack(
       children: [
-        // Line numbers column
-        SizedBox(
-          width: 32,
-          child: Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: List.generate(lines.length, (index) {
-                return GestureDetector(
-                  onTap: () => widget.onLineTapped(index, lines[index]),
-                  behavior: HitTestBehavior.opaque,
-                  child: SizedBox(
-                    height: lineHeight * 1.5,
-                    child: Text(
-                      '${index + 1}',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.outline,
-                        fontSize: 12,
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Line numbers column (display only)
+            SizedBox(
+              width: 32,
+              child: Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: List.generate(lines.length, (index) {
+                    return Container(
+                      height: lineHeight * 1.5,
+                      alignment: Alignment.centerRight,
+                      child: Text(
+                        '${index + 1}',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.outline,
+                          fontSize: 12,
+                        ),
                       ),
-                    ),
-                  ),
-                );
-              }),
-            ),
-          ),
-        ),
-        // Markdown content
-        Expanded(
-          child: Markdown(
-            data: widget.data,
-            shrinkWrap: true,
-            styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
-            builders: {
-              'blockquote': _AnnotationBlockquoteBuilder(
-                onLineTapped: widget.onLineTapped,
-                sourceLines: lines,
+                    );
+                  }),
+                ),
               ),
+            ),
+            // Markdown content
+            Expanded(
+              child: Markdown(
+                data: widget.data,
+                shrinkWrap: true,
+                styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
+                builders: {
+                  'blockquote': _AnnotationBlockquoteBuilder(
+                    onLineTapped: widget.onLineTapped,
+                    sourceLines: lines,
+                  ),
+                },
+                onTapLink: (text, href, title) {
+                  // Allow link taps to open URLs
+                },
+              ),
+            ),
+          ],
+        ),
+        // Tap overlay - use IgnorePointer to let taps pass through for scrolling
+        // but capture taps for line selection
+        Positioned.fill(
+          child: GestureDetector(
+            onTapUp: (details) {
+              // Calculate which line was tapped based on Y position
+              final tapY = details.localPosition.dy;
+              final tappedLine = (tapY / (lineHeight * 1.5)).floor();
+              if (tappedLine >= 0 && tappedLine < lines.length) {
+                widget.onLineTapped(tappedLine, lines[tappedLine]);
+              }
             },
-            onTapLink: (text, href, title) {
-              // Allow link taps to open URLs
-            },
+            behavior: HitTestBehavior.opaque,
           ),
         ),
       ],

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -48,16 +48,15 @@ class MarkdownWithAnnotations extends StatefulWidget {
 
 class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
   final _markdownKey = GlobalKey();
-  double _lineHeight = 24.0; // Default fallback
-  Size? _textSize;
+  final List<double> _lineOffsets = [];
 
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _computeLineHeight());
+    WidgetsBinding.instance.addPostFrameCallback((_) => _computeLineOffsets());
   }
 
-  void _computeLineHeight() {
+  void _computeLineOffsets() {
     if (_markdownKey.currentContext == null) return;
     final renderBox = _markdownKey.currentContext!.findRenderObject() as RenderBox?;
     if (renderBox == null) return;
@@ -71,13 +70,24 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
     );
     textPainter.layout(maxWidth: renderBox.size.width);
 
-    final lineCount = widget.data.split('\n').length;
-    if (lineCount > 0) {
-      setState(() {
-        _textSize = textPainter.size;
-        _lineHeight = textPainter.height / lineCount;
-      });
+    // Get exact line offsets using getLineBoundary
+    _lineOffsets.clear();
+    for (int i = 0; i < widget.data.split('\n').length; i++) {
+      final offset = textPainter.getOffsetForCaret(
+        TextPosition(offset: i < widget.data.length ? widget.data.split('\n').take(i + 1).join('\n').length : 0),
+        Rect.zero,
+      );
+      // Use line height directly since getOffsetForCaret gives character position
     }
+
+    final lineCount = widget.data.split('\n').length;
+    final lineHeight = textPainter.height / lineCount;
+    _lineOffsets.clear();
+    for (int i = 0; i < lineCount; i++) {
+      _lineOffsets.add(i * lineHeight);
+    }
+
+    if (mounted) setState(() {});
   }
 
   @override
@@ -116,7 +126,7 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
   }
 
   void _handleTap(Offset localPosition) {
-    if (_lineHeight <= 0) {
+    if (_lineOffsets.isEmpty) {
       // Fallback: use estimated line height
       final lineIndex = (localPosition.dy / 24).floor();
       final lines = widget.data.split('\n');
@@ -126,8 +136,17 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
       return;
     }
 
-    // Use the actual computed line height directly
-    final lineIndex = (localPosition.dy / _lineHeight).floor();
+    // Find closest line to tap position using precomputed offsets
+    final tapY = localPosition.dy;
+    int lineIndex = 0;
+    for (int i = 0; i < _lineOffsets.length; i++) {
+      if (tapY >= _lineOffsets[i]) {
+        lineIndex = i;
+      } else {
+        break;
+      }
+    }
+
     final lines = widget.data.split('\n');
     if (lineIndex >= 0 && lineIndex < lines.length) {
       widget.onLineTapped(lineIndex, lines[lineIndex]);

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -89,49 +89,55 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
               ),
             ),
           ),
-        // Line numbers + Markdown
+        // Line numbers + Markdown (line numbers are tappable)
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Line numbers column
+            // Line numbers column - tappable
             SizedBox(
               width: 32,
               child: Padding(
                 padding: const EdgeInsets.only(right: 8),
-                child: RichText(
-                  text: TextSpan(
-                    style: theme.textTheme.bodyMedium?.copyWith(height: 1.5),
-                    children: List.generate(lines.length, (index) {
-                      return TextSpan(text: '${index + 1}\n');
-                    }),
-                  ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: List.generate(lines.length, (index) {
+                    return GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          _selectedText = lines[index];
+                        });
+                      },
+                      child: Container(
+                        height: 24, // Fixed height per line
+                        alignment: Alignment.centerRight,
+                        child: Text(
+                          '${index + 1}',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.outline,
+                            fontSize: 12,
+                          ),
+                        ),
+                      ),
+                    );
+                  }),
                 ),
               ),
             ),
-            // Markdown content - selectable
+            // Markdown content
             Expanded(
-              child: SelectionArea(
-                onSelectionChanged: (selection) {
-                  if (selection != null && selection.plainText.isNotEmpty) {
-                    setState(() {
-                      _selectedText = selection.plainText;
-                    });
-                  }
+              child: Markdown(
+                data: widget.data,
+                shrinkWrap: true,
+                styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
+                builders: {
+                  'blockquote': _AnnotationBlockquoteBuilder(
+                    onLineTapped: widget.onLineTapped,
+                    sourceLines: lines,
+                  ),
                 },
-                child: Markdown(
-                  data: widget.data,
-                  shrinkWrap: true,
-                  styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
-                  builders: {
-                    'blockquote': _AnnotationBlockquoteBuilder(
-                      onLineTapped: widget.onLineTapped,
-                      sourceLines: lines,
-                    ),
-                  },
-                  onTapLink: (text, href, title) {
-                    // Allow link taps to open URLs
-                  },
-                ),
+                onTapLink: (text, href, title) {
+                  // Allow link taps to open URLs
+                },
               ),
             ),
           ],

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -87,20 +87,24 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
       const TextStyle(height: 1.5),
     );
 
-    return Markdown(
-      key: _markdownKey,
-      data: widget.data,
-      shrinkWrap: true,
-      styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
-      builders: {
-        'blockquote': _AnnotationBlockquoteBuilder(
-          onLineTapped: widget.onLineTapped,
-          sourceLines: widget.data.split('\n'),
-        ),
-      },
-      onTapLink: (text, href, title) {
-        // Allow link taps to open URLs
-      },
+    return GestureDetector(
+      onTapUp: (details) => _handleTap(details.localPosition),
+      behavior: HitTestBehavior.translucent,
+      child: Markdown(
+        key: _markdownKey,
+        data: widget.data,
+        shrinkWrap: true,
+        styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
+        builders: {
+          'blockquote': _AnnotationBlockquoteBuilder(
+            onLineTapped: widget.onLineTapped,
+            sourceLines: widget.data.split('\n'),
+          ),
+        },
+        onTapLink: (text, href, title) {
+          // Allow link taps to open URLs
+        },
+      ),
     );
   }
 

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -18,8 +18,8 @@ class MarkdownWithAnnotations extends StatelessWidget {
   final String data;
 
   /// Called when the user taps a line or paragraph of rendered markdown.
-  /// Passes the 0-based line index, the tapped text, and the 1-based line number.
-  final void Function(int lineIndex, String tappedText, int lineNumber) onLineTapped;
+  /// Passes the 0-based line index and the tapped text.
+  final void Function(int lineIndex, String tappedText) onLineTapped;
 
   /// Optional style for annotation markers. Falls back to default amber
   /// blockquote styling.
@@ -85,7 +85,7 @@ class MarkdownWithAnnotations extends StatelessWidget {
 
 /// Custom builder for blockquote elements that detects annotation markers.
 class _AnnotationBlockquoteBuilder extends MarkdownElementBuilder {
-  final void Function(int lineIndex, String tappedText, int lineNumber) onLineTapped;
+  final void Function(int lineIndex, String tappedText) onLineTapped;
   final List<String> sourceLines;
 
   _AnnotationBlockquoteBuilder({

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -47,6 +47,8 @@ class MarkdownWithAnnotations extends StatefulWidget {
 }
 
 class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
+  String _selectedText = '';
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -56,43 +58,104 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
     final lines = widget.data.split('\n');
     final lineHeight = theme.textTheme.bodyMedium?.fontSize ?? 16;
 
-    return Row(
+    return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Line numbers column - use RichText with same style as markdown for alignment
-        SizedBox(
-          width: 32,
-          child: Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: RichText(
-              text: TextSpan(
-                style: theme.textTheme.bodyMedium?.copyWith(height: 1.5),
-                children: List.generate(lines.length, (index) {
-                  return TextSpan(text: '${index + 1}\n');
-                }),
+        // Show selected text if any
+        if (_selectedText.isNotEmpty)
+          GestureDetector(
+            onTap: () => _showCommentSheet(_selectedText),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              margin: const EdgeInsets.only(bottom: 8),
+              decoration: BoxDecoration(
+                color: Colors.amber.shade100,
+                borderRadius: BorderRadius.circular(4),
+                border: Border.all(color: Colors.amber.shade300),
+              ),
+              child: Row(
+                children: [
+                  Icon(Icons.comment_outlined, size: 16, color: Colors.amber.shade700),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Comment on: "$_selectedText"',
+                      style: TextStyle(color: Colors.amber.shade900, fontSize: 13),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  Icon(Icons.add, size: 16, color: Colors.amber.shade700),
+                ],
               ),
             ),
           ),
-        ),
-        // Markdown content
-        Expanded(
-          child: Markdown(
-            data: widget.data,
-            shrinkWrap: true,
-            styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
-            builders: {
-              'blockquote': _AnnotationBlockquoteBuilder(
-                onLineTapped: widget.onLineTapped,
-                sourceLines: lines,
+        // Line numbers + Markdown
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Line numbers column
+            SizedBox(
+              width: 32,
+              child: Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: RichText(
+                  text: TextSpan(
+                    style: theme.textTheme.bodyMedium?.copyWith(height: 1.5),
+                    children: List.generate(lines.length, (index) {
+                      return TextSpan(text: '${index + 1}\n');
+                    }),
+                  ),
+                ),
               ),
-            },
-            onTapLink: (text, href, title) {
-              // Allow link taps to open URLs
-            },
-          ),
+            ),
+            // Markdown content - selectable
+            Expanded(
+              child: SelectionArea(
+                onSelectionChanged: (selection) {
+                  if (selection != null && selection.plainText.isNotEmpty) {
+                    setState(() {
+                      _selectedText = selection.plainText;
+                    });
+                  }
+                },
+                child: Markdown(
+                  data: widget.data,
+                  shrinkWrap: true,
+                  styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
+                  builders: {
+                    'blockquote': _AnnotationBlockquoteBuilder(
+                      onLineTapped: widget.onLineTapped,
+                      sourceLines: lines,
+                    ),
+                  },
+                  onTapLink: (text, href, title) {
+                    // Allow link taps to open URLs
+                  },
+                ),
+              ),
+            ),
+          ],
         ),
       ],
     );
+  }
+
+  void _showCommentSheet(String selectedText) {
+    // Find the line index of the selected text
+    final lines = widget.data.split('\n');
+    int lineIndex = 0;
+    for (int i = 0; i < lines.length; i++) {
+      if (lines[i].contains(selectedText) || selectedText.contains(lines[i])) {
+        lineIndex = i;
+        break;
+      }
+    }
+
+    widget.onLineTapped(lineIndex, lines[lineIndex]);
+    setState(() {
+      _selectedText = '';
+    });
   }
 
   MarkdownStyleSheet _buildAnnotationStyleSheet(

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -87,24 +87,31 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
       const TextStyle(height: 1.5),
     );
 
-    return GestureDetector(
-      onTapUp: (details) => _handleTap(details.localPosition),
-      behavior: HitTestBehavior.translucent,
-      child: Markdown(
-        key: _markdownKey,
-        data: widget.data,
-        shrinkWrap: true,
-        styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
-        builders: {
-          'blockquote': _AnnotationBlockquoteBuilder(
-            onLineTapped: widget.onLineTapped,
-            sourceLines: widget.data.split('\n'),
+    return Stack(
+      children: [
+        Markdown(
+          key: _markdownKey,
+          data: widget.data,
+          shrinkWrap: true,
+          styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
+          builders: {
+            'blockquote': _AnnotationBlockquoteBuilder(
+              onLineTapped: widget.onLineTapped,
+              sourceLines: widget.data.split('\n'),
+            ),
+          },
+          onTapLink: (text, href, title) {
+            // Allow link taps to open URLs
+          },
+        ),
+        Positioned.fill(
+          child: GestureDetector(
+            onTapUp: (details) => _handleTap(details.localPosition),
+            behavior: HitTestBehavior.translucent,
+            child: Container(color: Colors.transparent),
           ),
-        },
-        onTapLink: (text, href, title) {
-          // Allow link taps to open URLs
-        },
-      ),
+        ),
+      ],
     );
   }
 

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -87,24 +87,20 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
       const TextStyle(height: 1.5),
     );
 
-    return GestureDetector(
-      onTapUp: (details) => _handleTap(details.localPosition),
-      behavior: HitTestBehavior.opaque,
-      child: Markdown(
-        key: _markdownKey,
-        data: widget.data,
-        shrinkWrap: true,
-        styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
-        builders: {
-          'blockquote': _AnnotationBlockquoteBuilder(
-            onLineTapped: widget.onLineTapped,
-            sourceLines: widget.data.split('\n'),
-          ),
-        },
-        onTapLink: (text, href, title) {
-          // Allow link taps to open URLs
-        },
-      ),
+    return Markdown(
+      key: _markdownKey,
+      data: widget.data,
+      shrinkWrap: true,
+      styleSheet: widget.styleSheet ?? _buildAnnotationStyleSheet(context, defaultStyleSheet),
+      builders: {
+        'blockquote': _AnnotationBlockquoteBuilder(
+          onLineTapped: widget.onLineTapped,
+          sourceLines: widget.data.split('\n'),
+        ),
+      },
+      onTapLink: (text, href, title) {
+        // Allow link taps to open URLs
+      },
     );
   }
 

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -60,6 +60,7 @@ class _MarkdownWithAnnotationsState extends State<MarkdownWithAnnotations> {
 
     return Markdown(
       data: widget.data,
+      shrinkWrap: true,
       styleSheet: widget.styleSheet ??
           _buildAnnotationStyleSheet(context, defaultStyleSheet),
       builders: {


### PR DESCRIPTION
## Summary
- Add inline commenting to Markdown viewer (DocumentViewerScreen)
- Tap any line to add a location-tagged comment (## N: title format)
- Comments render as blockquote-style annotation markers with amber/yellow styling
- Immediate save and refresh on submit

## Implementation
- Created InlineCommentSheet widget (bottom-sheet with context header)
- Created MarkdownWithAnnotations widget (tap detection + annotation rendering)
- Modified DocumentViewerScreen to integrate both
- Added appendInlineSection to AgentApiClient

## Test Plan
- [x] flutter analyze passes
- [x] flutter build web --release succeeds
- [x] All AC verified

Closes AVO-066