### PR TITLE
AVO-073: Pass defaultProvider/defaultModel through RoutingTeam.toPaTeam()

### DIFF
--- a/phone/lib/models/deploy_routing.dart
+++ b/phone/lib/models/deploy_routing.dart
@@ -33,11 +33,15 @@ class RoutingTeam {
   final String name;
   final String description;
   final List<RoutingMode> modes;
+  final String? defaultProvider;
+  final String? defaultModel;
 
   const RoutingTeam({
     required this.name,
     required this.description,
     required this.modes,
+    this.defaultProvider,
+    this.defaultModel,
   });
 
   factory RoutingTeam.fromJson(Map<String, dynamic> json) {
@@ -48,6 +52,8 @@ class RoutingTeam {
               ?.map((e) => RoutingMode.fromJson(e as Map<String, dynamic>))
               .toList() ??
           const [],
+      defaultProvider: json['default_provider'] as String?,
+      defaultModel: json['default_model'] as String?,
     );
   }
 
@@ -58,6 +64,8 @@ class RoutingTeam {
         deployModes: modes
             .map((m) => DeployMode(id: m.id, label: m.label, modeType: m.modeType))
             .toList(),
+        defaultProvider: defaultProvider,
+        defaultModel: defaultModel,
       );
 }
 


### PR DESCRIPTION
## Summary
- Fix `RoutingTeam.toPaTeam()` in `deploy_routing.dart` to pass `defaultProvider` and `defaultModel` through to `PaTeam`
- Add `default_provider` and `default_model` JSON parsing to `RoutingTeam.fromJson()`
- This is the Flutter-side fix for AVO-073 (provider override not taking effect)

## Details
`PaTeam` already supports `defaultProvider`/`defaultModel` fields, and `DeploySheet._applyTeamDefaults()` reads them to pre-select the provider/model dropdowns. However, when teams come through the deploy-routing endpoint, `RoutingTeam.toPaTeam()` was creating `PaTeam` without these fields, so team defaults were always null.

**Note:** The PA server also needs to be updated to include `default_provider`/`default_model` in the `/api/deploy-routing` response for the full fix to take effect.

## Test plan
- [ ] Verify `flutter test` passes in phone/
- [ ] Verify provider dropdown pre-selects team default when server provides `default_provider`
- [ ] Verify manual provider selection still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)