### PR TITLE
AVO-079: Fix ticket photo attachment

### DIFF
--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -53,6 +53,9 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
   // Per-field saving state (field name → true while saving)
   final Set<String> _savingFields = {};
 
+  // Image attachment selection state
+  bool _hasSelectedImages = false;
+
   // Deploy state
   DeployRouting? _deployRouting;
   DateTime? _deployRoutingFetchedAt;
@@ -107,6 +110,39 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
           _loading = false;
         });
       }
+    }
+  }
+
+  Future<void> _uploadAttachments() async {
+    final picker = _imagePickerKey.currentState;
+    if (picker == null || _ticket == null) return;
+    final images = picker.selectedImages;
+    if (images.isEmpty) return;
+
+    picker.setUploading(true);
+    try {
+      final (successes: successes, failures: failures) =
+          await picker.widget.onUpload(images, _ticket!.id);
+      if (mounted) {
+        if (successes.isNotEmpty) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('${successes.length} image(s) attached')),
+          );
+          picker.clear();
+          setState(() {
+            _hasSelectedImages = false;
+          });
+          _loadTicket();
+        }
+        if (failures.isNotEmpty) {
+          final names = failures.map((p) => p.split('/').last).join(', ');
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Failed to upload: $names')),
+          );
+        }
+      }
+    } finally {
+      picker.setUploading(false);
     }
   }
 
@@ -1259,7 +1295,31 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
             onUploadingChanged: (uploading) {
               setState(() {});
             },
+            onSelectionChanged: () {
+              setState(() {
+                _hasSelectedImages =
+                    _imagePickerKey.currentState?.selectedImages.isNotEmpty ??
+                        false;
+              });
+            },
           ),
+          // Upload button — visible when images are selected
+          if (_hasSelectedImages ||
+              (_imagePickerKey.currentState?.uploading ?? false))
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: FilledButton.icon(
+                onPressed: _imagePickerKey.currentState?.uploading ?? false
+                    ? null
+                    : _uploadAttachments,
+                icon: const Icon(Icons.cloud_upload, size: 18),
+                label: Text(
+                  _imagePickerKey.currentState?.uploading ?? false
+                      ? 'Uploading...'
+                      : 'Upload',
+                ),
+              ),
+            ),
           const SizedBox(height: 8),
           TicketDeploymentsSection(
             deployments: _ticketDeployments ?? [],

--- a/phone/lib/widgets/image_attachment_picker.dart
+++ b/phone/lib/widgets/image_attachment_picker.dart
@@ -25,10 +25,14 @@ class ImageAttachmentPicker extends StatefulWidget {
   /// Whether uploads are currently in progress.
   final ValueChanged<bool>? onUploadingChanged;
 
+  /// Called when the selected images list changes (image added or removed).
+  final VoidCallback? onSelectionChanged;
+
   const ImageAttachmentPicker({
     super.key,
     required this.onUpload,
     this.onUploadingChanged,
+    this.onSelectionChanged,
   });
 
   @override
@@ -114,6 +118,7 @@ class ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
         setState(() {
           _selectedImages.add(image);
         });
+        widget.onSelectionChanged?.call();
       }
     } catch (e) {
       if (mounted) {
@@ -128,10 +133,14 @@ class ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
     setState(() {
       _selectedImages.removeAt(index);
     });
+    widget.onSelectionChanged?.call();
   }
 
   /// Returns the selected images for upload after ticket creation.
   List<XFile> get selectedImages => List.unmodifiable(_selectedImages);
+
+  /// Whether an upload is currently in progress.
+  bool get uploading => _uploading;
 
   /// Clears all selected images (after successful upload).
   void clear() {


### PR DESCRIPTION
## Summary

- S-sized fix: add upload button to ticket detail screen for photo attachments
- Wire ImageAttachmentPicker to boardProvider client for multipart upload
- Follows existing pattern from create_ticket_screen.dart

## Changed Files

| File | Change |
|------|--------|
| `phone/lib/widgets/image_attachment_picker.dart` | Added `onSelectionChanged` callback and `uploading` getter |
| `phone/lib/screens/ticket_detail_screen.dart` | Added `_uploadAttachments()` method and upload button |

## Acceptance Criteria

- [x] AC1: Upload button appears when images selected
- [x] AC2: Upload triggers progress indicator
- [x] AC3: Snackbar confirmation + picker clears after upload
- [x] AC4: doc_refs section updates after upload
- [x] AC5: Partial failure handling (successful uploads preserved)
- [x] AC6: Buttons disabled during upload
- [ ] AC7: Android device testing (deferred — requires sinh-oppo)

## Regression

- `flutter build web --release` passed
- No new API endpoints or schema changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)