### PR TITLE
AVO-071: Improve deployment form input — keyboard fix + draft persistence

### DIFF
--- a/phone/lib/services/deploy_draft_service.dart
+++ b/phone/lib/services/deploy_draft_service.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists and restores partial deploy form data across app sessions.
+///
+/// Used to restore user input when they revisit the deploy screen
+/// after navigating away or switching apps.
+class DeployDraftService {
+  DeployDraftService._();
+
+  static const String _key = 'deploy_draft';
+
+  static Timer? _saveTimer;
+
+  /// Saves [draft] asynchronously to SharedPreferences with 500ms debounce.
+  static Future<void> saveDraft(DeployDraft draft) async {
+    _saveTimer?.cancel();
+    final completer = Completer<void>();
+    _saveTimer = Timer(const Duration(milliseconds: 500), () async {
+      try {
+        final prefs = await SharedPreferences.getInstance();
+        final json = jsonEncode(draft.toJson());
+        await prefs.setString(_key, json);
+        completer.complete();
+      } catch (e) {
+        completer.completeError(e);
+      }
+    });
+    return completer.future;
+  }
+
+  /// Loads the saved draft, or null if none exists.
+  static Future<DeployDraft?> loadDraft() async {
+    final prefs = await SharedPreferences.getInstance();
+    final json = prefs.getString(_key);
+    if (json == null) return null;
+    try {
+      final map = jsonDecode(json) as Map<String, dynamic>;
+      return DeployDraft.fromJson(map);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Clears any saved draft.
+  static Future<void> clearDraft() async {
+    _saveTimer?.cancel();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}
+
+/// Partial deploy form state captured as a draft.
+///
+/// All fields are optional so the draft can be saved incrementally.
+class DeployDraft {
+  final String? team;
+  final String? mode;
+  final String? repo;
+  final String? provider;
+  final String? model;
+  final String? objective;
+
+  const DeployDraft({
+    this.team,
+    this.mode,
+    this.repo,
+    this.provider,
+    this.model,
+    this.objective,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'team': team,
+        'mode': mode,
+        'repo': repo,
+        'provider': provider,
+        'model': model,
+        'objective': objective,
+      };
+
+  factory DeployDraft.fromJson(Map<String, dynamic> json) => DeployDraft(
+        team: json['team'] as String?,
+        mode: json['mode'] as String?,
+        repo: json['repo'] as String?,
+        provider: json['provider'] as String?,
+        model: json['model'] as String?,
+        objective: json['objective'] as String?,
+      );
+}

--- a/phone/lib/widgets/deploy_sheet.dart
+++ b/phone/lib/widgets/deploy_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/pa_team.dart';
+import '../services/deploy_draft_service.dart';
 
 /// A reusable deploy bottom sheet.
 ///
@@ -96,6 +97,45 @@ class _DeploySheetState extends State<DeploySheet> {
 
     // Pre-select provider and model from team's configured defaults.
     _applyTeamDefaults();
+
+    // Restore draft after setting initial values; draft values override call-site
+    // defaults so the user can resume after switching away.
+    _loadDraft();
+  }
+
+  Future<void> _loadDraft() async {
+    final draft = await DeployDraftService.loadDraft();
+    if (draft == null || !mounted) return;
+    setState(() {
+      if (draft.team != null &&
+          widget.paTeams.any((t) => t.name == draft.team)) {
+        _selectedTeam = draft.team;
+        _autoSelectMode();
+        _applyTeamDefaults();
+      }
+      if (draft.mode != null) _selectedMode = draft.mode;
+      if (draft.repo != null &&
+          widget.paRepos.any((r) => r.name == draft.repo)) {
+        _selectedRepo = draft.repo;
+      }
+      if (draft.provider != null) _selectedProvider = draft.provider;
+      if (draft.model != null) _selectedModel = draft.model;
+      if (draft.objective != null && draft.objective!.isNotEmpty) {
+        _objectiveController.text = draft.objective!;
+        _objectiveTouched = true;
+      }
+    });
+  }
+
+  void _saveDraft() {
+    DeployDraftService.saveDraft(DeployDraft(
+      team: _selectedTeam,
+      mode: _selectedMode,
+      repo: _selectedRepo,
+      provider: _selectedProvider,
+      model: _selectedModel,
+      objective: _objectiveController.text.isEmpty ? null : _objectiveController.text,
+    ));
   }
 
   void _applyTeamDefaults() {
@@ -125,6 +165,7 @@ class _DeploySheetState extends State<DeploySheet> {
       _objectiveTouched = true;
     }
     setState(() {});
+    _saveDraft();
   }
 
   /// Sanitize objective text: replace & with 'and', strip blocked chars.
@@ -216,6 +257,7 @@ class _DeploySheetState extends State<DeploySheet> {
                       _autoSelectMode();
                       _applyTeamDefaults();
                     });
+                    _saveDraft();
                   },
                 ),
                 const SizedBox(height: 16),
@@ -234,7 +276,10 @@ class _DeploySheetState extends State<DeploySheet> {
                     paRepos: widget.paRepos,
                     selectedRepo: _selectedRepo,
                     enabled: !_deploying,
-                    onChanged: (repo) => setState(() => _selectedRepo = repo),
+                    onChanged: (repo) {
+                      setState(() => _selectedRepo = repo);
+                      _saveDraft();
+                    },
                   ),
                   const SizedBox(height: 16),
                 ],
