### PR TITLE
AVO-077: Git visualization improvements for phone app

### DIFF
--- a/phone/lib/models/repo_diff.dart
+++ b/phone/lib/models/repo_diff.dart
@@ -46,12 +46,18 @@ class DiffEntry {
   });
 
   factory DiffEntry.fromJson(Map<String, dynamic> json) {
+    final oldPath = json['old_path'] as String? ?? '';
     return DiffEntry(
-      oldPath: json['old_path'] as String? ?? '',
+      oldPath: oldPath,
       newPath: json['new_path'] as String? ?? '',
       changeType: json['change_type'] as String? ?? '',
       hunks: (json['hunks'] as List?)
-              ?.map((e) => DiffHunk.fromJson(e as Map<String, dynamic>))
+              ?.map((e) {
+                final hunkJson = e as Map<String, dynamic>;
+                // Inject old_path from entry level into hunk JSON for language inference
+                hunkJson['old_path'] = oldPath;
+                return DiffHunk.fromJson(hunkJson);
+              })
               .toList() ??
           const [],
       binary: json['binary'] as bool? ?? false,
@@ -66,6 +72,8 @@ class DiffHunk {
   final int newStart;
   final int newLines;
   final List<DiffLine> lines;
+  /// Path of the file this hunk belongs to (used for language inference).
+  final String oldPath;
 
   const DiffHunk({
     required this.oldStart,
@@ -73,6 +81,7 @@ class DiffHunk {
     required this.newStart,
     required this.newLines,
     required this.lines,
+    this.oldPath = '',
   });
 
   factory DiffHunk.fromJson(Map<String, dynamic> json) {
@@ -85,6 +94,7 @@ class DiffHunk {
               ?.map((e) => DiffLine.fromJson(e as Map<String, dynamic>))
               .toList() ??
           const [],
+      oldPath: json['old_path'] as String? ?? '',
     );
   }
 }

--- a/phone/lib/screens/branch_detail_screen.dart
+++ b/phone/lib/screens/branch_detail_screen.dart
@@ -6,6 +6,7 @@ import '../models/repo_git_info.dart';
 import '../services/agent_api_client.dart';
 import '../utils/date_helpers.dart';
 import '../widgets/diff_widgets.dart';
+import '../widgets/expandable_commit_tile.dart';
 
 /// Screen showing details of a single feature branch with embedded commit history.
 ///
@@ -406,177 +407,16 @@ class _BranchDetailScreenState extends State<BranchDetailScreen> {
               child: Center(child: CircularProgressIndicator()),
             );
           }
-          return _ExpandableCommitTile(
+          return ExpandableCommitTile(
             commit: _commits[index],
             repoKey: widget.repoKey,
-            apiClient: widget.apiClient,
             diffCache: _diffCache,
             failedDiffs: _failedDiffs,
             onExpand: () => _loadDiff(_commits[index].hash),
             onRetry: () => _retryDiff(_commits[index].hash),
+            shrinkWrapDiff: true,
           );
         },
-      ),
-    );
-  }
-}
-
-class _ExpandableCommitTile extends StatefulWidget {
-  final RepoCommit commit;
-  final String repoKey;
-  final AgentApiClient apiClient;
-  final Map<String, RepoDiff?> diffCache;
-  final Set<String> failedDiffs;
-  final VoidCallback onExpand;
-  final VoidCallback onRetry;
-
-  const _ExpandableCommitTile({
-    required this.commit,
-    required this.repoKey,
-    required this.apiClient,
-    required this.diffCache,
-    required this.failedDiffs,
-    required this.onExpand,
-    required this.onRetry,
-  });
-
-  @override
-  State<_ExpandableCommitTile> createState() => _ExpandableCommitTileState();
-}
-
-class _ExpandableCommitTileState extends State<_ExpandableCommitTile> {
-  bool _isExpanded = false;
-
-  void _handleTap() {
-    final wasExpanded = _isExpanded;
-    setState(() {
-      _isExpanded = !_isExpanded;
-    });
-    if (!wasExpanded) {
-      widget.onExpand();
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final diff = widget.commit.diffSummary;
-    final cachedDiff = widget.diffCache[widget.commit.hash];
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Card(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Collapsed header (always visible, tappable)
-            InkWell(
-              onTap: _handleTap,
-              borderRadius: BorderRadius.circular(12),
-              child: Padding(
-                padding: const EdgeInsets.all(12),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Top row: hash_short + date
-                    Row(
-                      children: [
-                        Text(
-                          widget.commit.hashShort,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontFamily: 'monospace',
-                            color: theme.colorScheme.primary,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                        const Spacer(),
-                        Text(
-                          formatDateShort(widget.commit.date),
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.outline,
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        AnimatedRotation(
-                          turns: _isExpanded ? 0.25 : 0,
-                          duration: const Duration(milliseconds: 200),
-                          child: Icon(
-                            Icons.chevron_right,
-                            size: 18,
-                            color: theme.colorScheme.outline,
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-
-                    // Middle: commit message (first line)
-                    Text(
-                      widget.commit.message,
-                      style: theme.textTheme.bodyMedium,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    const SizedBox(height: 6),
-
-                    // Bottom row: author name + diff summary
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            widget.commit.authorName,
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.outline,
-                            ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                        Text(
-                          '+${diff.insertions} -${diff.deletions} in ${diff.filesChanged} file${diff.filesChanged == 1 ? '' : 's'}',
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.outline,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            ),
-
-            // Expanded: diff view (lazy-loaded)
-            if (_isExpanded)
-              widget.failedDiffs.contains(widget.commit.hash)
-                  ? Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Center(
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(Icons.error_outline,
-                                color: theme.colorScheme.error, size: 32),
-                            const SizedBox(height: 8),
-                            Text('Failed to load diff',
-                                style: TextStyle(color: theme.colorScheme.error)),
-                            const SizedBox(height: 8),
-                            TextButton.icon(
-                              onPressed: widget.onRetry,
-                              icon: const Icon(Icons.refresh, size: 16),
-                              label: const Text('Retry'),
-                            ),
-                          ],
-                        ),
-                      ),
-                    )
-                  : cachedDiff == null
-                      ? const Padding(
-                          padding: EdgeInsets.all(16),
-                          child: Center(child: CircularProgressIndicator()),
-                        )
-                      : DiffView(diff: cachedDiff, shrinkWrap: true, physics: const NeverScrollableScrollPhysics()),
-          ],
-        ),
       ),
     );
   }

--- a/phone/lib/screens/commit_history_screen.dart
+++ b/phone/lib/screens/commit_history_screen.dart
@@ -5,6 +5,7 @@ import '../models/repo_diff.dart';
 import '../services/agent_api_client.dart';
 import '../utils/date_helpers.dart';
 import '../widgets/diff_widgets.dart';
+import '../widgets/expandable_commit_tile.dart';
 
 /// Screen showing paginated commit history for a specific branch.
 ///
@@ -244,177 +245,15 @@ class _CommitHistoryScreenState extends State<CommitHistoryScreen> {
               child: Center(child: CircularProgressIndicator()),
             );
           }
-          return _ExpandableCommitTile(
+          return ExpandableCommitTile(
             commit: _filteredCommits[index],
             repoKey: widget.repoKey,
-            apiClient: widget.apiClient,
             diffCache: _diffCache,
             failedDiffs: _failedDiffs,
             onExpand: () => _loadDiff(_filteredCommits[index].hash),
             onRetry: () => _retryDiff(_filteredCommits[index].hash),
           );
         },
-      ),
-    );
-  }
-}
-
-class _ExpandableCommitTile extends StatefulWidget {
-  final RepoCommit commit;
-  final String repoKey;
-  final AgentApiClient apiClient;
-  final Map<String, RepoDiff?> diffCache;
-  final Set<String> failedDiffs;
-  final VoidCallback onExpand;
-  final VoidCallback onRetry;
-
-  const _ExpandableCommitTile({
-    required this.commit,
-    required this.repoKey,
-    required this.apiClient,
-    required this.diffCache,
-    required this.failedDiffs,
-    required this.onExpand,
-    required this.onRetry,
-  });
-
-  @override
-  State<_ExpandableCommitTile> createState() => _ExpandableCommitTileState();
-}
-
-class _ExpandableCommitTileState extends State<_ExpandableCommitTile> {
-  bool _isExpanded = false;
-
-  void _handleTap() {
-    final wasExpanded = _isExpanded;
-    setState(() {
-      _isExpanded = !_isExpanded;
-    });
-    if (!wasExpanded) {
-      widget.onExpand();
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final diff = widget.commit.diffSummary;
-    final cachedDiff = widget.diffCache[widget.commit.hash];
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Card(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Collapsed header (always visible, tappable)
-            InkWell(
-              onTap: _handleTap,
-              borderRadius: BorderRadius.circular(12),
-              child: Padding(
-                padding: const EdgeInsets.all(12),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Top row: hash_short + date
-                    Row(
-                      children: [
-                        Text(
-                          widget.commit.hashShort,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            fontFamily: 'monospace',
-                            color: theme.colorScheme.primary,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                        const Spacer(),
-                        Text(
-                          formatDateShort(widget.commit.date),
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.outline,
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        AnimatedRotation(
-                          turns: _isExpanded ? 0.25 : 0,
-                          duration: const Duration(milliseconds: 200),
-                          child: Icon(
-                            Icons.chevron_right,
-                            size: 18,
-                            color: theme.colorScheme.outline,
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-
-                    // Middle: commit message (first line)
-                    Text(
-                      widget.commit.message,
-                      style: theme.textTheme.bodyMedium,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    const SizedBox(height: 6),
-
-                    // Bottom row: author name + diff summary
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            widget.commit.authorName,
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.outline,
-                            ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                        Text(
-                          '+${diff.insertions} -${diff.deletions} in ${diff.filesChanged} file${diff.filesChanged == 1 ? '' : 's'}',
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.outline,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            ),
-
-            // Expanded: diff view (lazy-loaded)
-            if (_isExpanded)
-              widget.failedDiffs.contains(widget.commit.hash)
-                  ? Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Center(
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(Icons.error_outline,
-                                color: theme.colorScheme.error, size: 32),
-                            const SizedBox(height: 8),
-                            Text('Failed to load diff',
-                                style: TextStyle(color: theme.colorScheme.error)),
-                            const SizedBox(height: 8),
-                            TextButton.icon(
-                              onPressed: widget.onRetry,
-                              icon: const Icon(Icons.refresh, size: 16),
-                              label: const Text('Retry'),
-                            ),
-                          ],
-                        ),
-                      ),
-                    )
-                  : cachedDiff == null
-                      ? const Padding(
-                          padding: EdgeInsets.all(16),
-                          child: Center(child: CircularProgressIndicator()),
-                        )
-                      : DiffView(diff: cachedDiff),
-          ],
-        ),
       ),
     );
   }

--- a/phone/lib/utils/syntax_highlight.dart
+++ b/phone/lib/utils/syntax_highlight.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:highlight/highlight.dart' as hl;
+
+/// Maps common file extensions to highlight.js language names.
+String? inferLanguage(String? filePath) {
+  if (filePath == null || filePath.isEmpty) return null;
+
+  final lastDot = filePath.lastIndexOf('.');
+  if (lastDot < 0 || lastDot == filePath.length - 1) return null;
+  final ext = filePath.substring(lastDot);
+
+  const Map<String, String> extToLang = {
+    '.dart': 'dart',
+    '.js': 'javascript',
+    '.jsx': 'javascript',
+    '.ts': 'typescript',
+    '.tsx': 'typescript',
+    '.py': 'python',
+    '.rb': 'ruby',
+    '.go': 'go',
+    '.rs': 'rust',
+    '.java': 'java',
+    '.kt': 'kotlin',
+    '.swift': 'swift',
+    '.c': 'c',
+    '.cpp': 'cpp',
+    '.cc': 'cpp',
+    '.cxx': 'cpp',
+    '.h': 'c',
+    '.hpp': 'cpp',
+    '.cs': 'csharp',
+    '.php': 'php',
+    '.html': 'xml',
+    '.htm': 'xml',
+    '.xml': 'xml',
+    '.svg': 'xml',
+    '.css': 'css',
+    '.scss': 'scss',
+    '.sass': 'scss',
+    '.less': 'less',
+    '.json': 'json',
+    '.yaml': 'yaml',
+    '.yml': 'yaml',
+    '.md': 'markdown',
+    '.sql': 'sql',
+    '.sh': 'bash',
+    '.bash': 'bash',
+    '.zsh': 'bash',
+    '.fish': 'bash',
+    '.ps1': 'powershell',
+    '.psm1': 'powershell',
+    '.dockerfile': 'dockerfile',
+    '.tf': 'hcl',
+    '.hcl': 'hcl',
+    '.toml': 'ini',
+    '.ini': 'ini',
+    '.cfg': 'ini',
+    '.conf': 'ini',
+    '.env': 'bash',
+    '.gitignore': 'gitignore',
+    '.vim': 'vim',
+    '.lua': 'lua',
+    '.r': 'r',
+    '.R': 'r',
+    '.scala': 'scala',
+    '.sbt': 'scala',
+    '.gradle': 'gradle',
+    '.ex': 'elixir',
+    '.exs': 'elixir',
+    '.erl': 'erlang',
+    '.hrl': 'erlang',
+    '.hs': 'haskell',
+    '.ml': 'ocaml',
+    '.fs': 'fsharp',
+    '.fsx': 'fsharp',
+    '.clj': 'clojure',
+    '.cljs': 'clojure',
+    '.cljc': 'clojure',
+    '.elm': 'elm',
+    '.vue': 'xml',
+    '.svelte': 'xml',
+    '.proto': 'protobuf',
+    '.rspec': 'ruby',
+    '.jbuilder': 'ruby',
+    '.rake': 'ruby',
+    '.gemspec': 'ruby',
+    '.feature': 'gherkin',
+    '.gradle.kts': 'kotlin',
+    '.kts': 'kotlin',
+  };
+
+  return extToLang[ext.toLowerCase()];
+}
+
+/// Muted color scheme for syntax highlighting in diff context.
+/// Colors are desaturated to avoid clashing with green/red word-diff highlighting.
+Map<String, Color> _syntaxColors = {
+  'keyword': const Color(0xFF9E9E9E),
+  'built_in': const Color(0xFF8D8D8D),
+  'type': const Color(0xFF7A8B9A),
+  'literal': const Color(0xFF8D8D8D),
+  'number': const Color(0xFF9E9E9E),
+  'string': const Color(0xFF8A8A8A),
+  'comment': const Color(0xFF6B7B6B),
+  'doctag': const Color(0xFF6B7B6B),
+  'meta': const Color(0xFF7A7A7A),
+  'function': const Color(0xFF8A7A6A),
+  'class': const Color(0xFF7A8B9A),
+  'title': const Color(0xFF8A7A6A),
+  'attr': const Color(0xFF8A7A6A),
+  'variable': const Color(0xFF8A7A6A),
+  'selector-tag': const Color(0xFF9E9E9E),
+  'selector-id': const Color(0xFF9E9E9E),
+  'selector-class': const Color(0xFF9E9E9E),
+  'template-variable': const Color(0xFF8A7A6A),
+  'tag': const Color(0xFF9E9E9E),
+  'name': const Color(0xFF9E9E9E),
+  'bullet': const Color(0xFF9E9E9E),
+  'section': const Color(0xFF9E9E9E),
+  'subst': const Color(0xFF9E9E9E),
+  'emphasis': const Color(0xFF9E9E9E),
+  'strong': const Color(0xFF9E9E9E),
+  'default': const Color(0xFFE0E0E0),
+};
+
+Color _colorForClass(String? className) {
+  if (className == null || className.isEmpty) return _syntaxColors['default']!;
+
+  final firstClass = className.split(' ').first;
+  if (_syntaxColors.containsKey(firstClass)) {
+    return _syntaxColors[firstClass]!;
+  }
+  for (final key in _syntaxColors.keys) {
+    if (firstClass.startsWith(key)) {
+      return _syntaxColors[key]!;
+    }
+  }
+  return _syntaxColors['default']!;
+}
+
+/// Parses code with syntax highlighting and returns a list of TextSpans.
+List<TextSpan> parseSyntaxHighlighted(String code, String? language) {
+  if (language == null || language.isEmpty || code.isEmpty) {
+    return [TextSpan(text: code, style: const TextStyle(color: Color(0xFFE0E0E0)))];
+  }
+
+  try {
+    final result = hl.highlight.parse(code, language: language);
+    final spans = _convertNodes(result.nodes ?? []);
+    if (spans.isEmpty) {
+      return [TextSpan(text: code, style: const TextStyle(color: Color(0xFFE0E0E0)))];
+    }
+    return spans;
+  } catch (_) {
+    return [TextSpan(text: code, style: const TextStyle(color: Color(0xFFE0E0E0)))];
+  }
+}
+
+List<TextSpan> _convertNodes(List<hl.Node> nodes) {
+  final spans = <TextSpan>[];
+  for (final node in nodes) {
+    if (node.value != null) {
+      spans.add(TextSpan(
+        text: node.value,
+        style: TextStyle(color: _colorForClass(node.className)),
+      ));
+    } else if (node.children != null) {
+      final childSpans = _convertNodes(node.children!);
+      if (childSpans.isNotEmpty) {
+        spans.addAll(childSpans);
+      }
+    }
+  }
+  return spans;
+}

--- a/phone/lib/utils/word_diff.dart
+++ b/phone/lib/utils/word_diff.dart
@@ -1,0 +1,276 @@
+/// Result of a word-level diff computation on a pair of lines.
+///
+/// Each entry represents a segment of the diff with its text content
+/// and the type of change (unchanged, added, or deleted).
+class WordDiffResult {
+  /// The segments making up the diff, in order.
+  final List<WordDiffSegment> segments;
+
+  /// Whether this diff was skipped due to size threshold.
+  final bool skipped;
+
+  const WordDiffResult({required this.segments, this.skipped = false});
+
+  /// An empty result for when no diff is needed (empty lines).
+  const WordDiffResult.empty()
+      : segments = const [],
+        skipped = false;
+
+  /// A result indicating the diff was skipped due to size.
+  const WordDiffResult.skipped()
+      : segments = const [],
+        skipped = true;
+}
+
+/// A single segment within a word diff result.
+class WordDiffSegment {
+  /// The text content of this segment.
+  final String text;
+
+  /// The type of this segment: 'unchanged', 'added', or 'deleted'.
+  final String type;
+
+  const WordDiffSegment({required this.text, required this.type});
+
+  bool get isAdded => type == 'added';
+  bool get isDeleted => type == 'deleted';
+  bool get isUnchanged => type == 'unchanged';
+}
+
+/// Options for word diff computation.
+class WordDiffOptions {
+  /// Maximum total lines in a diff hunk before skipping word-level diff.
+  /// Large diffs can be slow and are better handled with full-line highlighting.
+  final int maxLinesForWordDiff;
+
+  const WordDiffOptions({this.maxLinesForWordDiff = 500});
+}
+
+/// Computes word-level diff between two strings.
+///
+/// Returns a [WordDiffResult] containing the segments with their change types.
+/// Returns [WordDiffResult.skipped] if the hunk exceeds [maxLinesForWordDiff] total lines.
+WordDiffResult computeWordDiff(String oldLine, String newLine, {WordDiffOptions options = const WordDiffOptions()}) {
+  // Fast path: empty lines need no word diff
+  if (oldLine.isEmpty && newLine.isEmpty) {
+    return const WordDiffResult.empty();
+  }
+
+  // Fast path: if either is empty, all content is add or delete
+  if (oldLine.isEmpty) {
+    return WordDiffResult(segments: [WordDiffSegment(text: newLine, type: 'added')]);
+  }
+  if (newLine.isEmpty) {
+    return WordDiffResult(segments: [WordDiffSegment(text: oldLine, type: 'deleted')]);
+  }
+
+  // Compute LCS-based word diff
+  final oldWords = _splitIntoWords(oldLine);
+  final newWords = _splitIntoWords(newLine);
+
+  final segments = _computeLcsDiff(oldWords, newWords);
+
+  // Merge adjacent segments of the same type to reduce widget count
+  final merged = _mergeAdjacentSegments(segments);
+
+  return WordDiffResult(segments: merged);
+}
+
+/// Splits a line into words (tokens separated by whitespace).
+///
+/// Preserves whitespace as separate tokens so we can reconstruct
+/// the original spacing when rendering.
+List<String> _splitIntoWords(String line) {
+  if (line.isEmpty) return [];
+
+  final result = <String>[];
+  final buffer = StringBuffer();
+  bool inWhitespace = false;
+
+  for (int i = 0; i < line.length; i++) {
+    final char = line[i];
+    final isWs = char == ' ' || char == '\t';
+
+    if (isWs) {
+      if (!inWhitespace && buffer.isNotEmpty) {
+        // End of a word - save it
+        result.add(buffer.toString());
+        buffer.clear();
+      }
+      // Collect whitespace into a single token
+      if (!inWhitespace) {
+        inWhitespace = true;
+        buffer.write(char);
+      } else {
+        buffer.write(char);
+      }
+    } else {
+      if (inWhitespace && buffer.isNotEmpty) {
+        // End of whitespace - save it
+        result.add(buffer.toString());
+        buffer.clear();
+        inWhitespace = false;
+      }
+      buffer.write(char);
+    }
+  }
+
+  // Don't forget the last buffer
+  if (buffer.isNotEmpty) {
+    result.add(buffer.toString());
+  }
+
+  return result;
+}
+
+/// Computes LCS-based diff between two word lists.
+List<WordDiffSegment> _computeLcsDiff(List<String> oldWords, List<String> newWords) {
+  final result = <WordDiffSegment>[];
+
+  // Build LCS table using Myers' algorithm-inspired approach
+  // For word-level diff, we want to find which words are unchanged, added, deleted
+
+  final m = oldWords.length;
+  final n = newWords.length;
+
+  // Build the LCS cost matrix
+  // dp[i][j] = length of LCS of oldWords[0..i-1] and newWords[0..j-1]
+  final dp = List.generate(m + 1, (_) => List.filled(n + 1, 0));
+
+  for (int i = 1; i <= m; i++) {
+    for (int j = 1; j <= n; j++) {
+      if (oldWords[i - 1] == newWords[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = dp[i - 1][j] > dp[i][j - 1] ? dp[i - 1][j] : dp[i][j - 1];
+      }
+    }
+  }
+
+  // Backtrack to find the diff
+  int i = m;
+  int j = n;
+  final diffPairs = <({String text, String type})>[];
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldWords[i - 1] == newWords[j - 1]) {
+      // Unchanged word
+      diffPairs.add((text: oldWords[i - 1], type: 'unchanged'));
+      i--;
+      j--;
+    } else if (j > 0 && (i == 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      // Added word (in new but not in old)
+      diffPairs.add((text: newWords[j - 1], type: 'added'));
+      j--;
+    } else if (i > 0) {
+      // Deleted word (in old but not in new)
+      diffPairs.add((text: oldWords[i - 1], type: 'deleted'));
+      i--;
+    }
+  }
+
+  // Reverse since we backtracked from the end
+  for (int k = diffPairs.length - 1; k >= 0; k--) {
+    result.add(WordDiffSegment(text: diffPairs[k].text, type: diffPairs[k].type));
+  }
+
+  return result;
+}
+
+/// Merges adjacent segments of the same type to reduce widget count.
+List<WordDiffSegment> _mergeAdjacentSegments(List<WordDiffSegment> segments) {
+  if (segments.isEmpty) return [];
+
+  final result = <WordDiffSegment>[];
+  var current = segments.first;
+
+  for (int i = 1; i < segments.length; i++) {
+    final seg = segments[i];
+    if (seg.type == current.type) {
+      // Merge with current
+      current = WordDiffSegment(text: current.text + seg.text, type: current.type);
+    } else {
+      result.add(current);
+      current = seg;
+    }
+  }
+  result.add(current);
+
+  return result;
+}
+
+/// Checks if a diff hunk should be skipped due to size.
+///
+/// When a hunk has too many lines, word-level diff is skipped
+/// to maintain UI responsiveness.
+bool shouldSkipWordDiff(List<({String type, String content})> lines, {int maxLines = 500}) {
+  return lines.length > maxLines;
+}
+
+/// Computes word diff for a list of del/add line pairs within a hunk.
+///
+/// Returns a map where keys are line indices and values are [WordDiffResult].
+/// Lines that don't pair evenly are returned as full-line add/del without word-level diff.
+///
+/// The [delLines] and [addLines] must be parallel lists (same length).
+Map<int, WordDiffResult> computeHunkWordDiffs(
+  List<({String type, String content})> lines, {
+  WordDiffOptions options = const WordDiffOptions(),
+}) {
+  final results = <int, WordDiffResult>{};
+
+  // Skip if too many lines
+  if (shouldSkipWordDiff(lines, maxLines: options.maxLinesForWordDiff)) {
+    // Mark all add lines as skipped
+    for (int i = 0; i < lines.length; i++) {
+      if (lines[i].type == 'add') {
+        results[i] = const WordDiffResult.skipped();
+      }
+    }
+    return results;
+  }
+
+  // Find consecutive del→add pairs
+  int i = 0;
+  while (i < lines.length) {
+    if (lines[i].type == 'del') {
+      // Count consecutive del lines
+      int delCount = 0;
+      while (i + delCount < lines.length && lines[i + delCount].type == 'del') {
+        delCount++;
+      }
+
+      // Check if followed by same count of add lines
+      if (i + delCount < lines.length && lines[i + delCount].type == 'add') {
+        int addCount = 0;
+        while (i + delCount + addCount < lines.length &&
+               lines[i + delCount + addCount].type == 'add') {
+          addCount++;
+        }
+
+        if (delCount == addCount) {
+          // Paired sequence - compute word diff for each pair
+          for (int pair = 0; pair < delCount; pair++) {
+            final delIdx = i + pair;
+            final addIdx = i + delCount + pair;
+            results[addIdx] = computeWordDiff(
+              lines[delIdx].content,
+              lines[addIdx].content,
+              options: options,
+            );
+          }
+          i += delCount + addCount;
+          continue;
+        }
+      }
+    }
+
+    // Not part of a paired sequence - mark add lines as skipped (no word diff)
+    if (lines[i].type == 'add') {
+      results[i] = const WordDiffResult.skipped();
+    }
+    i++;
+  }
+
+  return results;
+}

--- a/phone/lib/widgets/diff_stat_bar.dart
+++ b/phone/lib/widgets/diff_stat_bar.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+
+import '../models/repo_diff.dart';
+
+/// A reusable diff stat bar widget that shows per-file change statistics.
+///
+/// Displays a GitHub-style colored bar (green for insertions, red for deletions)
+/// with `+N -M` count, proportional to the total changes relative to [maxChanges].
+class DiffStatBar extends StatelessWidget {
+  /// Number of inserted lines for this file.
+  final int insertions;
+
+  /// Number of deleted lines for this file.
+  final int deletions;
+
+  /// The maximum number of changes (insertions + deletions) across all files
+  /// in the diff. Used to calculate proportional bar width.
+  /// If null, uses this file's total as the denominator (showing 100% bar).
+  final int? maxChanges;
+
+  const DiffStatBar({
+    super.key,
+    required this.insertions,
+    required this.deletions,
+    this.maxChanges,
+  });
+
+  /// Total changes for this file.
+  int get _total => insertions + deletions;
+
+  /// The denominator for calculating proportional width.
+  int get _denominator => maxChanges ?? _total;
+
+  @override
+  Widget build(BuildContext context) {
+    // Skip rendering bar for binary files or zero changes
+    if (_total == 0) {
+      return const SizedBox.shrink();
+    }
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // +N -M count
+        Text(
+          '+$insertions -$deletions',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                fontFamily: 'monospace',
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+        const SizedBox(width: 8),
+        // Colored stat bar
+        _StatBar(
+          insertions: insertions,
+          deletions: deletions,
+          total: _total,
+          denominator: _denominator,
+        ),
+      ],
+    );
+  }
+}
+
+class _StatBar extends StatelessWidget {
+  final int insertions;
+  final int deletions;
+  final int total;
+  final int denominator;
+
+  const _StatBar({
+    required this.insertions,
+    required this.deletions,
+    required this.total,
+    required this.denominator,
+  });
+
+  static const double _maxBarWidth = 80.0;
+  static const double _minSegmentWidth = 1.0;
+  static const double _barHeight = 8.0;
+
+  @override
+  Widget build(BuildContext context) {
+    if (denominator == 0) return const SizedBox.shrink();
+
+    final ratio = total / denominator;
+    final barWidth = (_maxBarWidth * ratio).clamp(_minSegmentWidth, _maxBarWidth);
+
+    return Container(
+      width: barWidth,
+      height: _barHeight,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(2),
+        color: Colors.grey[300],
+      ),
+      child: Row(
+        children: [
+          // Green portion for insertions
+          if (insertions > 0)
+            Flexible(
+              flex: insertions,
+              child: Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.horizontal(
+                    left: const Radius.circular(2),
+                    right: deletions == 0 ? const Radius.circular(2) : Radius.zero,
+                  ),
+                  color: Colors.green,
+                ),
+              ),
+            ),
+          // Red portion for deletions
+          if (deletions > 0)
+            Flexible(
+              flex: deletions,
+              child: Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.horizontal(
+                    left: insertions == 0 ? Radius.zero : Radius.zero,
+                    right: const Radius.circular(2),
+                  ),
+                  color: Colors.red,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Calculates per-file insertion/deletion counts from hunk data.
+({int insertions, int deletions}) calcFileStats(DiffEntry entry) {
+  int insertions = 0;
+  int deletions = 0;
+  for (final hunk in entry.hunks) {
+    for (final line in hunk.lines) {
+      if (line.type == 'add') {
+        insertions++;
+      } else if (line.type == 'del') {
+        deletions++;
+      }
+    }
+  }
+  return (insertions: insertions, deletions: deletions);
+}
+
+/// Finds the maximum total changes across all diff entries.
+int maxChangesInDiff(List<DiffEntry> entries) {
+  int maxTotal = 0;
+  for (final entry in entries) {
+    final stats = calcFileStats(entry);
+    final total = stats.insertions + stats.deletions;
+    if (total > maxTotal) maxTotal = total;
+  }
+  return maxTotal;
+}

--- a/phone/lib/widgets/diff_widgets.dart
+++ b/phone/lib/widgets/diff_widgets.dart
@@ -454,8 +454,8 @@ class DiffLineView extends StatelessWidget {
                 segment.text,
                 style: theme.textTheme.bodySmall?.copyWith(
                   fontFamily: 'monospace',
-                  // Muted color for changed segments to not compete with bg
-                  color: isHighlighted ? const Color(0xFFBBBBBB) : null,
+                  // White text for highlighted segments (sufficient contrast on green/red bg)
+                  color: isHighlighted ? const Color(0xFFFFFFFF) : null,
                 ),
               ),
             );

--- a/phone/lib/widgets/diff_widgets.dart
+++ b/phone/lib/widgets/diff_widgets.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/repo_diff.dart';
+import '../utils/syntax_highlight.dart';
 import '../utils/word_diff.dart';
 import 'diff_stat_bar.dart';
 
@@ -179,7 +180,10 @@ class DiffEntryTile extends StatelessWidget {
           if (entry.binary)
             const BinaryFileIndicator()
           else
-            ...entry.hunks.map((hunk) => DiffHunkView(hunk: hunk)),
+            ...entry.hunks.map((hunk) => DiffHunkView(
+              hunk: hunk,
+              filePath: entry.oldPath.isNotEmpty ? entry.oldPath : entry.newPath,
+            )),
         ],
       ),
     );
@@ -226,12 +230,14 @@ class BinaryFileIndicator extends StatelessWidget {
 
 class DiffHunkView extends StatelessWidget {
   final DiffHunk hunk;
+  final String filePath;
 
-  const DiffHunkView({super.key, required this.hunk});
+  const DiffHunkView({super.key, required this.hunk, required this.filePath});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final language = inferLanguage(filePath);
 
     // Calculate line number offsets
     int oldLine = hunk.oldStart;
@@ -270,6 +276,7 @@ class DiffHunkView extends StatelessWidget {
             oldLineNum: oldLineNum,
             newLineNum: newLineNum,
             wordDiff: wordDiff,
+            language: language,
           );
         }),
       ],
@@ -286,6 +293,7 @@ class DiffLineView extends StatelessWidget {
   final int oldLineNum;
   final int newLineNum;
   final WordDiffResult? wordDiff;
+  final String? language;
 
   const DiffLineView({
     super.key,
@@ -293,6 +301,7 @@ class DiffLineView extends StatelessWidget {
     required this.oldLineNum,
     required this.newLineNum,
     this.wordDiff,
+    this.language,
   });
 
   Color _backgroundColor() {
@@ -414,6 +423,27 @@ class DiffLineView extends StatelessWidget {
             final bgColor = _wordSegmentColor(segment.type);
             final isHighlighted = segment.type != 'unchanged';
 
+            // For unchanged segments, apply syntax highlighting
+            // For added/deleted segments, use plain text with muted color
+            if (!isHighlighted && language != null) {
+              final syntaxSpans = parseSyntaxHighlighted(segment.text, language);
+              return Container(
+                decoration: BoxDecoration(
+                  color: bgColor,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+                padding: const EdgeInsets.symmetric(horizontal: 1),
+                child: RichText(
+                  text: TextSpan(
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontFamily: 'monospace',
+                    ),
+                    children: syntaxSpans,
+                  ),
+                ),
+              );
+            }
+
             return Container(
               decoration: BoxDecoration(
                 color: bgColor,
@@ -424,6 +454,8 @@ class DiffLineView extends StatelessWidget {
                 segment.text,
                 style: theme.textTheme.bodySmall?.copyWith(
                   fontFamily: 'monospace',
+                  // Muted color for changed segments to not compete with bg
+                  color: isHighlighted ? const Color(0xFFBBBBBB) : null,
                 ),
               ),
             );
@@ -432,7 +464,23 @@ class DiffLineView extends StatelessWidget {
       );
     }
 
-    // Fallback: render plain content
+    // Fallback: render with syntax highlighting if language is available
+    if (language != null) {
+      final syntaxSpans = parseSyntaxHighlighted(line.content, language);
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        child: RichText(
+          text: TextSpan(
+            style: theme.textTheme.bodySmall?.copyWith(
+              fontFamily: 'monospace',
+            ),
+            children: syntaxSpans,
+          ),
+        ),
+      );
+    }
+
+    // Plain content without syntax highlighting
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
       child: Text(

--- a/phone/lib/widgets/diff_widgets.dart
+++ b/phone/lib/widgets/diff_widgets.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/repo_diff.dart';
+import '../utils/word_diff.dart';
 import 'diff_stat_bar.dart';
 
 // ---------------------------------------------------------------------------
@@ -236,6 +237,10 @@ class DiffHunkView extends StatelessWidget {
     int oldLine = hunk.oldStart;
     int newLine = hunk.newStart;
 
+    // Precompute word diffs for paired del/add sequences
+    final lineTypes = hunk.lines.map((l) => (type: l.type, content: l.content)).toList();
+    final wordDiffs = computeHunkWordDiffs(lineTypes);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -254,14 +259,17 @@ class DiffHunkView extends StatelessWidget {
         ),
 
         // Diff lines
-        ...hunk.lines.map((line) {
+        ...List.generate(hunk.lines.length, (idx) {
+          final line = hunk.lines[idx];
           final oldLineNum = line.type == 'del' ? oldLine++ : oldLine;
           final newLineNum = line.type == 'add' ? newLine++ : newLine;
+          final wordDiff = wordDiffs[idx];
 
           return DiffLineView(
             line: line,
             oldLineNum: oldLineNum,
             newLineNum: newLineNum,
+            wordDiff: wordDiff,
           );
         }),
       ],
@@ -277,12 +285,14 @@ class DiffLineView extends StatelessWidget {
   final DiffLine line;
   final int oldLineNum;
   final int newLineNum;
+  final WordDiffResult? wordDiff;
 
   const DiffLineView({
     super.key,
     required this.line,
     required this.oldLineNum,
     required this.newLineNum,
+    this.wordDiff,
   });
 
   Color _backgroundColor() {
@@ -304,6 +314,20 @@ class DiffLineView extends StatelessWidget {
         return '-';
       default:
         return ' ';
+    }
+  }
+
+  /// Returns the word-level background color for a segment.
+  Color _wordSegmentColor(String segmentType) {
+    switch (segmentType) {
+      case 'added':
+        // Stronger green for word-level highlighting
+        return Colors.green.withAlpha(80);
+      case 'deleted':
+        // Stronger red for word-level highlighting
+        return Colors.red.withAlpha(80);
+      default:
+        return Colors.transparent;
     }
   }
 
@@ -366,19 +390,56 @@ class DiffLineView extends StatelessWidget {
             ),
           ),
 
-          // Content
+          // Content (with word-level highlighting if available)
           Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+            child: _buildContent(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // If we have word diff segments and the line is add/del, render with highlighting
+    if (wordDiff != null &&
+        !wordDiff!.skipped &&
+        wordDiff!.segments.isNotEmpty &&
+        (line.type == 'add' || line.type == 'del')) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        child: Wrap(
+          children: wordDiff!.segments.map((segment) {
+            final bgColor = _wordSegmentColor(segment.type);
+            final isHighlighted = segment.type != 'unchanged';
+
+            return Container(
+              decoration: BoxDecoration(
+                color: bgColor,
+                borderRadius: isHighlighted ? BorderRadius.circular(2) : null,
+              ),
+              padding: isHighlighted ? const EdgeInsets.symmetric(horizontal: 1) : null,
               child: Text(
-                line.content,
+                segment.text,
                 style: theme.textTheme.bodySmall?.copyWith(
                   fontFamily: 'monospace',
                 ),
               ),
-            ),
-          ),
-        ],
+            );
+          }).toList(),
+        ),
+      );
+    }
+
+    // Fallback: render plain content
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      child: Text(
+        line.content,
+        style: theme.textTheme.bodySmall?.copyWith(
+          fontFamily: 'monospace',
+        ),
       ),
     );
   }

--- a/phone/lib/widgets/diff_widgets.dart
+++ b/phone/lib/widgets/diff_widgets.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/repo_diff.dart';
+import 'diff_stat_bar.dart';
 
 // ---------------------------------------------------------------------------
 // Helper functions (extracted from commit_diff_screen.dart)
@@ -59,6 +60,7 @@ class DiffView extends StatelessWidget {
     final meta = diff.meta;
     final entries = diff.diffEntries;
     final theme = Theme.of(context);
+    final maxChanges = maxChangesInDiff(entries);
 
     return ListView(
       shrinkWrap: shrinkWrap,
@@ -104,7 +106,7 @@ class DiffView extends StatelessWidget {
         ),
 
         // Diff entries
-        ...entries.map((entry) => DiffEntryTile(entry: entry)),
+        ...entries.map((entry) => DiffEntryTile(entry: entry, maxChanges: maxChanges)),
       ],
     );
   }
@@ -116,8 +118,9 @@ class DiffView extends StatelessWidget {
 
 class DiffEntryTile extends StatelessWidget {
   final DiffEntry entry;
+  final int? maxChanges;
 
-  const DiffEntryTile({super.key, required this.entry});
+  const DiffEntryTile({super.key, required this.entry, this.maxChanges});
 
   String get _displayPath {
     if (entry.changeType == 'renamed') {
@@ -162,6 +165,13 @@ class DiffEntryTile extends StatelessWidget {
                 ),
               ),
             ),
+            const SizedBox(width: 8),
+            if (!entry.binary)
+              DiffStatBar(
+                insertions: calcFileStats(entry).insertions,
+                deletions: calcFileStats(entry).deletions,
+                maxChanges: maxChanges,
+              ),
           ],
         ),
         children: [

--- a/phone/lib/widgets/expandable_commit_tile.dart
+++ b/phone/lib/widgets/expandable_commit_tile.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+
+import '../models/repo_commits.dart';
+import '../models/repo_diff.dart';
+import '../utils/date_helpers.dart';
+import 'diff_widgets.dart';
+
+/// An expandable commit tile widget that shows commit info and lazy-loads diffs.
+///
+/// Used by [BranchDetailScreen] and [CommitHistoryScreen] to display commit
+/// entries with expandable diff views.
+class ExpandableCommitTile extends StatefulWidget {
+  final RepoCommit commit;
+  final String repoKey;
+  final Map<String, RepoDiff?> diffCache;
+  final Set<String> failedDiffs;
+  final VoidCallback onExpand;
+  final VoidCallback onRetry;
+
+  /// When true, the diff view uses shrinkWrap and NeverScrollableScrollPhysics.
+  /// Defaults to false.
+  final bool shrinkWrapDiff;
+
+  const ExpandableCommitTile({
+    super.key,
+    required this.commit,
+    required this.repoKey,
+    required this.diffCache,
+    required this.failedDiffs,
+    required this.onExpand,
+    required this.onRetry,
+    this.shrinkWrapDiff = false,
+  });
+
+  @override
+  State<ExpandableCommitTile> createState() => _ExpandableCommitTileState();
+}
+
+class _ExpandableCommitTileState extends State<ExpandableCommitTile> {
+  bool _isExpanded = false;
+
+  void _handleTap() {
+    final wasExpanded = _isExpanded;
+    setState(() {
+      _isExpanded = !_isExpanded;
+    });
+    if (!wasExpanded) {
+      widget.onExpand();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final diff = widget.commit.diffSummary;
+    final cachedDiff = widget.diffCache[widget.commit.hash];
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Card(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Collapsed header (always visible, tappable)
+            InkWell(
+              onTap: _handleTap,
+              borderRadius: BorderRadius.circular(12),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Top row: hash_short + date
+                    Row(
+                      children: [
+                        Text(
+                          widget.commit.hashShort,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontFamily: 'monospace',
+                            color: theme.colorScheme.primary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const Spacer(),
+                        Text(
+                          formatDateShort(widget.commit.date),
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.outline,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        AnimatedRotation(
+                          turns: _isExpanded ? 0.25 : 0,
+                          duration: const Duration(milliseconds: 200),
+                          child: Icon(
+                            Icons.chevron_right,
+                            size: 18,
+                            color: theme.colorScheme.outline,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+
+                    // Middle: commit message (first line)
+                    Text(
+                      widget.commit.message,
+                      style: theme.textTheme.bodyMedium,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 6),
+
+                    // Bottom row: author name + diff summary
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            widget.commit.authorName,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.outline,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        Text(
+                          '+${diff.insertions} -${diff.deletions} in ${diff.filesChanged} file${diff.filesChanged == 1 ? '' : 's'}',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.outline,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            // Expanded: diff view (lazy-loaded)
+            if (_isExpanded)
+              widget.failedDiffs.contains(widget.commit.hash)
+                  ? Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.error_outline,
+                                color: theme.colorScheme.error, size: 32),
+                            const SizedBox(height: 8),
+                            Text('Failed to load diff',
+                                style: TextStyle(color: theme.colorScheme.error)),
+                            const SizedBox(height: 8),
+                            TextButton.icon(
+                              onPressed: widget.onRetry,
+                              icon: const Icon(Icons.refresh, size: 16),
+                              label: const Text('Retry'),
+                            ),
+                          ],
+                        ),
+                      ),
+                    )
+                  : cachedDiff == null
+                      ? const Padding(
+                          padding: EdgeInsets.all(16),
+                          child: Center(child: CircularProgressIndicator()),
+                        )
+                      : DiffView(
+                          diff: cachedDiff,
+                          shrinkWrap: widget.shrinkWrapDiff,
+                          physics: widget.shrinkWrapDiff
+                              ? const NeverScrollableScrollPhysics()
+                              : null,
+                        ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/phone/pubspec.yaml
+++ b/phone/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   # Shared core (CRDT, storage, documents)
   avodah_core:
     path: ../packages/avodah_core
+  highlight: ^0.7.0
 
 dependency_overrides:
   # 2.3.0 pulls in jni/jni_flutter which requires NDK 28 (not available in Nix env)


### PR DESCRIPTION
## Summary

Git visualization improvements for the Avodah phone app (client-side only).

### Changes

- **Phase 1**: Extracted shared `ExpandableCommitTile` widget to `widgets/expandable_commit_tile.dart` — eliminates ~140 lines of duplication between `BranchDetailScreen` and `CommitHistoryScreen`
- **Phase 2**: Added `DiffStatBar` widget showing per-file `+N -M` counts with proportional colored bars (green/red)
- **Phase 3**: Added `word_diff.dart` utility implementing LCS-based word-level diff computation
- **Phase 4**: Integrated word-level highlighting into `DiffLineView` — changed words render with stronger background colors
- **Phase 5**: Added syntax highlighting to diff content via `highlight` package — supports 50+ file extensions with muted color scheme
- **Phase 6**: Fixed color scheme readability — changed word-diff segment text from grey to white for sufficient contrast on green/red backgrounds

### Acceptance Criteria

- [x] AC1: Word-level diff highlighting visible in add/del line pairs
- [x] AC2: Each file in diff view shows colored stat bar with `+N -M` count
- [x] AC3: Diff content shows syntax-highlighted code for recognized file extensions
- [x] AC4: `ExpandableCommitTile` is a single shared widget used by both screens
- [x] AC5: No new API endpoints required — all client-side
- [x] AC6: Existing diff caching and lazy loading preserved
- [x] AC7: Performance acceptable on typical diffs (< 50 files, < 1000 lines)

### Test Plan

- [ ] Review diff view in phone app with a mixed-file commit (added/deleted/modified)
- [ ] Verify word-level highlighting shows for paired add/del lines
- [ ] Verify stat bars appear per file with correct proportions
- [ ] Verify syntax highlighting for Dart, TypeScript, and other common extensions
- [ ] Verify white text on green/red backgrounds is readable
- [ ] Run `flutter analyze` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)