### PR TITLE
AVO-078: Phone-triggered self-update

### DIFF
--- a/mcp/bin/sync_server.dart
+++ b/mcp/bin/sync_server.dart
@@ -14,12 +14,14 @@
 library;
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:avodah_core/avodah_core.dart';
 import 'package:avodah_mcp/config/avo_config.dart';
 import 'package:avodah_mcp/config/paths.dart';
 import 'package:avodah_mcp/services/jira_service.dart';
+import 'package:avodah_mcp/services/self_update_service.dart';
 import 'package:avodah_mcp/services/sync_api_service.dart';
 import 'package:avodah_mcp/storage/database_opener.dart';
 import 'package:args/args.dart';
@@ -70,6 +72,9 @@ Future<void> main(List<String> args) async {
     paths: paths,
   );
 
+  // Self-update service for phone-triggered APK builds
+  final selfUpdateService = SelfUpdateService();
+
   // Start HTTP server
   final server = await HttpServer.bind(InternetAddress.anyIPv4, port);
   stderr.writeln('Avodah Sync Server listening on 0.0.0.0:$port');
@@ -89,19 +94,27 @@ Future<void> main(List<String> args) async {
 
   // Accept connections — handle each request concurrently
   await for (final request in server) {
-    unawaited(_handleRequest(request, syncApi, agentApiUrl));
+    unawaited(_handleRequest(request, syncApi, selfUpdateService, agentApiUrl));
   }
 }
 
 Future<void> _handleRequest(
   HttpRequest request,
   SyncApiService syncApi,
+  SelfUpdateService selfUpdateService,
   String agentApiUrl,
 ) async {
   try {
     // WebSocket upgrade requests → proxy to AGENT_API_URL
     if (WebSocketTransformer.isUpgradeRequest(request)) {
       await _proxyWebSocket(request, agentApiUrl);
+      return;
+    }
+
+    // Self-update endpoints
+    final path = request.uri.path;
+    if (path == '/api/self-update' || path == '/api/self-update/status') {
+      await _handleSelfUpdate(request, selfUpdateService);
       return;
     }
 
@@ -123,6 +136,77 @@ Future<void> _handleRequest(
       ..close();
   } catch (e, stack) {
     stderr.writeln('Unhandled request error: $e\n$stack');
+  }
+}
+
+Future<void> _handleSelfUpdate(
+  HttpRequest request,
+  SelfUpdateService selfUpdateService,
+) async {
+  // CORS
+  request.response.headers.add('Access-Control-Allow-Origin', '*');
+  request.response.headers
+      .add('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  request.response.headers
+      .add('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (request.method == 'OPTIONS') {
+    request.response
+      ..statusCode = HttpStatus.ok
+      ..close();
+    return;
+  }
+
+  final path = request.uri.path;
+
+  if (path == '/api/self-update') {
+    if (request.method == 'POST') {
+      // F1/F3: Trigger build (async), return 202 Accepted
+      final started = selfUpdateService.triggerIfIdle();
+      if (started) {
+        final state = selfUpdateService.state;
+        request.response
+          ..statusCode = HttpStatus.accepted
+          ..headers.contentType = ContentType.json
+          ..write(jsonEncode({
+            'status': 'building',
+            'startedAt': state.startedAt?.toIso8601String(),
+          }))
+          ..close();
+      } else {
+        // F5: Mutex — build already running
+        request.response
+          ..statusCode = HttpStatus.conflict
+          ..headers.contentType = ContentType.json
+          ..write('{"error":"Build already in progress","code":"CONFLICT"}')
+          ..close();
+      }
+    } else {
+      request.response
+        ..statusCode = HttpStatus.methodNotAllowed
+        ..write('{"error":"Method not allowed"}')
+        ..close();
+    }
+  } else if (path == '/api/self-update/status') {
+    if (request.method == 'GET') {
+      // F4: Return current status
+      final state = selfUpdateService.state;
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(jsonEncode(state.toJson()))
+        ..close();
+    } else {
+      request.response
+        ..statusCode = HttpStatus.methodNotAllowed
+        ..write('{"error":"Method not allowed"}')
+        ..close();
+    }
+  } else {
+    request.response
+      ..statusCode = HttpStatus.notFound
+      ..write('{"error":"Not found"}')
+      ..close();
   }
 }
 

--- a/mcp/lib/services/self_update_service.dart
+++ b/mcp/lib/services/self_update_service.dart
@@ -1,0 +1,183 @@
+/// Self-update service for phone-triggered APK builds.
+///
+/// Provides endpoints:
+/// - POST /api/self-update  — triggers async build via tool/deploy.sh oppo
+/// - GET /api/self-update/status  — returns current build status + log tail
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// Build status enum.
+enum BuildStatus {
+  idle,
+  building,
+  success,
+  error,
+}
+
+/// Holds the current self-update state.
+class SelfUpdateState {
+  BuildStatus status;
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+  final List<String> logLines;
+
+  SelfUpdateState({
+    this.status = BuildStatus.idle,
+    this.startedAt,
+    this.completedAt,
+    this.logLines = const [],
+  });
+
+  Map<String, dynamic> toJson() => {
+        'status': status.name,
+        'startedAt': startedAt?.toIso8601String(),
+        'completedAt': completedAt?.toIso8601String(),
+        'log': logLines,
+      };
+
+  SelfUpdateState copyWith({
+    BuildStatus? status,
+    DateTime? startedAt,
+    DateTime? completedAt,
+    List<String>? logLines,
+  }) {
+    return SelfUpdateState(
+      status: status ?? this.status,
+      startedAt: startedAt ?? this.startedAt,
+      completedAt: completedAt ?? this.completedAt,
+      logLines: logLines ?? this.logLines,
+    );
+  }
+}
+
+/// Handles self-update build requests.
+///
+/// Runs tool/deploy.sh oppo asynchronously and captures stdout/stderr
+/// into an in-memory log buffer (last 20 lines returned in status).
+class SelfUpdateService {
+  /// Hardcoded script path — no user input in shell command (NF2).
+  static const String _deployScript = 'tool/deploy.sh';
+
+  /// The device argument passed to the deploy script.
+  static const String _deviceArg = 'oppo';
+
+  /// Maximum log lines to retain.
+  static const int _maxLogLines = 200;
+
+  /// Current build state.
+  SelfUpdateState _state = SelfUpdateState();
+
+  /// Lock to prevent concurrent builds (F5).
+  bool get _isBuilding => _state.status == BuildStatus.building;
+
+  /// Triggers async build if not already running. Returns false if build
+  /// is in progress (caller should return 409).
+  bool triggerIfIdle() {
+    if (_isBuilding) return false;
+
+    _state = SelfUpdateState(
+      status: BuildStatus.building,
+      startedAt: DateTime.now(),
+      logLines: ['Build started at ${_state.startedAt}'],
+    );
+
+    _runBuildAsync();
+    return true;
+  }
+
+  /// Returns the current state as JSON.
+  SelfUpdateState get state => _state;
+
+  /// Runs the deploy script asynchronously.
+  Future<void> _runBuildAsync() async {
+    final logLines = <String>[];
+
+    try {
+      // Step 1: git pull to get latest code (F2)
+      final repoRoot = _resolveRepoRoot();
+      final pullResult = await Process.run(
+        'git',
+        ['pull'],
+        workingDirectory: repoRoot,
+      );
+
+      logLines.add('[git pull] exit code: ${pullResult.exitCode}');
+      if (pullResult.stdout.isNotEmpty) {
+        for (final line in pullResult.stdout.toString().split('\n')) {
+          if (line.isNotEmpty) logLines.add('[git pull] stdout: $line');
+        }
+      }
+      if (pullResult.stderr.isNotEmpty) {
+        for (final line in pullResult.stderr.toString().split('\n')) {
+          if (line.isNotEmpty) logLines.add('[git pull] stderr: $line');
+        }
+      }
+
+      // Step 2: Run deploy.sh oppo (F1)
+      final deployPath = '$repoRoot/$_deployScript';
+      logLines.add('Running: $deployPath $_deviceArg');
+
+      final process = await Process.start(
+        'bash',
+        [deployPath, _deviceArg],
+        workingDirectory: repoRoot,
+      );
+
+      // Capture stdout + stderr line by line
+      process.stdout
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen((line) {
+        if (logLines.length < _maxLogLines) {
+          logLines.add(line);
+        }
+      });
+
+      process.stderr
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen((line) {
+        if (logLines.length < _maxLogLines) {
+          logLines.add('[stderr] $line');
+        }
+      });
+
+      final exitCode = await process.exitCode;
+
+      logLines.add('deploy.sh exited with code: $exitCode');
+
+      _state = _state.copyWith(
+        status: exitCode == 0 ? BuildStatus.success : BuildStatus.error,
+        completedAt: DateTime.now(),
+        logLines: logLines.length > 20
+            ? logLines.sublist(logLines.length - 20)
+            : logLines,
+      );
+    } catch (e, stack) {
+      logLines.add('EXCEPTION: $e\n$stack');
+      _state = _state.copyWith(
+        status: BuildStatus.error,
+        completedAt: DateTime.now(),
+        logLines: logLines.length > 20
+            ? logLines.sublist(logLines.length - 20)
+            : logLines,
+      );
+    }
+  }
+
+  String _resolveRepoRoot() {
+    // Use Platform.script to derive the repo root
+    // Works when running from the avodah repo via dart run
+    final script = Platform.script.toFilePath();
+    // mcp/bin/sync_server.dart → repo root is two levels up from mcp/bin/
+    final idx = script.indexOf('/mcp/bin/');
+    if (idx != -1) {
+      return script.substring(0, idx);
+    }
+    // Fallback: assume CWD is repo root
+    return Directory.current.path;
+  }
+}

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io' show HttpStatus;
 
 import 'package:http/http.dart' as http;
 import 'package:image_picker/image_picker.dart' show XFile;
@@ -536,6 +537,46 @@ class AgentApiClient {
         .toList();
   }
 
+  // --- Self-Update ---
+
+  /// Triggers a self-update build (phone → server → APK push).
+  ///
+  /// POST /api/self-update → 202 Accepted with {status: building, startedAt}
+  /// Returns null on network error.
+  Future<SelfUpdateResult?> triggerSelfUpdate() async {
+    try {
+      final response = await _client
+          .post(Uri.parse('$baseUrl/api/self-update'))
+          .timeout(const Duration(seconds: 10));
+      if (response.statusCode == HttpStatus.accepted) {
+        final json = jsonDecode(response.body) as Map<String, dynamic>;
+        return SelfUpdateResult.fromJson(json);
+      }
+      return null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Gets the current self-update build status.
+  ///
+  /// GET /api/self-update/status → {status, log, startedAt, completedAt}
+  /// Returns null on network error.
+  Future<SelfUpdateStatus?> getSelfUpdateStatus() async {
+    try {
+      final response = await _client
+          .get(Uri.parse('$baseUrl/api/self-update/status'))
+          .timeout(const Duration(seconds: 10));
+      if (response.statusCode == HttpStatus.ok) {
+        final json = jsonDecode(response.body) as Map<String, dynamic>;
+        return SelfUpdateStatus.fromJson(json);
+      }
+      return null;
+    } catch (_) {
+      return null;
+    }
+  }
+
   // --- Repo Detail ---
 
   /// Fetch git info for a repository.
@@ -972,4 +1013,57 @@ class PagedFolderResult {
     required this.total,
     required this.hasMore,
   });
+}
+
+/// Result of triggering a self-update build.
+class SelfUpdateResult {
+  final String status;
+  final DateTime? startedAt;
+
+  const SelfUpdateResult({required this.status, this.startedAt});
+
+  factory SelfUpdateResult.fromJson(Map<String, dynamic> json) {
+    return SelfUpdateResult(
+      status: json['status'] as String? ?? 'unknown',
+      startedAt: json['startedAt'] != null
+          ? DateTime.tryParse(json['startedAt'] as String)
+          : null,
+    );
+  }
+}
+
+/// Current self-update build status.
+class SelfUpdateStatus {
+  final String status;
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+  final List<String> log;
+
+  const SelfUpdateStatus({
+    required this.status,
+    this.startedAt,
+    this.completedAt,
+    this.log = const [],
+  });
+
+  factory SelfUpdateStatus.fromJson(Map<String, dynamic> json) {
+    return SelfUpdateStatus(
+      status: json['status'] as String? ?? 'idle',
+      startedAt: json['startedAt'] != null
+          ? DateTime.tryParse(json['startedAt'] as String)
+          : null,
+      completedAt: json['completedAt'] != null
+          ? DateTime.tryParse(json['completedAt'] as String)
+          : null,
+      log: (json['log'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
+    );
+  }
+
+  bool get isBuilding => status == 'building';
+  bool get isSuccess => status == 'success';
+  bool get isError => status == 'error';
+  bool get isIdle => status == 'idle';
 }

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
@@ -55,6 +57,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   /// Whether chip data is being loaded.
   bool _loadingChips = false;
+
+  /// Self-update build state.
+  bool _updateBuilding = false;
+  String? _updateStatus;
+  List<String> _updateLog = [];
+
+  /// Polling timer for build status.
+  Timer? _statusPollTimer;
 
   @override
   void initState() {
@@ -182,7 +192,68 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void dispose() {
     _controller.dispose();
     _chipController.dispose();
+    _statusPollTimer?.cancel();
     super.dispose();
+  }
+
+  Future<void> _triggerSelfUpdate() async {
+    final url = await SettingsScreen.loadServerUrl();
+    final client = AgentApiClient(baseUrl: url);
+
+    final result = await client.triggerSelfUpdate();
+    if (result == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to trigger update')),
+        );
+      }
+      return;
+    }
+
+    setState(() {
+      _updateBuilding = true;
+      _updateStatus = 'Building...';
+      _updateLog = ['Started at ${result.startedAt}'];
+    });
+
+    _startStatusPolling(url);
+  }
+
+  void _startStatusPolling(String url) {
+    _statusPollTimer?.cancel();
+    _statusPollTimer = Timer.periodic(const Duration(seconds: 5), (timer) async {
+      final client = AgentApiClient(baseUrl: url);
+      final status = await client.getSelfUpdateStatus();
+
+      if (status == null) return;
+
+      setState(() {
+        _updateLog = status.log;
+        if (status.isBuilding) {
+          _updateStatus = 'Building...';
+        } else if (status.isSuccess) {
+          _updateStatus = 'Update complete!';
+          _updateBuilding = false;
+          timer.cancel();
+        } else if (status.isError) {
+          _updateStatus = 'Build failed';
+          _updateBuilding = false;
+          timer.cancel();
+        }
+      });
+
+      if (!status.isBuilding) {
+        timer.cancel();
+        if (mounted) {
+          final snackMsg = status.isSuccess
+              ? 'Update complete!'
+              : 'Build failed. Check logs for details.';
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(snackMsg)),
+          );
+        }
+      }
+    });
   }
 
   @override
@@ -336,6 +407,105 @@ class _SettingsScreenState extends State<SettingsScreen> {
             leading: const Icon(Icons.info_outline),
             title: const Text('About'),
             subtitle: Text('Avodah v$avodahVersion'),
+          ),
+          const Divider(),
+          // Update App section
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('App Updates',
+                    style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                const Text(
+                  'Build and install the latest version on your device.',
+                  style: TextStyle(color: Colors.grey),
+                ),
+                const SizedBox(height: 12),
+                if (_updateBuilding || _updateStatus != null) ...[
+                  // Status display
+                  Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: _updateStatus == 'Update complete!'
+                          ? Colors.green.shade50
+                          : _updateStatus == 'Build failed'
+                              ? Colors.red.shade50
+                              : Colors.blue.shade50,
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(
+                        color: _updateStatus == 'Update complete!'
+                            ? Colors.green.shade200
+                            : _updateStatus == 'Build failed'
+                                ? Colors.red.shade200
+                                : Colors.blue.shade200,
+                      ),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            if (_updateBuilding)
+                              const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            else
+                              Icon(
+                                _updateStatus == 'Update complete!'
+                                    ? Icons.check_circle
+                                    : Icons.error,
+                                size: 16,
+                                color: _updateStatus == 'Update complete!'
+                                    ? Colors.green
+                                    : Colors.red,
+                              ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                _updateStatus ?? '',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w500,
+                                  color: _updateStatus == 'Update complete!'
+                                      ? Colors.green.shade700
+                                      : _updateStatus == 'Build failed'
+                                          ? Colors.red.shade700
+                                          : Colors.blue.shade700,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        if (_updateLog.isNotEmpty) ...[
+                          const SizedBox(height: 8),
+                          Text(
+                            _updateLog.take(5).join('\n'),
+                            style: const TextStyle(
+                              fontFamily: 'monospace',
+                              fontSize: 11,
+                              color: Colors.grey,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                ],
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _updateBuilding ? null : _triggerSelfUpdate,
+                    icon: const Icon(Icons.system_update),
+                    label: Text(_updateBuilding ? 'Building...' : 'Update App'),
+                  ),
+                ),
+              ],
+            ),
           ),
           const SizedBox(height: 32),
         ],