@@ -246,8 +291,10 @@ class _DeploySheetState extends State<DeploySheet> {
                   _ProviderSelector(
                     selectedProvider: _selectedProvider,
                     enabled: !_deploying,
-                    onChanged: (p) =>
-                        setState(() => _selectedProvider = p),
+                    onChanged: (p) {
+                        setState(() => _selectedProvider = p);
+                        _saveDraft();
+                      },
                   ),
                   const SizedBox(height: 16),
                 ],
@@ -259,7 +306,10 @@ class _DeploySheetState extends State<DeploySheet> {
                   _ModelSelector(
                     selectedModel: _selectedModel,
                     enabled: !_deploying,
-                    onChanged: (m) => setState(() => _selectedModel = m),
+                    onChanged: (m) {
+                        setState(() => _selectedModel = m);
+                        _saveDraft();
+                      },
                   ),
                   const SizedBox(height: 16),
                 ],
@@ -345,9 +395,12 @@ class _DeploySheetState extends State<DeploySheet> {
                   : null,
               onSelected: _deploying
                   ? null
-                  : (_) => setState(() {
-                        _selectedMode = selected ? null : mode.id;
-                      }),
+                  : (bool selected) {
+                        setState(() {
+                          _selectedMode = selected ? null : mode.id;
+                        });
+                        _saveDraft();
+                      },
             );
           }).toList(),
         ),
@@ -368,6 +421,7 @@ class _DeploySheetState extends State<DeploySheet> {
         provider: _selectedProvider,
         teamModel: _selectedModel,
       );
+      await DeployDraftService.clearDraft();
     } finally {
       if (mounted) setState(() => _deploying = false);
     }

--- a/phone/lib/widgets/deploy_sheet.dart
+++ b/phone/lib/widgets/deploy_sheet.dart
@@ -173,7 +173,7 @@ class _DeploySheetState extends State<DeploySheet> {
         bottom: MediaQuery.of(context).viewInsets.bottom,
       ),
       child: SafeArea(
-        child: Padding(
+        child: SingleChildScrollView(
           padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
           child: Column(
             mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary

- **Keyboard fix**: Wrapped `DeploySheet` form `Column` in `SingleChildScrollView` so all fields (objective TextField, Launch button) remain scrollable when the soft keyboard is open. Follows the same pattern as `StopTimerSheet`.
- **Draft persistence**: Created `DeployDraftService` (mirroring `TicketDraftService`) with debounced auto-save to SharedPreferences. Draft restores on sheet open and clears on successful launch.

## Files Changed

- `phone/lib/widgets/deploy_sheet.dart` — SingleChildScrollView wrap + draft restore/save/clear wiring
- `phone/lib/services/deploy_draft_service.dart` — New service: load/save/clear with 500ms debounce

## Acceptance Criteria

- [ ] AC1: Open DeploySheet on phone, tap objective TextField, verify Launch button reachable by scrolling
- [ ] AC2: Fill team + objective, close sheet, reopen — same values restored
- [ ] AC3: Launch deploy, reopen sheet — fresh defaults (draft cleared)
- [ ] AC4: No new dependencies — `flutter build web --release` passes

## Test Plan

- [ ] Manual test on phone: keyboard avoidance with scrolling
- [ ] Manual test: draft save/restore cycle
- [ ] Manual test: draft clear on successful launch
- [ ] Verify `flutter analyze` clean
- [ ] Verify `flutter build web --release` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)