### PR DESCRIPTION
## Summary
- Added SelfUpdateService to sync_server.dart with POST /api/self-update + GET /api/self-update/status endpoints
- Added Update App button to phone settings screen with 5s polling for build status
- Added triggerSelfUpdate() and getSelfUpdateStatus() to AgentApiClient

## Changes
- `mcp/bin/sync_server.dart` — wired SelfUpdateService into HTTP request routing
- `mcp/lib/services/self_update_service.dart` — new service (POST /api/self-update, GET /api/self-update/status)
- `phone/lib/services/agent_api_client.dart` — added triggerSelfUpdate() and getSelfUpdateStatus()
- `phone/lib/settings/settings_screen.dart` — added Update App button with build status UI

## Acceptance Criteria Checklist
- [ ] AC1: Tapping Update App in phone settings triggers build on server
- [ ] AC2: Phone shows Building status while build is in progress
- [ ] AC3: Phone shows Update complete or error message when build finishes
- [ ] AC4: Server runs tool/deploy.sh oppo which builds and installs APK on phone
- [ ] AC5: Concurrent update requests return 409 with build in progress message
- [ ] AC6: GET /api/self-update/status returns current status + log tail
- [ ] AC7: Server pulls latest code before building (git pull)

🤖 Generated with [Claude Code](https://claude.com/claude-code)