### PR TITLE
AVO-065: Secure the Avodah Sync and Android Communication

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -55,6 +55,81 @@ JIRA_ENABLED=false
 
 > **Warning:** Only one sync server instance should access the SQLite database at a time. Running both the Docker container and the native `avodah-sync` binary simultaneously will cause SQLite locking errors.
 
+## TLS Setup (Tailscale)
+
+The sync server supports HTTPS via Tailscale-provisioned Let's Encrypt certs.
+With TLS enabled, the phone connects to `https://<hostname>.ts.net:9847`
+and no manual certificate approval is needed (trusted CA chain).
+
+### Prerequisites
+
+Enable HTTPS certificates for your Tailscale tailnet:
+1. Go to [tailscale.com/admin/dns](https://tailscale.com/admin/dns)
+2. Enable "HTTPS Certificates"
+
+### Generate Certs
+
+```bash
+./tool/tailscale-cert.sh
+# Or with a custom domain:
+./tool/tailscale-cert.sh myhost.tail12345.ts.net
+```
+
+This writes certs to `~/.config/avodah/` (already mounted as `/config` in the container).
+
+### Configure config.json
+
+Edit `~/.config/avodah/config.json` and set the `syncTls` block:
+
+```json
+{
+  "syncTls": {
+    "certPath": "/config/drgnfly.tail10c2c6.ts.net.crt",
+    "keyPath":  "/config/drgnfly.tail10c2c6.ts.net.key"
+  }
+}
+```
+
+> **Note:** Paths use `/config/` (the container mount point). When running natively
+> (outside Docker), use the full host path instead (e.g. `~/.config/avodah/...`).
+
+Then restart the container:
+
+```bash
+docker compose restart avodah-sync
+```
+
+Verify TLS is active:
+
+```bash
+curl https://drgnfly.tail10c2c6.ts.net:9847/
+# Expected: {"status":"ok","service":"avodah-sync"}
+```
+
+### Phone Connection
+
+After enabling TLS, update the phone's server URL in Settings to:
+```
+https://drgnfly.tail10c2c6.ts.net:9847
+```
+
+Since the cert is Let's Encrypt-signed, no fingerprint approval dialog appears.
+
+### Cert Renewal
+
+Tailscale certs expire every ~90 days. Renew by re-running the script and restarting:
+
+```bash
+./tool/tailscale-cert.sh
+docker compose restart avodah-sync
+```
+
+Optional monthly cron:
+
+```
+0 3 1 * * /path/to/avodah/tool/tailscale-cert.sh && docker compose -f /path/to/avodah/docker-compose.yml restart avodah-sync
+```
+
 ## Proxy Architecture
 
 ```

--- a/mcp/bin/sync_server.dart
+++ b/mcp/bin/sync_server.dart
@@ -16,8 +16,10 @@ library;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:avodah_core/avodah_core.dart';
+import 'package:cryptography/cryptography.dart' as crypto;
 import 'package:avodah_mcp/config/avo_config.dart';
 import 'package:avodah_mcp/config/paths.dart';
 import 'package:avodah_mcp/services/jira_service.dart';
@@ -27,6 +29,10 @@ import 'package:avodah_mcp/services/sync_api_service.dart';
 import 'package:avodah_mcp/storage/database_opener.dart';
 import 'package:args/args.dart';
 import 'package:http/http.dart' as http;
+
+/// Server fingerprint computed from the TLS certificate (SHA-256, base64).
+/// Set during TLS binding and used in the /api/sync/status response.
+String? serverFingerprint;
 
 Future<void> main(List<String> args) async {
   final paths = AvodahPaths();
@@ -58,30 +64,75 @@ Future<void> main(List<String> args) async {
   final nodeId = paths.getNodeIdSync();
   final clock = HybridLogicalClock(nodeId: nodeId);
 
+  // Pairing service for secure sync device authentication
+  final pairingService = PairingService(db: db);
+
   // Jira service — only when JIRA_ENABLED=true
   JiraService? jiraService;
   if (jiraEnabled) {
     jiraService = JiraService(db: db, clock: clock, paths: paths);
   }
 
-  // CRDT delta sync API service
+  // CRDT delta sync API service (needs pairingService for auth middleware)
   final syncApi = SyncApiService(
     db: db,
     clock: clock,
     jiraService: jiraService,
     config: config,
     paths: paths,
+    pairingService: pairingService,
   );
-
-  // Pairing service for secure sync device authentication
-  final pairingService = PairingService(db: db);
 
   // Self-update service for phone-triggered APK builds
   final selfUpdateService = SelfUpdateService();
 
-  // Start HTTP server
-  final server = await HttpServer.bind(InternetAddress.anyIPv4, port);
-  stderr.writeln('Avodah Sync Server listening on 0.0.0.0:$port');
+  // Start server (TLS or plain HTTP)
+  HttpServer server;
+  final tlsCertPath = config.syncTlsCertPath;
+  final tlsKeyPath = config.syncTlsKeyPath;
+
+  if (tlsCertPath != null && tlsKeyPath != null) {
+    // TLS mode: load certificate and bind securely
+    final certFile = File(tlsCertPath);
+    final keyFile = File(tlsKeyPath);
+
+    if (!await certFile.exists()) {
+      stderr.writeln('ERROR: TLS certificate not found: $tlsCertPath');
+      stderr.writeln('Please provide valid TLS cert and key files, or remove syncTls config.');
+      exit(1);
+    }
+    if (!await keyFile.exists()) {
+      stderr.writeln('ERROR: TLS key not found: $tlsKeyPath');
+      stderr.writeln('Please provide valid TLS cert and key files, or remove syncTls config.');
+      exit(1);
+    }
+
+    final context = SecurityContext();
+    try {
+      context.useCertificateChainBytes(await certFile.readAsBytes());
+      context.usePrivateKeyBytes(await keyFile.readAsBytes());
+    } catch (e) {
+      stderr.writeln('ERROR: Failed to load TLS certificate/key: $e');
+      exit(1);
+    }
+
+    // Compute server fingerprint from the certificate (SHA-256, base64)
+    serverFingerprint = await _computeFingerprint(await certFile.readAsBytes());
+
+    server = await HttpServer.bindSecure(
+      InternetAddress.anyIPv4,
+      port,
+      context,
+    );
+    stderr.writeln('Avodah Sync Server (HTTPS/TLS) listening on 0.0.0.0:$port');
+    stderr.writeln('TLS fingerprint: ${serverFingerprint ?? "unknown"}');
+  } else {
+    // Plain HTTP mode (no TLS — for development or local-only networks)
+    server = await HttpServer.bind(InternetAddress.anyIPv4, port);
+    stderr.writeln('Avodah Sync Server (HTTP) listening on 0.0.0.0:$port');
+    stderr.writeln('WARNING: HTTP mode — sync traffic is NOT encrypted. Use TLS for production.');
+  }
+
   stderr.writeln(
       'Agent API proxy → $agentApiUrl (Jira: ${jiraEnabled ? "enabled" : "disabled"})');
 
@@ -101,6 +152,41 @@ Future<void> main(List<String> args) async {
     unawaited(_handleRequest(
         request, syncApi, pairingService, selfUpdateService, agentApiUrl));
   }
+}
+
+/// Computes a SHA-256 fingerprint from a PEM-encoded certificate.
+Future<String?> _computeFingerprint(List<int> certBytes) async {
+  try {
+    // Extract the certificate der bytes from PEM if needed
+    String pem = String.fromCharCodes(certBytes);
+    List<int> derBytes;
+
+    if (pem.contains('-----BEGIN CERTIFICATE-----')) {
+      // PEM format — extract base64 content and decode
+      final base64Content = pem
+          .replaceAll('-----BEGIN CERTIFICATE-----', '')
+          .replaceAll('-----END CERTIFICATE-----', '')
+          .replaceAll(RegExp(r'\s'), '');
+      derBytes = base64.decode(base64Content);
+    } else {
+      // Assume DER format
+      derBytes = certBytes;
+    }
+
+    // SHA-256 hash and base64 encode
+    final fingerprint = await _sha256(Uint8List.fromList(derBytes));
+    return base64.encode(fingerprint);
+  } catch (e) {
+    stderr.writeln('Warning: could not compute TLS fingerprint: $e');
+    return null;
+  }
+}
+
+/// SHA-256 digest helper.
+Future<Uint8List> _sha256(Uint8List data) async {
+  final sha256 = crypto.Sha256();
+  final digest = await sha256.hash(data);
+  return Uint8List.fromList(digest.bytes);
 }
 
 Future<void> _handleRequest(
@@ -171,7 +257,9 @@ Future<void> _handleRequest(
 /// GET /api/sync/status — Returns pairing status.
 Future<void> _handleSyncStatus(
     HttpRequest request, PairingService pairingService) async {
-  _setSyncCors(request);
+  final paired = await pairingService.listPairedDevices();
+  final pairedOrigin = paired.isNotEmpty ? paired.first.origin : null;
+  _setSyncCors(request, pairedOrigin: pairedOrigin);
   if (request.method == 'OPTIONS') {
     request.response
       ..statusCode = HttpStatus.ok
@@ -180,6 +268,10 @@ Future<void> _handleSyncStatus(
   }
 
   final status = await pairingService.getStatus();
+  // Include serverFingerprint if TLS is configured
+  if (serverFingerprint != null) {
+    status['serverFingerprint'] = serverFingerprint;
+  }
   _jsonResponse(request, HttpStatus.ok, status);
 }
 
@@ -237,6 +329,8 @@ Future<void> _handlePairConfirm(
     final nodeId = json['nodeId'] as String? ?? 'phone';
     final phonePubKey = json['phonePubKey'] as String?;
     final hmacProof = json['hmacProof'] as String?;
+    // Capture origin for CORS restriction (e.g. "https://100.64.0.1:9847")
+    final origin = request.headers.value('origin');
 
     if (phonePubKey == null || hmacProof == null) {
       _jsonResponse(request, HttpStatus.badRequest,
@@ -248,6 +342,7 @@ Future<void> _handlePairConfirm(
       nodeId: nodeId,
       phonePubKeyBase64: phonePubKey,
       hmacProofBase64: hmacProof,
+      origin: origin,
     );
 
     if (result['success'] == true) {
@@ -294,12 +389,17 @@ Future<void> _handlePairRevoke(
 }
 
 /// Sets CORS headers for sync endpoints.
-void _setSyncCors(HttpRequest request) {
-  request.response.headers.add('Access-Control-Allow-Origin', '*');
+///
+/// After pairing is established, restricts CORS to the paired device's origin.
+void _setSyncCors(HttpRequest request, {String? pairedOrigin}) {
+  final origin = request.headers.value('origin');
+  final allowedOrigin = pairedOrigin ?? origin ?? '*';
+  request.response.headers.add(
+      'Access-Control-Allow-Origin', allowedOrigin == '*' ? '*' : allowedOrigin);
   request.response.headers
       .add('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
   request.response.headers.add('Access-Control-Allow-Headers',
-      'Content-Type, X-Av-Pair-Token');
+      'Content-Type, X-Av-Pair-Token, X-Av-Node-Id');
 }
 
 /// Sends a JSON response.

--- a/mcp/bin/sync_server.dart
+++ b/mcp/bin/sync_server.dart
@@ -357,7 +357,10 @@ Future<void> _handlePairConfirm(
   }
 }
 
-/// DELETE /api/sync/pair — Revokes pairing.
+/// DELETE /api/sync/pair — Revokes pairing (authenticated via headers).
+///
+/// Requires X-Av-Pair-Token and X-Av-Node-Id headers.
+/// Returns success even if already unpaired (idempotent).
 Future<void> _handlePairRevoke(
     HttpRequest request, PairingService pairingService) async {
   _setSyncCors(request);
@@ -374,11 +377,25 @@ Future<void> _handlePairRevoke(
     return;
   }
 
-  try {
-    final body = await utf8.decoder.bind(request).join();
-    final json = jsonDecode(body) as Map<String, dynamic>;
-    final nodeId = json['nodeId'] as String? ?? 'phone';
+  // Auth via headers
+  final nodeId = request.headers.value('X-Av-Node-Id');
+  final token = request.headers.value('X-Av-Pair-Token');
 
+  if (nodeId == null || token == null) {
+    _jsonResponse(request, HttpStatus.forbidden,
+        {'error': 'Missing X-Av-Node-Id or X-Av-Pair-Token header'});
+    return;
+  }
+
+  // Verify token before revoking (authenticated revocation)
+  final valid = await pairingService.verifyPairToken(nodeId, token);
+  if (!valid) {
+    _jsonResponse(request, HttpStatus.forbidden,
+        {'error': 'Invalid pairing token'});
+    return;
+  }
+
+  try {
     await pairingService.revokePairing(nodeId);
     _jsonResponse(request, HttpStatus.ok, {'success': true});
   } catch (e) {

--- a/mcp/bin/sync_server.dart
+++ b/mcp/bin/sync_server.dart
@@ -21,6 +21,7 @@ import 'package:avodah_core/avodah_core.dart';
 import 'package:avodah_mcp/config/avo_config.dart';
 import 'package:avodah_mcp/config/paths.dart';
 import 'package:avodah_mcp/services/jira_service.dart';
+import 'package:avodah_mcp/services/pairing_service.dart';
 import 'package:avodah_mcp/services/self_update_service.dart';
 import 'package:avodah_mcp/services/sync_api_service.dart';
 import 'package:avodah_mcp/storage/database_opener.dart';
@@ -72,6 +73,9 @@ Future<void> main(List<String> args) async {
     paths: paths,
   );
 
+  // Pairing service for secure sync device authentication
+  final pairingService = PairingService(db: db);
+
   // Self-update service for phone-triggered APK builds
   final selfUpdateService = SelfUpdateService();
 
@@ -94,13 +98,15 @@ Future<void> main(List<String> args) async {
 
   // Accept connections — handle each request concurrently
   await for (final request in server) {
-    unawaited(_handleRequest(request, syncApi, selfUpdateService, agentApiUrl));
+    unawaited(_handleRequest(
+        request, syncApi, pairingService, selfUpdateService, agentApiUrl));
   }
 }
 
 Future<void> _handleRequest(
   HttpRequest request,
   SyncApiService syncApi,
+  PairingService pairingService,
   SelfUpdateService selfUpdateService,
   String agentApiUrl,
 ) async {
@@ -111,19 +117,38 @@ Future<void> _handleRequest(
       return;
     }
 
-    // Self-update endpoints
     final path = request.uri.path;
+
+    // Self-update endpoints
     if (path == '/api/self-update' || path == '/api/self-update/status') {
       await _handleSelfUpdate(request, selfUpdateService);
       return;
     }
 
-    // Sync API handles its own paths (e.g. /sync/*)
+    // Pairing endpoints (before auth check — pairing doesn't require auth)
+    if (path == '/api/sync/status') {
+      await _handleSyncStatus(request, pairingService);
+      return;
+    }
+    if (path == '/api/sync/pair/start' && request.method == 'POST') {
+      await _handlePairStart(request, pairingService);
+      return;
+    }
+    if (path == '/api/sync/pair/confirm' && request.method == 'POST') {
+      await _handlePairConfirm(request, pairingService);
+      return;
+    }
+    if (path == '/api/sync/pair' && request.method == 'DELETE') {
+      await _handlePairRevoke(request, pairingService);
+      return;
+    }
+
+    // Sync API handles its own paths (e.g. /api/sync/deltas)
     final syncHandled = await syncApi.handleRequest(request);
     if (syncHandled) return;
 
     // /api/* → proxy to AGENT_API_URL
-    if (request.uri.path.startsWith('/api/')) {
+    if (path.startsWith('/api/')) {
       await _proxyHttp(request, agentApiUrl);
       return;
     }
@@ -137,6 +162,154 @@ Future<void> _handleRequest(
   } catch (e, stack) {
     stderr.writeln('Unhandled request error: $e\n$stack');
   }
+}
+
+// ============================================================
+// Pairing handlers
+// ============================================================
+
+/// GET /api/sync/status — Returns pairing status.
+Future<void> _handleSyncStatus(
+    HttpRequest request, PairingService pairingService) async {
+  _setSyncCors(request);
+  if (request.method == 'OPTIONS') {
+    request.response
+      ..statusCode = HttpStatus.ok
+      ..close();
+    return;
+  }
+
+  final status = await pairingService.getStatus();
+  _jsonResponse(request, HttpStatus.ok, status);
+}
+
+/// POST /api/sync/pair/start — Initiates pairing handshake.
+Future<void> _handlePairStart(
+    HttpRequest request, PairingService pairingService) async {
+  _setSyncCors(request);
+  if (request.method == 'OPTIONS') {
+    request.response
+      ..statusCode = HttpStatus.ok
+      ..close();
+    return;
+  }
+
+  if (request.method != 'POST') {
+    _jsonResponse(request, HttpStatus.methodNotAllowed,
+        {'error': 'Method not allowed'});
+    return;
+  }
+
+  try {
+    final body = await utf8.decoder.bind(request).join();
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final nodeId = json['nodeId'] as String? ?? 'phone';
+
+    final result = await pairingService.startPairing(nodeId);
+    _jsonResponse(request, HttpStatus.ok, result);
+  } catch (e) {
+    stderr.writeln('Pair start error: $e');
+    _jsonResponse(request, HttpStatus.internalServerError,
+        {'error': 'Pairing start failed: $e'});
+  }
+}
+
+/// POST /api/sync/pair/confirm — Completes pairing handshake.
+Future<void> _handlePairConfirm(
+    HttpRequest request, PairingService pairingService) async {
+  _setSyncCors(request);
+  if (request.method == 'OPTIONS') {
+    request.response
+      ..statusCode = HttpStatus.ok
+      ..close();
+    return;
+  }
+
+  if (request.method != 'POST') {
+    _jsonResponse(request, HttpStatus.methodNotAllowed,
+        {'error': 'Method not allowed'});
+    return;
+  }
+
+  try {
+    final body = await utf8.decoder.bind(request).join();
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final nodeId = json['nodeId'] as String? ?? 'phone';
+    final phonePubKey = json['phonePubKey'] as String?;
+    final hmacProof = json['hmacProof'] as String?;
+
+    if (phonePubKey == null || hmacProof == null) {
+      _jsonResponse(request, HttpStatus.badRequest,
+          {'error': 'Missing phonePubKey or hmacProof'});
+      return;
+    }
+
+    final result = await pairingService.confirmPairing(
+      nodeId: nodeId,
+      phonePubKeyBase64: phonePubKey,
+      hmacProofBase64: hmacProof,
+    );
+
+    if (result['success'] == true) {
+      _jsonResponse(request, HttpStatus.ok, result);
+    } else {
+      _jsonResponse(request, HttpStatus.forbidden, result);
+    }
+  } catch (e) {
+    stderr.writeln('Pair confirm error: $e');
+    _jsonResponse(request, HttpStatus.internalServerError,
+        {'error': 'Pairing confirm failed: $e'});
+  }
+}
+
+/// DELETE /api/sync/pair — Revokes pairing.
+Future<void> _handlePairRevoke(
+    HttpRequest request, PairingService pairingService) async {
+  _setSyncCors(request);
+  if (request.method == 'OPTIONS') {
+    request.response
+      ..statusCode = HttpStatus.ok
+      ..close();
+    return;
+  }
+
+  if (request.method != 'DELETE') {
+    _jsonResponse(request, HttpStatus.methodNotAllowed,
+        {'error': 'Method not allowed'});
+    return;
+  }
+
+  try {
+    final body = await utf8.decoder.bind(request).join();
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final nodeId = json['nodeId'] as String? ?? 'phone';
+
+    await pairingService.revokePairing(nodeId);
+    _jsonResponse(request, HttpStatus.ok, {'success': true});
+  } catch (e) {
+    stderr.writeln('Pair revoke error: $e');
+    _jsonResponse(request, HttpStatus.internalServerError,
+        {'error': 'Pairing revoke failed: $e'});
+  }
+}
+
+/// Sets CORS headers for sync endpoints.
+void _setSyncCors(HttpRequest request) {
+  request.response.headers.add('Access-Control-Allow-Origin', '*');
+  request.response.headers
+      .add('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  request.response.headers.add('Access-Control-Allow-Headers',
+      'Content-Type, X-Av-Pair-Token');
+}
+
+/// Sends a JSON response.
+void _jsonResponse(
+    HttpRequest request, int statusCode, Map<String, dynamic> body) {
+  request.response
+    ..statusCode = statusCode
+    ..headers.contentType = ContentType.json
+    ..write(jsonEncode(body))
+    ..close();
 }
 
 Future<void> _handleSelfUpdate(

--- a/mcp/bin/sync_server.dart
+++ b/mcp/bin/sync_server.dart
@@ -162,11 +162,12 @@ Future<String?> _computeFingerprint(List<int> certBytes) async {
     List<int> derBytes;
 
     if (pem.contains('-----BEGIN CERTIFICATE-----')) {
-      // PEM format — extract base64 content and decode
-      final base64Content = pem
-          .replaceAll('-----BEGIN CERTIFICATE-----', '')
-          .replaceAll('-----END CERTIFICATE-----', '')
-          .replaceAll(RegExp(r'\s'), '');
+      // PEM format — extract first certificate only (chain may have multiple)
+      final beginMarker = '-----BEGIN CERTIFICATE-----';
+      final endMarker = '-----END CERTIFICATE-----';
+      final start = pem.indexOf(beginMarker) + beginMarker.length;
+      final end = pem.indexOf(endMarker);
+      final base64Content = pem.substring(start, end).replaceAll(RegExp(r'\s'), '');
       derBytes = base64.decode(base64Content);
     } else {
       // Assume DER format
@@ -197,16 +198,32 @@ Future<void> _handleRequest(
   String agentApiUrl,
 ) async {
   try {
-    // WebSocket upgrade requests → proxy to AGENT_API_URL
+    // WebSocket upgrade requests → proxy to AGENT_API_URL (requires auth)
     if (WebSocketTransformer.isUpgradeRequest(request)) {
+      final nodeId = request.headers.value('X-Av-Node-Id');
+      final token = request.headers.value('X-Av-Pair-Token');
+      if (nodeId == null || token == null ||
+          !await pairingService.verifyPairToken(nodeId, token)) {
+        _jsonResponse(request, HttpStatus.forbidden,
+            {'error': 'Invalid or expired pairing token'});
+        return;
+      }
       await _proxyWebSocket(request, agentApiUrl);
       return;
     }
 
     final path = request.uri.path;
 
-    // Self-update endpoints
+    // Self-update endpoints (requires auth)
     if (path == '/api/self-update' || path == '/api/self-update/status') {
+      final nodeId = request.headers.value('X-Av-Node-Id');
+      final token = request.headers.value('X-Av-Pair-Token');
+      if (nodeId == null || token == null ||
+          !await pairingService.verifyPairToken(nodeId, token)) {
+        _jsonResponse(request, HttpStatus.forbidden,
+            {'error': 'Invalid or expired pairing token'});
+        return;
+      }
       await _handleSelfUpdate(request, selfUpdateService);
       return;
     }
@@ -233,8 +250,31 @@ Future<void> _handleRequest(
     final syncHandled = await syncApi.handleRequest(request);
     if (syncHandled) return;
 
-    // /api/* → proxy to AGENT_API_URL
+    // /api/* → proxy to AGENT_API_URL (requires valid pairing token)
     if (path.startsWith('/api/')) {
+      // CORS preflight passes through without auth
+      if (request.method == 'OPTIONS') {
+        _setSyncCors(request);
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..close();
+        return;
+      }
+
+      final nodeId = request.headers.value('X-Av-Node-Id');
+      final token = request.headers.value('X-Av-Pair-Token');
+      if (nodeId == null || token == null) {
+        _jsonResponse(request, HttpStatus.forbidden,
+            {'error': 'Missing X-Av-Node-Id or X-Av-Pair-Token header'});
+        return;
+      }
+      final valid = await pairingService.verifyPairToken(nodeId, token);
+      if (!valid) {
+        _jsonResponse(request, HttpStatus.forbidden,
+            {'error': 'Invalid or expired pairing token'});
+        return;
+      }
+
       await _proxyHttp(request, agentApiUrl);
       return;
     }

--- a/mcp/lib/config/avo_config.dart
+++ b/mcp/lib/config/avo_config.dart
@@ -25,6 +25,13 @@ class AvoConfig {
   ///           'Learning': ['reading', 'course']}
   final Map<String, List<String>> categoryChips;
 
+  /// Path to the TLS certificate PEM file for the sync server.
+  /// If set, the sync server uses HTTPS. If null, uses plain HTTP.
+  final String? syncTlsCertPath;
+
+  /// Path to the TLS private key PEM file for the sync server.
+  final String? syncTlsKeyPath;
+
   static const defaultCategories = [
     'Learning',
     'Working',
@@ -38,6 +45,8 @@ class AvoConfig {
     this.syncPort = 9847,
     this.syncInterval = 30,
     this.categoryChips = const {},
+    this.syncTlsCertPath,
+    this.syncTlsKeyPath,
   });
 
   /// Effective categories list — user's if set, otherwise defaults.
@@ -82,11 +91,17 @@ class AvoConfig {
       }
     }
 
+    final tlsMap = json['syncTls'] as Map<String, dynamic>?;
+    final syncTlsCertPath = tlsMap?['certPath'] as String?;
+    final syncTlsKeyPath = tlsMap?['keyPath'] as String?;
+
     return AvoConfig(
       categories: categories,
       syncPort: syncPort,
       syncInterval: syncInterval,
       categoryChips: categoryChips,
+      syncTlsCertPath: syncTlsCertPath,
+      syncTlsKeyPath: syncTlsKeyPath,
     );
   }
 
@@ -99,6 +114,10 @@ class AvoConfig {
         'intervalSeconds': syncInterval,
       },
       'categoryChips': categoryChips,
+      'syncTls': {
+        if (syncTlsCertPath != null) 'certPath': syncTlsCertPath,
+        if (syncTlsKeyPath != null) 'keyPath': syncTlsKeyPath,
+      },
     };
   }
 
@@ -116,11 +135,15 @@ class AvoConfig {
     int? syncPort,
     int? syncInterval,
     Map<String, List<String>>? categoryChips,
+    String? syncTlsCertPath,
+    String? syncTlsKeyPath,
   }) =>
       AvoConfig(
         categories: categories ?? this.categories,
         syncPort: syncPort ?? this.syncPort,
         syncInterval: syncInterval ?? this.syncInterval,
         categoryChips: categoryChips ?? this.categoryChips,
+        syncTlsCertPath: syncTlsCertPath ?? this.syncTlsCertPath,
+        syncTlsKeyPath: syncTlsKeyPath ?? this.syncTlsKeyPath,
       );
 }

--- a/mcp/lib/services/pairing_service.dart
+++ b/mcp/lib/services/pairing_service.dart
@@ -7,8 +7,9 @@
 /// ### POST /api/sync/pair/start
 /// - Generates a random 6-digit passcode (valid 5 minutes)
 /// - Generates an ephemeral X25519 keypair
-/// - Returns {passcode, serverPubKey, expiresIn}
-/// - Passcode is displayed to user on server console
+/// - Returns {serverPubKey, expiresIn}
+/// - Passcode is ONLY displayed on the server console (not sent to phone)
+/// - User must manually enter the passcode on the phone
 ///
 /// ### POST /api/sync/pair/confirm
 /// - Accepts {phonePubKey, hmacProof}
@@ -72,7 +73,11 @@ class PairingService {
   /// POST /api/sync/pair/start
   ///
   /// Generates a 6-digit passcode and ephemeral X25519 keypair.
-  /// Returns {passcode, serverPubKey, expiresIn}.
+  /// Returns {serverPubKey, expiresIn}.
+  ///
+  /// The passcode is only displayed on the server console — it is NOT
+  /// sent to the phone. The user must manually key it in on the phone
+  /// for multi-level authentication.
   Future<Map<String, dynamic>> startPairing(String nodeId) async {
     // Clean up expired handshakes
     _handshakes.removeWhere((_, state) => state.isExpired);
@@ -88,14 +93,14 @@ class PairingService {
     );
     _handshakes[nodeId] = state;
 
-    // Log passcode to console for user to see
+    // Log passcode to console — the ONLY place it is shown
     stderr.writeln('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
     stderr.writeln('  PAIRING CODE: $passcode');
-    stderr.writeln('  Valid for 5 minutes. Confirm on phone.');
+    stderr.writeln('  Enter this code on your phone to pair.');
+    stderr.writeln('  Valid for 5 minutes.');
     stderr.writeln('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
 
     return {
-      'passcode': passcode,
       'serverPubKey': base64Encode(keyPair.publicKey),
       'expiresIn': 300,
     };

--- a/mcp/lib/services/pairing_service.dart
+++ b/mcp/lib/services/pairing_service.dart
@@ -103,12 +103,13 @@ class PairingService {
 
   /// POST /api/sync/pair/confirm
   ///
-  /// Accepts {phonePubKey, hmacProof}.
+  /// Accepts {phonePubKey, hmacProof, origin?}.
   /// Derives shared secret, stores pairing key, returns {success, error?}.
   Future<Map<String, dynamic>> confirmPairing({
     required String nodeId,
     required String phonePubKeyBase64,
     required String hmacProofBase64,
+    String? origin,
   }) async {
     final state = _handshakes[nodeId];
     if (state == null || state.isExpired) {
@@ -134,12 +135,13 @@ class PairingService {
     // Derive pairing key: HMAC-SHA256(sharedSecret, "avodah-pair-v1")
     final pairingKey = await derivePairingKey(sharedSecret);
 
-    // Store pairing: phone's public key + pairing key
+    // Store pairing: phone's public key + pairing key + origin for CORS
     await db.into(db.pairedDevices).insertOnConflictUpdate(
           PairedDevicesCompanion.insert(
             id: nodeId,
             publicKey: Uint8List.fromList(phonePubKey),
             privateKey: Value(Uint8List.fromList(pairingKey)),
+            origin: Value(origin),
             created: DateTime.now().millisecondsSinceEpoch,
             lastSeen: Value(DateTime.now().millisecondsSinceEpoch),
           ),

--- a/mcp/lib/services/pairing_service.dart
+++ b/mcp/lib/services/pairing_service.dart
@@ -1,0 +1,218 @@
+/// Server-side pairing service for secure sync.
+///
+/// Implements the Anytype-inspired passcode + X25519 key exchange:
+///
+/// ## Pairing Flow
+///
+/// ### POST /api/sync/pair/start
+/// - Generates a random 6-digit passcode (valid 5 minutes)
+/// - Generates an ephemeral X25519 keypair
+/// - Returns {passcode, serverPubKey, expiresIn}
+/// - Passcode is displayed to user on server console
+///
+/// ### POST /api/sync/pair/confirm
+/// - Accepts {phonePubKey, hmacProof}
+/// - phonePubKey: base64 X25519 public key from phone
+/// - hmacProof: base64 HMAC-SHA256(passcode, phonePubKey)
+/// - Verifies HMAC proof against stored passcode
+/// - Derives shared secret via X25519
+/// - Stores pairing key (HMAC of shared secret) in paired_devices table
+///
+/// ## Subsequent Sync
+///
+/// All /api/sync/* requests must include:
+/// - X-Av-Pair-Token: <base64(HMAC-SHA256(pairingKey, "avodah-sync-v1"))>
+///
+/// Server verifies token against stored pairing key before accepting requests.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart' hide KeyPair;
+import 'package:avodah_core/avodah_core.dart';
+import 'package:drift/drift.dart' show Value;
+
+/// In-memory state for an in-progress pairing handshake.
+class _PairingState {
+  final String passcode;
+  final List<int> serverPrivateKey; // ephemeral X25519 private key
+  final List<int> serverPublicKey; // ephemeral X25519 public key
+  final DateTime expiresAt;
+
+  _PairingState({
+    required this.passcode,
+    required this.serverPrivateKey,
+    required this.serverPublicKey,
+    required this.expiresAt,
+  });
+
+  bool get isExpired => DateTime.now().isAfter(expiresAt);
+}
+
+/// Manages the pairing handshake for secure sync.
+class PairingService {
+  final AppDatabase db;
+
+  /// In-memory pairing handshakes keyed by nodeId.
+  final Map<String, _PairingState> _handshakes = {};
+
+  PairingService({required this.db});
+
+  /// GET /api/sync/status
+  ///
+  /// Returns whether the server needs pairing.
+  Future<Map<String, dynamic>> getStatus() async {
+    final paired = await db.select(db.pairedDevices).get();
+    return {'needsPairing': paired.isEmpty};
+  }
+
+  /// POST /api/sync/pair/start
+  ///
+  /// Generates a 6-digit passcode and ephemeral X25519 keypair.
+  /// Returns {passcode, serverPubKey, expiresIn}.
+  Future<Map<String, dynamic>> startPairing(String nodeId) async {
+    // Clean up expired handshakes
+    _handshakes.removeWhere((_, state) => state.isExpired);
+
+    final passcode = generateSixDigitCode();
+    final keyPair = await generateKeyPair();
+
+    final state = _PairingState(
+      passcode: passcode,
+      serverPrivateKey: keyPair.privateKey,
+      serverPublicKey: keyPair.publicKey,
+      expiresAt: DateTime.now().add(const Duration(minutes: 5)),
+    );
+    _handshakes[nodeId] = state;
+
+    // Log passcode to console for user to see
+    stderr.writeln('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    stderr.writeln('  PAIRING CODE: $passcode');
+    stderr.writeln('  Valid for 5 minutes. Confirm on phone.');
+    stderr.writeln('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+
+    return {
+      'passcode': passcode,
+      'serverPubKey': base64Encode(keyPair.publicKey),
+      'expiresIn': 300,
+    };
+  }
+
+  /// POST /api/sync/pair/confirm
+  ///
+  /// Accepts {phonePubKey, hmacProof}.
+  /// Derives shared secret, stores pairing key, returns {success, error?}.
+  Future<Map<String, dynamic>> confirmPairing({
+    required String nodeId,
+    required String phonePubKeyBase64,
+    required String hmacProofBase64,
+  }) async {
+    final state = _handshakes[nodeId];
+    if (state == null || state.isExpired) {
+      return {'success': false, 'error': 'Pairing timeout — restart from phone.'};
+    }
+
+    final phonePubKey = base64Decode(phonePubKeyBase64);
+    final hmacProof = base64Decode(hmacProofBase64);
+
+    // Verify HMAC: HMAC-SHA256(passcode, phonePubKey)
+    final expectedHmac = await _computeHmacPasscode(state.passcode, phonePubKey);
+    if (!_constantTimeEquals(hmacProof, expectedHmac)) {
+      return {'success': false, 'error': 'Invalid pairing proof.'};
+    }
+
+    // Derive shared secret via X25519
+    final serverKeyPair = KeyPair(
+      publicKey: state.serverPublicKey,
+      privateKey: state.serverPrivateKey,
+    );
+    final sharedSecret = await deriveSharedSecret(serverKeyPair, phonePubKey);
+
+    // Derive pairing key: HMAC-SHA256(sharedSecret, "avodah-pair-v1")
+    final pairingKey = await derivePairingKey(sharedSecret);
+
+    // Store pairing: phone's public key + pairing key
+    await db.into(db.pairedDevices).insertOnConflictUpdate(
+          PairedDevicesCompanion.insert(
+            id: nodeId,
+            publicKey: Uint8List.fromList(phonePubKey),
+            privateKey: Value(Uint8List.fromList(pairingKey)),
+            created: DateTime.now().millisecondsSinceEpoch,
+            lastSeen: Value(DateTime.now().millisecondsSinceEpoch),
+          ),
+        );
+
+    _handshakes.remove(nodeId);
+
+    stderr.writeln('Device paired successfully: $nodeId');
+
+    return {'success': true};
+  }
+
+  /// Verifies an X-Av-Pair-Token header from a paired device.
+  ///
+  /// Returns true if the token is valid for this device.
+  Future<bool> verifyPairToken(String nodeId, String tokenBase64) async {
+    final device = await (db.select(db.pairedDevices)
+          ..where((d) => d.id.equals(nodeId)))
+        .getSingleOrNull();
+
+    if (device == null) return false;
+
+    // Pairing key stored in privateKey column
+    final pairingKey = device.privateKey;
+    if (pairingKey == null) return false;
+
+    // Derive expected token: HMAC-SHA256(pairingKey, "avodah-sync-v1")
+    final expectedToken = await generateSyncVerifyCode(pairingKey);
+
+    return verifySyncCode(expectedToken, tokenBase64);
+  }
+
+  /// Returns the stored pairing for a device, or null if not paired.
+  Future<PairedDevice?> getPairedDevice(String nodeId) async {
+    return (db.select(db.pairedDevices)..where((d) => d.id.equals(nodeId)))
+        .getSingleOrNull();
+  }
+
+  /// Revokes pairing for a device.
+  Future<void> revokePairing(String nodeId) async {
+    await (db.delete(db.pairedDevices)..where((d) => d.id.equals(nodeId)))
+        .go();
+    stderr.writeln('Pairing revoked for device: $nodeId');
+  }
+
+  /// Returns all paired devices (for admin/status purposes).
+  Future<List<PairedDevice>> listPairedDevices() async {
+    return db.select(db.pairedDevices).get();
+  }
+
+  // ============================================================
+  // Internal HMAC helpers
+  // ============================================================
+
+  /// Computes HMAC-SHA256(passcode, phonePubKey) for pairing proof verification.
+  Future<Uint8List> _computeHmacPasscode(
+      String passcode, List<int> phonePubKey) async {
+    final hmac = Hmac.sha256();
+    final secretKey = SecretKey(utf8.encode(passcode));
+    final mac = await hmac.calculateMac(
+      Uint8List.fromList(phonePubKey),
+      secretKey: secretKey,
+    );
+    return Uint8List.fromList(mac.bytes);
+  }
+
+  /// Constant-time byte comparison to prevent timing attacks.
+  bool _constantTimeEquals(Uint8List a, Uint8List b) {
+    if (a.length != b.length) return false;
+    int result = 0;
+    for (int i = 0; i < a.length; i++) {
+      result |= a[i] ^ b[i];
+    }
+    return result == 0;
+  }
+}

--- a/mcp/lib/services/sync_api_service.dart
+++ b/mcp/lib/services/sync_api_service.dart
@@ -18,6 +18,7 @@ import 'package:drift/drift.dart' show Value;
 import '../config/avo_config.dart';
 import '../config/paths.dart';
 import 'jira_service.dart';
+import 'pairing_service.dart';
 
 /// Document type identifiers used in sync delta payloads.
 class SyncDocType {
@@ -52,6 +53,9 @@ class SyncApiService {
   /// Paths for config storage (injected to avoid read-only default path on NixOS).
   final AvodahPaths? paths;
 
+  /// Optional pairing service for device authentication.
+  final PairingService? pairingService;
+
   SyncApiService({
     required this.db,
     required this.clock,
@@ -59,6 +63,7 @@ class SyncApiService {
     this.jiraService,
     this.config,
     this.paths,
+    this.pairingService,
   });
 
   /// Routes a sync API request. Returns true if handled.
@@ -72,18 +77,42 @@ class SyncApiService {
       return false;
     }
 
-    // CORS headers
-    request.response.headers.add('Access-Control-Allow-Origin', '*');
-    request.response.headers
-        .add('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    request.response.headers
-        .add('Access-Control-Allow-Headers', 'Content-Type');
+    // Set CORS headers (restricted to paired origin after pairing is established)
+    await _setCorsHeaders(request);
 
     if (method == 'OPTIONS') {
       request.response
         ..statusCode = HttpStatus.ok
         ..close();
       return true;
+    }
+
+    // Auth check for /api/sync/deltas — requires valid X-Av-Pair-Token
+    if (path == '/api/sync/deltas') {
+      final nodeId = request.headers.value('X-Av-Node-Id');
+      final token = request.headers.value('X-Av-Pair-Token');
+
+      if (nodeId == null || token == null) {
+        _jsonResponse(request, HttpStatus.forbidden,
+            {'error': 'Missing X-Av-Node-Id or X-Av-Pair-Token header'});
+        return true;
+      }
+
+      if (pairingService == null) {
+        _jsonResponse(request, HttpStatus.internalServerError,
+            {'error': 'Pairing service not configured'});
+        return true;
+      }
+
+      final isValid = await pairingService!.verifyPairToken(nodeId, token);
+      if (!isValid) {
+        _jsonResponse(request, HttpStatus.forbidden,
+            {'error': 'Invalid or expired pairing token'});
+        return true;
+      }
+
+      // Update lastSeen for the paired device
+      await _updateLastSeen(nodeId);
     }
 
     try {
@@ -669,5 +698,58 @@ class SyncApiService {
       ..headers.contentType = ContentType.json
       ..write(jsonEncode(body))
       ..close();
+  }
+
+  // ============================================================
+  // Auth & CORS helpers
+  // ============================================================
+
+  /// Sets CORS headers for sync endpoints.
+  ///
+  /// After pairing is established, CORS is restricted to the paired device's origin.
+  /// Before pairing, a permissive CORS is set for the pairing endpoints.
+  ///
+  /// Returns the paired device's origin if known, otherwise null.
+  Future<String?> _setCorsHeaders(HttpRequest request) async {
+    final origin = request.headers.value('origin');
+
+    // If pairing service is available, check if we have a paired device
+    String? allowedOrigin;
+    if (pairingService != null && origin != null) {
+      // Try to look up the paired device by nodeId (from X-Av-Node-Id header)
+      final nodeId = request.headers.value('X-Av-Node-Id');
+      if (nodeId != null) {
+        final device = await pairingService!.getPairedDevice(nodeId);
+        if (device != null && device.origin != null) {
+          // If origin matches the stored origin (or is a sub-origin of it), allow it
+          if (origin == device.origin ||
+              origin.startsWith(device.origin!.replaceFirst(RegExp(r'^https?://'), ''))) {
+            allowedOrigin = origin;
+          }
+        }
+      }
+    }
+
+    // Default: allow the origin header value for pairing endpoints
+    // (After pairing, the phone sends the same origin it used during pairing)
+    allowedOrigin ??= origin ?? '*';
+
+    request.response.headers.add(
+        'Access-Control-Allow-Origin', allowedOrigin == '*' ? '*' : allowedOrigin);
+    request.response.headers
+        .add('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    request.response.headers.add('Access-Control-Allow-Headers',
+        'Content-Type, X-Av-Pair-Token, X-Av-Node-Id');
+
+    return allowedOrigin == '*' ? null : allowedOrigin;
+  }
+
+  /// Updates the lastSeen timestamp for a paired device.
+  Future<void> _updateLastSeen(String nodeId) async {
+    await (db.update(db.pairedDevices)
+          ..where((d) => d.id.equals(nodeId)))
+        .write(PairedDevicesCompanion(
+      lastSeen: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
   }
 }

--- a/packages/avodah_core/lib/avodah_core.dart
+++ b/packages/avodah_core/lib/avodah_core.dart
@@ -20,6 +20,10 @@ export 'storage/tables/timer.dart';
 export 'storage/tables/daily_plans.dart';
 export 'storage/tables/day_plan_tasks.dart';
 export 'storage/tables/sync_watermarks.dart';
+export 'storage/tables/paired_devices.dart';
+
+// Crypto
+export 'crypto/pairing.dart';
 
 // CRDT Document types
 export 'documents/daily_plan_document.dart';

--- a/packages/avodah_core/lib/crypto/pairing.dart
+++ b/packages/avodah_core/lib/crypto/pairing.dart
@@ -1,0 +1,114 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+
+/// Key pair for X25519 key exchange
+class KeyPair {
+  final List<int> publicKey;
+  final List<int> privateKey;
+
+  KeyPair({required this.publicKey, required this.privateKey});
+}
+
+/// Derives a pairing key from the shared secret using HMAC-SHA256
+Future<List<int>> _derivePairingKey(List<int> sharedSecret) async {
+  final hmac = Hmac.sha256();
+  final secretKey = SecretKey(sharedSecret);
+  final label = utf8.encode('avodah-pair-v1');
+  final mac = await hmac.calculateMac(
+    label,
+    secretKey: secretKey,
+  );
+  return mac.bytes;
+}
+
+/// Generates a sync verification code using HMAC-SHA256
+Future<String> _generateSyncVerifyCode(List<int> pairingKey) async {
+  final hmac = Hmac.sha256();
+  final secretKey = SecretKey(pairingKey);
+  final label = utf8.encode('avodah-sync-v1');
+  final mac = await hmac.calculateMac(
+    label,
+    secretKey: secretKey,
+  );
+  // Return base64-encoded HMAC tag
+  return base64Encode(mac.bytes);
+}
+
+/// Verifies a sync code in constant time using constant-time comparison
+bool _verifySyncCode(String expectedCode, String actualCode) {
+  // Use constant-time comparison to prevent timing attacks
+  if (expectedCode.length != actualCode.length) return false;
+
+  int result = 0;
+  for (int i = 0; i < expectedCode.length; i++) {
+    result |= expectedCode.codeUnitAt(i) ^ actualCode.codeUnitAt(i);
+  }
+  return result == 0;
+}
+
+/// Generates a cryptographically secure 6-digit code
+String generateSixDigitCode() {
+  final random = Random.secure();
+  // Generate a number between 0 and 999999, padded to 6 digits
+  final value = random.nextInt(1000000);
+  return value.toString().padLeft(6, '0');
+}
+
+/// Generates a new X25519 key pair for secure pairing
+Future<KeyPair> generateKeyPair() async {
+  final algorithm = X25519();
+  final keyPair = await algorithm.newKeyPair();
+
+  final publicKeyBytes = await keyPair.extractPublicKey();
+  final privateKeyBytes = await keyPair.extractPrivateKeyBytes();
+
+  return KeyPair(
+    publicKey: publicKeyBytes.bytes,
+    privateKey: privateKeyBytes,
+  );
+}
+
+/// Derives a shared secret from two key pairs using X25519 ECDH
+Future<List<int>> deriveSharedSecret(
+  KeyPair localKeyPair,
+  List<int> remotePublicKey,
+) async {
+  final algorithm = X25519();
+
+  // Create a key pair from the stored private key bytes
+  final localKeyPairData = await algorithm.newKeyPairFromSeed(
+    Uint8List.fromList(localKeyPair.privateKey),
+  );
+
+  // Create a SimplePublicKey from the remote public key
+  final remotePubKey = SimplePublicKey(
+    remotePublicKey,
+    type: KeyPairType.x25519,
+  );
+
+  // Perform ECDH to derive shared secret
+  final sharedSecret = await algorithm.sharedSecretKey(
+    keyPair: localKeyPairData,
+    remotePublicKey: remotePubKey,
+  );
+
+  return sharedSecret.extractBytes();
+}
+
+/// Derives the pairing key from a shared secret (used after ECDH)
+Future<List<int>> derivePairingKey(List<int> sharedSecret) async {
+  return _derivePairingKey(sharedSecret);
+}
+
+/// Generates a sync verification code from a pairing key
+Future<String> generateSyncVerifyCode(List<int> pairingKey) async {
+  return _generateSyncVerifyCode(pairingKey);
+}
+
+/// Verifies a sync code against an expected value
+bool verifySyncCode(String expectedCode, String actualCode) {
+  return _verifySyncCode(expectedCode, actualCode);
+}

--- a/packages/avodah_core/lib/storage/database.dart
+++ b/packages/avodah_core/lib/storage/database.dart
@@ -10,6 +10,7 @@ import 'tables/timer.dart';
 import 'tables/daily_plans.dart';
 import 'tables/day_plan_tasks.dart';
 import 'tables/sync_watermarks.dart';
+import 'tables/paired_devices.dart';
 
 part 'database.g.dart';
 
@@ -30,6 +31,7 @@ part 'database.g.dart';
   DailyPlanEntries,
   DayPlanTasks,
   SyncWatermarks,
+  PairedDevices,
 ])
 class AppDatabase extends _$AppDatabase {
   /// Creates a database with the given executor.
@@ -42,7 +44,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.executor(QueryExecutor executor) : super(executor);
 
   @override
-  int get schemaVersion => 12;
+  int get schemaVersion => 13;
 
   @override
   MigrationStrategy get migration {
@@ -118,6 +120,10 @@ class AppDatabase extends _$AppDatabase {
           } on Exception catch (_) {
             // Column already exists
           }
+        }
+        if (from < 13) {
+          // v13: secure sync — add paired_devices table for secure pairing
+          await m.createTable(pairedDevices);
         }
       },
     );

--- a/packages/avodah_core/lib/storage/database.dart
+++ b/packages/avodah_core/lib/storage/database.dart
@@ -44,7 +44,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.executor(QueryExecutor executor) : super(executor);
 
   @override
-  int get schemaVersion => 13;
+  int get schemaVersion => 14;
 
   @override
   MigrationStrategy get migration {
@@ -124,6 +124,14 @@ class AppDatabase extends _$AppDatabase {
         if (from < 13) {
           // v13: secure sync — add paired_devices table for secure pairing
           await m.createTable(pairedDevices);
+        }
+        if (from < 14) {
+          // v14: secure sync — add origin column to paired_devices for CORS restriction
+          try {
+            await m.addColumn(pairedDevices, pairedDevices.origin);
+          } on Exception catch (_) {
+            // Column may already exist
+          }
         }
       },
     );

--- a/packages/avodah_core/lib/storage/database.g.dart
+++ b/packages/avodah_core/lib/storage/database.g.dart
@@ -7570,6 +7570,15 @@ class $PairedDevicesTable extends PairedDevices
     type: DriftSqlType.blob,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _originMeta = const VerificationMeta('origin');
+  @override
+  late final GeneratedColumn<String> origin = GeneratedColumn<String>(
+    'origin',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _createdMeta = const VerificationMeta(
     'created',
   );
@@ -7597,6 +7606,7 @@ class $PairedDevicesTable extends PairedDevices
     id,
     publicKey,
     privateKey,
+    origin,
     created,
     lastSeen,
   ];
@@ -7629,6 +7639,12 @@ class $PairedDevicesTable extends PairedDevices
       context.handle(
         _privateKeyMeta,
         privateKey.isAcceptableOrUnknown(data['private_key']!, _privateKeyMeta),
+      );
+    }
+    if (data.containsKey('origin')) {
+      context.handle(
+        _originMeta,
+        origin.isAcceptableOrUnknown(data['origin']!, _originMeta),
       );
     }
     if (data.containsKey('created')) {
@@ -7666,6 +7682,10 @@ class $PairedDevicesTable extends PairedDevices
         DriftSqlType.blob,
         data['${effectivePrefix}private_key'],
       ),
+      origin: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}origin'],
+      ),
       created: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}created'],
@@ -7687,12 +7707,14 @@ class PairedDevice extends DataClass implements Insertable<PairedDevice> {
   final String id;
   final Uint8List publicKey;
   final Uint8List? privateKey;
+  final String? origin;
   final int created;
   final int? lastSeen;
   const PairedDevice({
     required this.id,
     required this.publicKey,
     this.privateKey,
+    this.origin,
     required this.created,
     this.lastSeen,
   });
@@ -7703,6 +7725,9 @@ class PairedDevice extends DataClass implements Insertable<PairedDevice> {
     map['public_key'] = Variable<Uint8List>(publicKey);
     if (!nullToAbsent || privateKey != null) {
       map['private_key'] = Variable<Uint8List>(privateKey);
+    }
+    if (!nullToAbsent || origin != null) {
+      map['origin'] = Variable<String>(origin);
     }
     map['created'] = Variable<int>(created);
     if (!nullToAbsent || lastSeen != null) {
@@ -7718,6 +7743,9 @@ class PairedDevice extends DataClass implements Insertable<PairedDevice> {
       privateKey: privateKey == null && nullToAbsent
           ? const Value.absent()
           : Value(privateKey),
+      origin: origin == null && nullToAbsent
+          ? const Value.absent()
+          : Value(origin),
       created: Value(created),
       lastSeen: lastSeen == null && nullToAbsent
           ? const Value.absent()
@@ -7734,6 +7762,7 @@ class PairedDevice extends DataClass implements Insertable<PairedDevice> {
       id: serializer.fromJson<String>(json['id']),
       publicKey: serializer.fromJson<Uint8List>(json['publicKey']),
       privateKey: serializer.fromJson<Uint8List?>(json['privateKey']),
+      origin: serializer.fromJson<String?>(json['origin']),
       created: serializer.fromJson<int>(json['created']),
       lastSeen: serializer.fromJson<int?>(json['lastSeen']),
     );
@@ -7745,6 +7774,7 @@ class PairedDevice extends DataClass implements Insertable<PairedDevice> {
       'id': serializer.toJson<String>(id),
       'publicKey': serializer.toJson<Uint8List>(publicKey),
       'privateKey': serializer.toJson<Uint8List?>(privateKey),
+      'origin': serializer.toJson<String?>(origin),
       'created': serializer.toJson<int>(created),
       'lastSeen': serializer.toJson<int?>(lastSeen),
     };
@@ -7754,12 +7784,14 @@ class PairedDevice extends DataClass implements Insertable<PairedDevice> {
     String? id,
     Uint8List? publicKey,
     Value<Uint8List?> privateKey = const Value.absent(),
+    Value<String?> origin = const Value.absent(),
     int? created,
     Value<int?> lastSeen = const Value.absent(),
   }) => PairedDevice(
     id: id ?? this.id,
     publicKey: publicKey ?? this.publicKey,
     privateKey: privateKey.present ? privateKey.value : this.privateKey,
+    origin: origin.present ? origin.value : this.origin,
     created: created ?? this.created,
     lastSeen: lastSeen.present ? lastSeen.value : this.lastSeen,
   );
@@ -7770,6 +7802,7 @@ class PairedDevice extends DataClass implements Insertable<PairedDevice> {
       privateKey: data.privateKey.present
           ? data.privateKey.value
           : this.privateKey,
+      origin: data.origin.present ? data.origin.value : this.origin,
       created: data.created.present ? data.created.value : this.created,
       lastSeen: data.lastSeen.present ? data.lastSeen.value : this.lastSeen,
     );
@@ -7781,6 +7814,7 @@ class PairedDevice extends DataClass implements Insertable<PairedDevice> {
           ..write('id: $id, ')
           ..write('publicKey: $publicKey, ')
           ..write('privateKey: $privateKey, ')
+          ..write('origin: $origin, ')
           ..write('created: $created, ')
           ..write('lastSeen: $lastSeen')
           ..write(')'))
@@ -7792,6 +7826,7 @@ class PairedDevice extends DataClass implements Insertable<PairedDevice> {
     id,
     $driftBlobEquality.hash(publicKey),
     $driftBlobEquality.hash(privateKey),
+    origin,
     created,
     lastSeen,
   );
@@ -7802,6 +7837,7 @@ class PairedDevice extends DataClass implements Insertable<PairedDevice> {
           other.id == this.id &&
           $driftBlobEquality.equals(other.publicKey, this.publicKey) &&
           $driftBlobEquality.equals(other.privateKey, this.privateKey) &&
+          other.origin == this.origin &&
           other.created == this.created &&
           other.lastSeen == this.lastSeen);
 }
@@ -7810,6 +7846,7 @@ class PairedDevicesCompanion extends UpdateCompanion<PairedDevice> {
   final Value<String> id;
   final Value<Uint8List> publicKey;
   final Value<Uint8List?> privateKey;
+  final Value<String?> origin;
   final Value<int> created;
   final Value<int?> lastSeen;
   final Value<int> rowid;
@@ -7817,6 +7854,7 @@ class PairedDevicesCompanion extends UpdateCompanion<PairedDevice> {
     this.id = const Value.absent(),
     this.publicKey = const Value.absent(),
     this.privateKey = const Value.absent(),
+    this.origin = const Value.absent(),
     this.created = const Value.absent(),
     this.lastSeen = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -7825,6 +7863,7 @@ class PairedDevicesCompanion extends UpdateCompanion<PairedDevice> {
     required String id,
     required Uint8List publicKey,
     this.privateKey = const Value.absent(),
+    this.origin = const Value.absent(),
     required int created,
     this.lastSeen = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -7835,6 +7874,7 @@ class PairedDevicesCompanion extends UpdateCompanion<PairedDevice> {
     Expression<String>? id,
     Expression<Uint8List>? publicKey,
     Expression<Uint8List>? privateKey,
+    Expression<String>? origin,
     Expression<int>? created,
     Expression<int>? lastSeen,
     Expression<int>? rowid,
@@ -7843,6 +7883,7 @@ class PairedDevicesCompanion extends UpdateCompanion<PairedDevice> {
       if (id != null) 'id': id,
       if (publicKey != null) 'public_key': publicKey,
       if (privateKey != null) 'private_key': privateKey,
+      if (origin != null) 'origin': origin,
       if (created != null) 'created': created,
       if (lastSeen != null) 'last_seen': lastSeen,
       if (rowid != null) 'rowid': rowid,
@@ -7853,6 +7894,7 @@ class PairedDevicesCompanion extends UpdateCompanion<PairedDevice> {
     Value<String>? id,
     Value<Uint8List>? publicKey,
     Value<Uint8List?>? privateKey,
+    Value<String?>? origin,
     Value<int>? created,
     Value<int?>? lastSeen,
     Value<int>? rowid,
@@ -7861,6 +7903,7 @@ class PairedDevicesCompanion extends UpdateCompanion<PairedDevice> {
       id: id ?? this.id,
       publicKey: publicKey ?? this.publicKey,
       privateKey: privateKey ?? this.privateKey,
+      origin: origin ?? this.origin,
       created: created ?? this.created,
       lastSeen: lastSeen ?? this.lastSeen,
       rowid: rowid ?? this.rowid,
@@ -7878,6 +7921,9 @@ class PairedDevicesCompanion extends UpdateCompanion<PairedDevice> {
     }
     if (privateKey.present) {
       map['private_key'] = Variable<Uint8List>(privateKey.value);
+    }
+    if (origin.present) {
+      map['origin'] = Variable<String>(origin.value);
     }
     if (created.present) {
       map['created'] = Variable<int>(created.value);
@@ -7897,6 +7943,7 @@ class PairedDevicesCompanion extends UpdateCompanion<PairedDevice> {
           ..write('id: $id, ')
           ..write('publicKey: $publicKey, ')
           ..write('privateKey: $privateKey, ')
+          ..write('origin: $origin, ')
           ..write('created: $created, ')
           ..write('lastSeen: $lastSeen, ')
           ..write('rowid: $rowid')
@@ -11486,6 +11533,7 @@ typedef $$PairedDevicesTableCreateCompanionBuilder =
       required String id,
       required Uint8List publicKey,
       Value<Uint8List?> privateKey,
+      Value<String?> origin,
       required int created,
       Value<int?> lastSeen,
       Value<int> rowid,
@@ -11495,6 +11543,7 @@ typedef $$PairedDevicesTableUpdateCompanionBuilder =
       Value<String> id,
       Value<Uint8List> publicKey,
       Value<Uint8List?> privateKey,
+      Value<String?> origin,
       Value<int> created,
       Value<int?> lastSeen,
       Value<int> rowid,
@@ -11521,6 +11570,11 @@ class $$PairedDevicesTableFilterComposer
 
   ColumnFilters<Uint8List> get privateKey => $composableBuilder(
     column: $table.privateKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get origin => $composableBuilder(
+    column: $table.origin,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -11559,6 +11613,11 @@ class $$PairedDevicesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get origin => $composableBuilder(
+    column: $table.origin,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get created => $composableBuilder(
     column: $table.created,
     builder: (column) => ColumnOrderings(column),
@@ -11589,6 +11648,9 @@ class $$PairedDevicesTableAnnotationComposer
     column: $table.privateKey,
     builder: (column) => column,
   );
+
+  GeneratedColumn<String> get origin =>
+      $composableBuilder(column: $table.origin, builder: (column) => column);
 
   GeneratedColumn<int> get created =>
       $composableBuilder(column: $table.created, builder: (column) => column);
@@ -11631,6 +11693,7 @@ class $$PairedDevicesTableTableManager
                 Value<String> id = const Value.absent(),
                 Value<Uint8List> publicKey = const Value.absent(),
                 Value<Uint8List?> privateKey = const Value.absent(),
+                Value<String?> origin = const Value.absent(),
                 Value<int> created = const Value.absent(),
                 Value<int?> lastSeen = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -11638,6 +11701,7 @@ class $$PairedDevicesTableTableManager
                 id: id,
                 publicKey: publicKey,
                 privateKey: privateKey,
+                origin: origin,
                 created: created,
                 lastSeen: lastSeen,
                 rowid: rowid,
@@ -11647,6 +11711,7 @@ class $$PairedDevicesTableTableManager
                 required String id,
                 required Uint8List publicKey,
                 Value<Uint8List?> privateKey = const Value.absent(),
+                Value<String?> origin = const Value.absent(),
                 required int created,
                 Value<int?> lastSeen = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -11654,6 +11719,7 @@ class $$PairedDevicesTableTableManager
                 id: id,
                 publicKey: publicKey,
                 privateKey: privateKey,
+                origin: origin,
                 created: created,
                 lastSeen: lastSeen,
                 rowid: rowid,

--- a/packages/avodah_core/lib/storage/database.g.dart
+++ b/packages/avodah_core/lib/storage/database.g.dart
@@ -7533,6 +7533,378 @@ class SyncWatermarksCompanion extends UpdateCompanion<SyncWatermark> {
   }
 }
 
+class $PairedDevicesTable extends PairedDevices
+    with TableInfo<$PairedDevicesTable, PairedDevice> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PairedDevicesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _publicKeyMeta = const VerificationMeta(
+    'publicKey',
+  );
+  @override
+  late final GeneratedColumn<Uint8List> publicKey = GeneratedColumn<Uint8List>(
+    'public_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.blob,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _privateKeyMeta = const VerificationMeta(
+    'privateKey',
+  );
+  @override
+  late final GeneratedColumn<Uint8List> privateKey = GeneratedColumn<Uint8List>(
+    'private_key',
+    aliasedName,
+    true,
+    type: DriftSqlType.blob,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdMeta = const VerificationMeta(
+    'created',
+  );
+  @override
+  late final GeneratedColumn<int> created = GeneratedColumn<int>(
+    'created',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _lastSeenMeta = const VerificationMeta(
+    'lastSeen',
+  );
+  @override
+  late final GeneratedColumn<int> lastSeen = GeneratedColumn<int>(
+    'last_seen',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    publicKey,
+    privateKey,
+    created,
+    lastSeen,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'paired_devices';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PairedDevice> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('public_key')) {
+      context.handle(
+        _publicKeyMeta,
+        publicKey.isAcceptableOrUnknown(data['public_key']!, _publicKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_publicKeyMeta);
+    }
+    if (data.containsKey('private_key')) {
+      context.handle(
+        _privateKeyMeta,
+        privateKey.isAcceptableOrUnknown(data['private_key']!, _privateKeyMeta),
+      );
+    }
+    if (data.containsKey('created')) {
+      context.handle(
+        _createdMeta,
+        created.isAcceptableOrUnknown(data['created']!, _createdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdMeta);
+    }
+    if (data.containsKey('last_seen')) {
+      context.handle(
+        _lastSeenMeta,
+        lastSeen.isAcceptableOrUnknown(data['last_seen']!, _lastSeenMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  PairedDevice map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PairedDevice(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      publicKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.blob,
+        data['${effectivePrefix}public_key'],
+      )!,
+      privateKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.blob,
+        data['${effectivePrefix}private_key'],
+      ),
+      created: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}created'],
+      )!,
+      lastSeen: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}last_seen'],
+      ),
+    );
+  }
+
+  @override
+  $PairedDevicesTable createAlias(String alias) {
+    return $PairedDevicesTable(attachedDatabase, alias);
+  }
+}
+
+class PairedDevice extends DataClass implements Insertable<PairedDevice> {
+  final String id;
+  final Uint8List publicKey;
+  final Uint8List? privateKey;
+  final int created;
+  final int? lastSeen;
+  const PairedDevice({
+    required this.id,
+    required this.publicKey,
+    this.privateKey,
+    required this.created,
+    this.lastSeen,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['public_key'] = Variable<Uint8List>(publicKey);
+    if (!nullToAbsent || privateKey != null) {
+      map['private_key'] = Variable<Uint8List>(privateKey);
+    }
+    map['created'] = Variable<int>(created);
+    if (!nullToAbsent || lastSeen != null) {
+      map['last_seen'] = Variable<int>(lastSeen);
+    }
+    return map;
+  }
+
+  PairedDevicesCompanion toCompanion(bool nullToAbsent) {
+    return PairedDevicesCompanion(
+      id: Value(id),
+      publicKey: Value(publicKey),
+      privateKey: privateKey == null && nullToAbsent
+          ? const Value.absent()
+          : Value(privateKey),
+      created: Value(created),
+      lastSeen: lastSeen == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastSeen),
+    );
+  }
+
+  factory PairedDevice.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PairedDevice(
+      id: serializer.fromJson<String>(json['id']),
+      publicKey: serializer.fromJson<Uint8List>(json['publicKey']),
+      privateKey: serializer.fromJson<Uint8List?>(json['privateKey']),
+      created: serializer.fromJson<int>(json['created']),
+      lastSeen: serializer.fromJson<int?>(json['lastSeen']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'publicKey': serializer.toJson<Uint8List>(publicKey),
+      'privateKey': serializer.toJson<Uint8List?>(privateKey),
+      'created': serializer.toJson<int>(created),
+      'lastSeen': serializer.toJson<int?>(lastSeen),
+    };
+  }
+
+  PairedDevice copyWith({
+    String? id,
+    Uint8List? publicKey,
+    Value<Uint8List?> privateKey = const Value.absent(),
+    int? created,
+    Value<int?> lastSeen = const Value.absent(),
+  }) => PairedDevice(
+    id: id ?? this.id,
+    publicKey: publicKey ?? this.publicKey,
+    privateKey: privateKey.present ? privateKey.value : this.privateKey,
+    created: created ?? this.created,
+    lastSeen: lastSeen.present ? lastSeen.value : this.lastSeen,
+  );
+  PairedDevice copyWithCompanion(PairedDevicesCompanion data) {
+    return PairedDevice(
+      id: data.id.present ? data.id.value : this.id,
+      publicKey: data.publicKey.present ? data.publicKey.value : this.publicKey,
+      privateKey: data.privateKey.present
+          ? data.privateKey.value
+          : this.privateKey,
+      created: data.created.present ? data.created.value : this.created,
+      lastSeen: data.lastSeen.present ? data.lastSeen.value : this.lastSeen,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PairedDevice(')
+          ..write('id: $id, ')
+          ..write('publicKey: $publicKey, ')
+          ..write('privateKey: $privateKey, ')
+          ..write('created: $created, ')
+          ..write('lastSeen: $lastSeen')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    $driftBlobEquality.hash(publicKey),
+    $driftBlobEquality.hash(privateKey),
+    created,
+    lastSeen,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PairedDevice &&
+          other.id == this.id &&
+          $driftBlobEquality.equals(other.publicKey, this.publicKey) &&
+          $driftBlobEquality.equals(other.privateKey, this.privateKey) &&
+          other.created == this.created &&
+          other.lastSeen == this.lastSeen);
+}
+
+class PairedDevicesCompanion extends UpdateCompanion<PairedDevice> {
+  final Value<String> id;
+  final Value<Uint8List> publicKey;
+  final Value<Uint8List?> privateKey;
+  final Value<int> created;
+  final Value<int?> lastSeen;
+  final Value<int> rowid;
+  const PairedDevicesCompanion({
+    this.id = const Value.absent(),
+    this.publicKey = const Value.absent(),
+    this.privateKey = const Value.absent(),
+    this.created = const Value.absent(),
+    this.lastSeen = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  PairedDevicesCompanion.insert({
+    required String id,
+    required Uint8List publicKey,
+    this.privateKey = const Value.absent(),
+    required int created,
+    this.lastSeen = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       publicKey = Value(publicKey),
+       created = Value(created);
+  static Insertable<PairedDevice> custom({
+    Expression<String>? id,
+    Expression<Uint8List>? publicKey,
+    Expression<Uint8List>? privateKey,
+    Expression<int>? created,
+    Expression<int>? lastSeen,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (publicKey != null) 'public_key': publicKey,
+      if (privateKey != null) 'private_key': privateKey,
+      if (created != null) 'created': created,
+      if (lastSeen != null) 'last_seen': lastSeen,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  PairedDevicesCompanion copyWith({
+    Value<String>? id,
+    Value<Uint8List>? publicKey,
+    Value<Uint8List?>? privateKey,
+    Value<int>? created,
+    Value<int?>? lastSeen,
+    Value<int>? rowid,
+  }) {
+    return PairedDevicesCompanion(
+      id: id ?? this.id,
+      publicKey: publicKey ?? this.publicKey,
+      privateKey: privateKey ?? this.privateKey,
+      created: created ?? this.created,
+      lastSeen: lastSeen ?? this.lastSeen,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (publicKey.present) {
+      map['public_key'] = Variable<Uint8List>(publicKey.value);
+    }
+    if (privateKey.present) {
+      map['private_key'] = Variable<Uint8List>(privateKey.value);
+    }
+    if (created.present) {
+      map['created'] = Variable<int>(created.value);
+    }
+    if (lastSeen.present) {
+      map['last_seen'] = Variable<int>(lastSeen.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PairedDevicesCompanion(')
+          ..write('id: $id, ')
+          ..write('publicKey: $publicKey, ')
+          ..write('privateKey: $privateKey, ')
+          ..write('created: $created, ')
+          ..write('lastSeen: $lastSeen, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -7550,6 +7922,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   );
   late final $DayPlanTasksTable dayPlanTasks = $DayPlanTasksTable(this);
   late final $SyncWatermarksTable syncWatermarks = $SyncWatermarksTable(this);
+  late final $PairedDevicesTable pairedDevices = $PairedDevicesTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -7565,6 +7938,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     dailyPlanEntries,
     dayPlanTasks,
     syncWatermarks,
+    pairedDevices,
   ];
 }
 
@@ -11107,6 +11481,208 @@ typedef $$SyncWatermarksTableProcessedTableManager =
       SyncWatermark,
       PrefetchHooks Function()
     >;
+typedef $$PairedDevicesTableCreateCompanionBuilder =
+    PairedDevicesCompanion Function({
+      required String id,
+      required Uint8List publicKey,
+      Value<Uint8List?> privateKey,
+      required int created,
+      Value<int?> lastSeen,
+      Value<int> rowid,
+    });
+typedef $$PairedDevicesTableUpdateCompanionBuilder =
+    PairedDevicesCompanion Function({
+      Value<String> id,
+      Value<Uint8List> publicKey,
+      Value<Uint8List?> privateKey,
+      Value<int> created,
+      Value<int?> lastSeen,
+      Value<int> rowid,
+    });
+
+class $$PairedDevicesTableFilterComposer
+    extends Composer<_$AppDatabase, $PairedDevicesTable> {
+  $$PairedDevicesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<Uint8List> get publicKey => $composableBuilder(
+    column: $table.publicKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<Uint8List> get privateKey => $composableBuilder(
+    column: $table.privateKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get created => $composableBuilder(
+    column: $table.created,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get lastSeen => $composableBuilder(
+    column: $table.lastSeen,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$PairedDevicesTableOrderingComposer
+    extends Composer<_$AppDatabase, $PairedDevicesTable> {
+  $$PairedDevicesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<Uint8List> get publicKey => $composableBuilder(
+    column: $table.publicKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<Uint8List> get privateKey => $composableBuilder(
+    column: $table.privateKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get created => $composableBuilder(
+    column: $table.created,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get lastSeen => $composableBuilder(
+    column: $table.lastSeen,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$PairedDevicesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $PairedDevicesTable> {
+  $$PairedDevicesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<Uint8List> get publicKey =>
+      $composableBuilder(column: $table.publicKey, builder: (column) => column);
+
+  GeneratedColumn<Uint8List> get privateKey => $composableBuilder(
+    column: $table.privateKey,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get created =>
+      $composableBuilder(column: $table.created, builder: (column) => column);
+
+  GeneratedColumn<int> get lastSeen =>
+      $composableBuilder(column: $table.lastSeen, builder: (column) => column);
+}
+
+class $$PairedDevicesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $PairedDevicesTable,
+          PairedDevice,
+          $$PairedDevicesTableFilterComposer,
+          $$PairedDevicesTableOrderingComposer,
+          $$PairedDevicesTableAnnotationComposer,
+          $$PairedDevicesTableCreateCompanionBuilder,
+          $$PairedDevicesTableUpdateCompanionBuilder,
+          (
+            PairedDevice,
+            BaseReferences<_$AppDatabase, $PairedDevicesTable, PairedDevice>,
+          ),
+          PairedDevice,
+          PrefetchHooks Function()
+        > {
+  $$PairedDevicesTableTableManager(_$AppDatabase db, $PairedDevicesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PairedDevicesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PairedDevicesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PairedDevicesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<Uint8List> publicKey = const Value.absent(),
+                Value<Uint8List?> privateKey = const Value.absent(),
+                Value<int> created = const Value.absent(),
+                Value<int?> lastSeen = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => PairedDevicesCompanion(
+                id: id,
+                publicKey: publicKey,
+                privateKey: privateKey,
+                created: created,
+                lastSeen: lastSeen,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required Uint8List publicKey,
+                Value<Uint8List?> privateKey = const Value.absent(),
+                required int created,
+                Value<int?> lastSeen = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => PairedDevicesCompanion.insert(
+                id: id,
+                publicKey: publicKey,
+                privateKey: privateKey,
+                created: created,
+                lastSeen: lastSeen,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$PairedDevicesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $PairedDevicesTable,
+      PairedDevice,
+      $$PairedDevicesTableFilterComposer,
+      $$PairedDevicesTableOrderingComposer,
+      $$PairedDevicesTableAnnotationComposer,
+      $$PairedDevicesTableCreateCompanionBuilder,
+      $$PairedDevicesTableUpdateCompanionBuilder,
+      (
+        PairedDevice,
+        BaseReferences<_$AppDatabase, $PairedDevicesTable, PairedDevice>,
+      ),
+      PairedDevice,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -11130,4 +11706,6 @@ class $AppDatabaseManager {
       $$DayPlanTasksTableTableManager(_db, _db.dayPlanTasks);
   $$SyncWatermarksTableTableManager get syncWatermarks =>
       $$SyncWatermarksTableTableManager(_db, _db.syncWatermarks);
+  $$PairedDevicesTableTableManager get pairedDevices =>
+      $$PairedDevicesTableTableManager(_db, _db.pairedDevices);
 }

--- a/packages/avodah_core/lib/storage/tables/paired_devices.dart
+++ b/packages/avodah_core/lib/storage/tables/paired_devices.dart
@@ -12,6 +12,9 @@ class PairedDevices extends Table {
   // Optional encrypted private key reference (for key recovery)
   BlobColumn get privateKey => blob().nullable()();
 
+  // Origin (e.g. "https://100.64.0.1:9847") for CORS restriction
+  TextColumn get origin => text().nullable()();
+
   // Timestamps
   IntColumn get created => integer()(); // Unix ms
   IntColumn get lastSeen => integer().nullable()(); // Unix ms

--- a/packages/avodah_core/lib/storage/tables/paired_devices.dart
+++ b/packages/avodah_core/lib/storage/tables/paired_devices.dart
@@ -1,0 +1,21 @@
+import 'package:drift/drift.dart';
+
+/// Paired devices table - stores paired device public keys for secure sync
+/// Used during the pairing handshake to establish trusted connections
+class PairedDevices extends Table {
+  // Core identification
+  TextColumn get id => text()();
+
+  // Public key for this device (used for key exchange)
+  BlobColumn get publicKey => blob()();
+
+  // Optional encrypted private key reference (for key recovery)
+  BlobColumn get privateKey => blob().nullable()();
+
+  // Timestamps
+  IntColumn get created => integer()(); // Unix ms
+  IntColumn get lastSeen => integer().nullable()(); // Unix ms
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/packages/avodah_core/pubspec.yaml
+++ b/packages/avodah_core/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   uuid: ^4.5.1
   collection: ^1.19.1
 
+  # Cryptography for secure sync pairing
+  cryptography: ^2.7.0
+
   # Immutable Data
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -48,6 +48,8 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
   BoardProvider? _boardProvider;
   FocusProvider? _focusProvider;
   Timer? _syncTimer;
+  bool _pairingInProgress = false;
+  final _navigatorKey = GlobalKey<NavigatorState>();
 
   @override
   void initState() {
@@ -93,8 +95,10 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
     );
     await crdtSyncService.loadPersistedState();
 
-    // Agent workflow API
-    final apiClient = AgentApiClient(baseUrl: httpBaseUrl);
+    // Agent workflow API — inject pairing credentials for authenticated proxy
+    final apiClient = AgentApiClient(baseUrl: httpBaseUrl)
+      ..pairingToken = cryptoSyncService.pairingToken
+      ..nodeId = nodeId;
     final reviewProvider = ReviewProvider(apiClient);
     reviewProvider.startAutoRefresh();
 
@@ -175,8 +179,10 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
     if (fingerprint == null) return false;
 
     if (!mounted) return false;
+    final navContext = _navigatorKey.currentContext;
+    if (navContext == null) return false;
     final approved = await showDialog<bool>(
-      context: context,
+      context: navContext,
       barrierDismissible: false,
       builder: (ctx) => AlertDialog(
         icon: const Icon(Icons.security, color: Colors.amber, size: 48),
@@ -232,35 +238,47 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
 
   /// Called when sync reports needsPairing:true or HTTP 403.
   Future<void> _onNeedsPairing() async {
+    // Guard against re-entrant calls from the periodic sync timer
+    if (_pairingInProgress) return;
     if (!mounted) return;
     final crypto = _cryptoSyncService;
     final crdt = _crdtSyncService;
     if (crypto == null || crdt == null) return;
 
-    // Handle pending cert approval if any
-    await _handlePendingCertApproval();
+    _pairingInProgress = true;
+    try {
+      // Handle pending cert approval if any
+      await _handlePendingCertApproval();
 
-    final nodeId = await CrdtSyncService.getOrCreateNodeId();
-    if (!mounted) return;
+      final nodeId = await CrdtSyncService.getOrCreateNodeId();
+      if (!mounted) return;
 
-    // Push the pairing screen as a blocking route
-    final result = await Navigator.of(context).push<bool>(
-      MaterialPageRoute(
-        builder: (_) => PairingScreen(
-          args: PairingScreenArgs(
-            cryptoClient: crypto,
-            nodeId: nodeId,
+      final nav = _navigatorKey.currentState;
+      if (nav == null) return;
+
+      // Push the pairing screen as a blocking route
+      final result = await nav.push<bool>(
+        MaterialPageRoute(
+          builder: (_) => PairingScreen(
+            args: PairingScreenArgs(
+              cryptoClient: crypto,
+              nodeId: nodeId,
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    if (!mounted) return;
+      if (!mounted) return;
 
-    if (result == true) {
-      // Pairing succeeded — reload persisted state and trigger sync
-      await crdt.loadPersistedState();
-      await _syncAndRefresh();
+      if (result == true) {
+        // Pairing succeeded — reload persisted state and trigger sync
+        await crdt.loadPersistedState();
+        // Update API client with new pairing token
+        _apiClient?.pairingToken = crypto.pairingToken;
+        await _syncAndRefresh();
+      }
+    } finally {
+      _pairingInProgress = false;
     }
   }
 
@@ -283,6 +301,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      navigatorKey: _navigatorKey,
       title: 'Avodah',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
@@ -380,12 +399,14 @@ class _HomeShellState extends State<_HomeShell> {
               dashboardProvider: widget.dashboardProvider,
               focusProvider: widget.focusProvider,
               deploymentProvider: widget.deploymentProvider,
+              crdtSyncService: widget.crdtSyncService,
             ),
           DashboardScreen(
             dashboardProvider: widget.dashboardProvider,
             writeService: widget.writeService,
             apiClient: widget.apiClient,
             onPushDeltas: widget.onPushDeltas,
+            crdtSyncService: widget.crdtSyncService,
           ),
           Scaffold(
             appBar: AppBar(

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -6,12 +6,14 @@ import 'package:flutter/material.dart';
 import 'screens/dashboard_screen.dart';
 import 'screens/deployment_screen.dart';
 import 'screens/kanban_board_screen.dart';
+import 'screens/pairing_screen.dart';
 import 'screens/review_queue_screen.dart';
 import 'screens/team_browser_screen.dart';
 import 'screens/timers_screen.dart';
 import 'services/agent_api_client.dart';
 import 'services/board_provider.dart';
 import 'services/crdt_sync_service.dart';
+import 'services/crypto_sync_service.dart';
 import 'services/deployment_provider.dart';
 import 'services/focus_provider.dart';
 import 'services/local_dashboard_provider.dart';
@@ -38,6 +40,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
   LocalDashboardProvider? _dashboardProvider;
   LocalWriteService? _writeService;
   CrdtSyncService? _crdtSyncService;
+  CryptoSyncService? _cryptoSyncService;
   AgentApiClient? _apiClient;
   ReviewProvider? _reviewProvider;
   DeploymentProvider? _deploymentProvider;
@@ -72,12 +75,23 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
     // Load stored server URL (already HTTP format)
     final httpBaseUrl = await SettingsScreen.loadServerUrl();
 
-    // CRDT sync service pulls deltas from desktop via HTTP
+    // TLS-capable HTTP client with certificate verification
+    final cryptoSyncService = CryptoSyncService(
+      baseUrl: httpBaseUrl,
+      nodeId: nodeId,
+    );
+    await cryptoSyncService.loadPersistedState();
+
+    // CRDT sync service with TLS + pairing integration
     final crdtSyncService = CrdtSyncService(
       baseUrl: httpBaseUrl,
       db: db,
       clock: clock,
+      cryptoClient: cryptoSyncService,
+      nodeId: nodeId,
+      onNeedsPairing: _onNeedsPairing,
     );
+    await crdtSyncService.loadPersistedState();
 
     // Agent workflow API
     final apiClient = AgentApiClient(baseUrl: httpBaseUrl);
@@ -103,6 +117,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
       _dashboardProvider = dashboardProvider;
       _writeService = writeService;
       _crdtSyncService = crdtSyncService;
+      _cryptoSyncService = cryptoSyncService;
       _apiClient = apiClient;
       _reviewProvider = reviewProvider;
       _deploymentProvider = deploymentProvider;
@@ -149,6 +164,106 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
     }
   }
 
+  /// Shows the certificate approval dialog if a cert is pending approval.
+  ///
+  /// Returns true if approved, false if rejected.
+  Future<bool> _handlePendingCertApproval() async {
+    final crypto = _cryptoSyncService;
+    if (crypto == null) return false;
+
+    final fingerprint = crypto.checkPendingCertFingerprint();
+    if (fingerprint == null) return false;
+
+    if (!mounted) return false;
+    final approved = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        icon: const Icon(Icons.security, color: Colors.amber, size: 48),
+        title: const Text('Certificate Not Trusted'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'The server\'s TLS certificate could not be verified. '
+              'This may happen with self-signed certificates.',
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'SHA-256 Fingerprint:',
+              style: TextStyle(fontWeight: FontWeight.w500),
+            ),
+            const SizedBox(height: 4),
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Colors.grey.shade100,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                fingerprint,
+                style: const TextStyle(fontFamily: 'monospace', fontSize: 10),
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Reject'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Approve'),
+          ),
+        ],
+      ),
+    );
+
+    final result = approved ?? false;
+    if (result) {
+      await crypto.approveCert(fingerprint);
+    } else {
+      crypto.rejectCert();
+    }
+    return result;
+  }
+
+  /// Called when sync reports needsPairing:true or HTTP 403.
+  Future<void> _onNeedsPairing() async {
+    if (!mounted) return;
+    final crypto = _cryptoSyncService;
+    final crdt = _crdtSyncService;
+    if (crypto == null || crdt == null) return;
+
+    // Handle pending cert approval if any
+    await _handlePendingCertApproval();
+
+    final nodeId = await CrdtSyncService.getOrCreateNodeId();
+    if (!mounted) return;
+
+    // Push the pairing screen as a blocking route
+    final result = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => PairingScreen(
+          args: PairingScreenArgs(
+            cryptoClient: crypto,
+            nodeId: nodeId,
+          ),
+        ),
+      ),
+    );
+
+    if (!mounted) return;
+
+    if (result == true) {
+      // Pairing succeeded — reload persisted state and trigger sync
+      await crdt.loadPersistedState();
+      await _syncAndRefresh();
+    }
+  }
+
   @override
   void dispose() {
     _syncTimer?.cancel();
@@ -159,6 +274,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
     _reviewProvider?.dispose();
     _apiClient?.dispose();
     _crdtSyncService?.dispose();
+    _cryptoSyncService?.dispose();
     _dashboardProvider?.dispose();
     _db?.close();
     super.dispose();

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -309,6 +309,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp> {
               boardProvider: _boardProvider!,
               focusProvider: _focusProvider,
               onPushDeltas: _pushDeltas,
+              crdtSyncService: _crdtSyncService,
             ),
     );
   }
@@ -325,6 +326,7 @@ class _HomeShell extends StatefulWidget {
   final BoardProvider boardProvider;
   final FocusProvider? focusProvider;
   final Future<void> Function(List<Map<String, dynamic>>)? onPushDeltas;
+  final CrdtSyncService? crdtSyncService;
 
   const _HomeShell({
     required this.dashboardProvider,
@@ -336,6 +338,7 @@ class _HomeShell extends StatefulWidget {
     required this.boardProvider,
     this.focusProvider,
     this.onPushDeltas,
+    this.crdtSyncService,
   });
 
   @override
@@ -400,7 +403,7 @@ class _HomeShellState extends State<_HomeShell> {
                   onPressed: () => Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => const SettingsScreen()),
+                        builder: (_) => SettingsScreen(crdtSyncService: widget.crdtSyncService)),
                   ),
                 ),
               ],
@@ -426,7 +429,7 @@ class _HomeShellState extends State<_HomeShell> {
                   onPressed: () => Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => const SettingsScreen()),
+                        builder: (_) => SettingsScreen(crdtSyncService: widget.crdtSyncService)),
                   ),
                 ),
                 IconButton(
@@ -456,7 +459,7 @@ class _HomeShellState extends State<_HomeShell> {
                   onPressed: () => Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => const SettingsScreen()),
+                        builder: (_) => SettingsScreen(crdtSyncService: widget.crdtSyncService)),
                   ),
                 ),
                 IconButton(

--- a/phone/lib/screens/dashboard_screen.dart
+++ b/phone/lib/screens/dashboard_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/snapshot.dart';
 import '../services/local_dashboard_provider.dart';
 import '../services/local_write_service.dart';
-import '../services/crdt_sync_service.dart' show SyncConnectionState;
+import '../services/crdt_sync_service.dart' show CrdtSyncService, SyncConnectionState;
 import '../services/agent_api_client.dart';
 import '../settings/settings_screen.dart';
 import '../widgets/connection_indicator.dart';
@@ -24,12 +24,15 @@ class DashboardScreen extends StatefulWidget {
   /// Fire-and-forget — errors are handled by the caller.
   final Future<void> Function(List<Map<String, dynamic>> deltas)? onPushDeltas;
 
+  final CrdtSyncService? crdtSyncService;
+
   const DashboardScreen({
     super.key,
     required this.dashboardProvider,
     required this.writeService,
     this.apiClient,
     this.onPushDeltas,
+    this.crdtSyncService,
   });
 
   @override
@@ -328,7 +331,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
             onPressed: () async {
               await Navigator.push<bool>(
                 context,
-                MaterialPageRoute(builder: (_) => const SettingsScreen()),
+                MaterialPageRoute(builder: (_) => SettingsScreen(crdtSyncService: widget.crdtSyncService)),
               );
             },
           ),

--- a/phone/lib/screens/kanban_board_screen.dart
+++ b/phone/lib/screens/kanban_board_screen.dart
@@ -38,6 +38,7 @@ class KanbanBoardScreen extends StatefulWidget {
   final LocalDashboardProvider dashboardProvider;
   final FocusProvider? focusProvider;
   final DeploymentProvider? deploymentProvider;
+  final CrdtSyncService? crdtSyncService;
 
   const KanbanBoardScreen({
     super.key,
@@ -45,6 +46,7 @@ class KanbanBoardScreen extends StatefulWidget {
     required this.dashboardProvider,
     this.focusProvider,
     this.deploymentProvider,
+    this.crdtSyncService,
   });
 
   @override
@@ -167,7 +169,7 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
             icon: const Icon(Icons.settings),
             onPressed: () => Navigator.push(
               context,
-              MaterialPageRoute(builder: (_) => const SettingsScreen()),
+              MaterialPageRoute(builder: (_) => SettingsScreen(crdtSyncService: widget.crdtSyncService)),
             ),
           ),
           IconButton(

--- a/phone/lib/screens/pairing_screen.dart
+++ b/phone/lib/screens/pairing_screen.dart
@@ -1,0 +1,487 @@
+/// Pairing screen for establishing secure sync with the Avodah server.
+///
+/// Displayed when `/api/sync/status` returns `needsPairing: true`.
+///
+/// Flow:
+/// 1. [PairingScreen] checks pairing status
+/// 2. If unpaired, initiates pairing via [PhonePairingService.startPairing]
+/// 3. Displays the server's 6-digit passcode + TLS fingerprint for verification
+/// 4. User confirms on phone after verifying match on server screen
+/// 5. [PhonePairingService.confirmPairing] completes the handshake
+/// 6. On success, navigates back to resume sync
+///
+/// AC2: Phone app shows "Pair with Server" screen when needsPairing:true
+/// AC8: If self-signed cert not approved, phone shows cert fingerprint dialog
+library;
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+import '../services/crypto_sync_service.dart';
+import '../services/pairing_service.dart';
+
+/// Arguments for [PairingScreen].
+class PairingScreenArgs {
+  final CryptoSyncService cryptoClient;
+  final String nodeId;
+
+  const PairingScreenArgs({
+    required this.cryptoClient,
+    required this.nodeId,
+  });
+}
+
+/// Pairing screen widget.
+class PairingScreen extends StatefulWidget {
+  final PairingScreenArgs args;
+
+  const PairingScreen({super.key, required this.args});
+
+  @override
+  State<PairingScreen> createState() => _PairingScreenState();
+}
+
+class _PairingScreenState extends State<PairingScreen> {
+  late final PhonePairingService _pairingService;
+
+  /// Pairing state machine states.
+  static const _kStateLoading = 'loading';
+  static const _kStateShowPasscode = 'show_passcode';
+  static const _kStatePairing = 'pairing';
+  static const _kStateError = 'error';
+  static const _kStateSuccess = 'success';
+
+  String _state = _kStateLoading;
+  String? _errorMessage;
+
+  // Passcode info (populated after startPairing)
+  String? _passcode;
+  String? _serverFingerprint;
+  List<int>? _serverPubKeyBytes;
+
+  @override
+  void initState() {
+    super.initState();
+    _initPairing();
+  }
+
+  void _initPairing() {
+    _pairingService = PhonePairingService(
+      cryptoClient: widget.args.cryptoClient,
+      nodeId: widget.args.nodeId,
+    );
+    _startPairingFlow();
+  }
+
+  Future<void> _startPairingFlow() async {
+    setState(() => _state = _kStateLoading);
+
+    // First check status to get the fingerprint
+    PairingStatus? status;
+    try {
+      status = await _pairingService.checkPairingStatus();
+    } on Exception catch (e) {
+      // Check if there's a pending cert fingerprint
+      final pendingFingerprint =
+          widget.args.cryptoClient.checkPendingCertFingerprint();
+      if (pendingFingerprint != null) {
+        // Show cert approval dialog
+        if (!mounted) return;
+        final approved = await _showCertApprovalDialog(pendingFingerprint);
+        if (!mounted) return;
+        if (approved) {
+          await widget.args.cryptoClient.approveCert(pendingFingerprint);
+          // Retry status check
+          if (!mounted) return;
+          status = await _pairingService.checkPairingStatus();
+        } else {
+          widget.args.cryptoClient.rejectCert();
+          setState(() {
+            _state = _kStateError;
+            _errorMessage = 'Certificate not approved. Pairing requires TLS verification.';
+          });
+          return;
+        }
+      } else {
+        debugPrint('[PairingScreen] Status check error: $e');
+        if (!mounted) return;
+        setState(() {
+          _state = _kStateError;
+          _errorMessage = 'Failed to connect to server: $e';
+        });
+        return;
+      }
+    }
+
+    if (!mounted) return;
+
+    if (!status.needsPairing) {
+      // Already paired — just go back
+      Navigator.of(context).pop(true);
+      return;
+    }
+
+    // Store fingerprint if provided
+    _serverFingerprint = status.serverFingerprint;
+
+    // Initiate pairing to get passcode
+    try {
+      final result = await _pairingService.startPairing();
+      if (!mounted) return;
+
+      _passcode = result['passcode'] as String;
+      _serverPubKeyBytes = base64Decode(result['serverPubKey'] as String);
+      setState(() => _state = _kStateShowPasscode);
+    } catch (e) {
+      debugPrint('[PairingScreen] Start pairing error: $e');
+      if (!mounted) return;
+      setState(() {
+        _state = _kStateError;
+        _errorMessage = 'Failed to start pairing: $e';
+      });
+    }
+  }
+
+  Future<bool> _showCertApprovalDialog(String fingerprint) async {
+    final approved = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => _CertApprovalDialog(fingerprint: fingerprint),
+    );
+    return approved ?? false;
+  }
+
+  Future<void> _confirmPairing() async {
+    if (_passcode == null || _serverPubKeyBytes == null) return;
+
+    setState(() => _state = _kStatePairing);
+
+    try {
+      final result = await _pairingService.confirmPairing(
+        passcode: _passcode!,
+        serverPubKeyBytes: _serverPubKeyBytes!,
+      );
+
+      if (!mounted) return;
+
+      if (result.success) {
+        setState(() => _state = _kStateSuccess);
+        // Give a moment to show success, then pop
+        await Future.delayed(const Duration(seconds: 1));
+        if (mounted) {
+          Navigator.of(context).pop(true);
+        }
+      } else {
+        setState(() {
+          _state = _kStateError;
+          _errorMessage = result.error ?? 'Pairing failed';
+        });
+      }
+    } catch (e) {
+      debugPrint('[PairingScreen] Confirm pairing error: $e');
+      if (!mounted) return;
+      setState(() {
+        _state = _kStateError;
+        _errorMessage = 'Pairing failed: $e';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pair with Server'),
+        automaticallyImplyLeading: false,
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    switch (_state) {
+      case _kStateLoading:
+        return const Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 16),
+              Text('Connecting to server...'),
+            ],
+          ),
+        );
+
+      case _kStateShowPasscode:
+        return _buildPasscodeView();
+
+      case _kStatePairing:
+        return const Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 16),
+              Text('Completing pairing...'),
+              SizedBox(height: 8),
+              Text(
+                'Keep this screen open.',
+                style: TextStyle(color: Colors.grey),
+              ),
+            ],
+          ),
+        );
+
+      case _kStateError:
+        return Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Icon(Icons.error_outline, size: 64, color: Colors.red),
+                const SizedBox(height: 16),
+                Text(
+                  'Pairing Failed',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  _errorMessage ?? 'Unknown error',
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(color: Colors.red),
+                ),
+                const SizedBox(height: 24),
+                FilledButton(
+                  onPressed: _startPairingFlow,
+                  child: const Text('Try Again'),
+                ),
+                const SizedBox(height: 12),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: const Text('Cancel'),
+                ),
+              ],
+            ),
+          ),
+        );
+
+      case _kStateSuccess:
+        return const Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.check_circle, size: 64, color: Colors.green),
+              SizedBox(height: 16),
+              Text('Pairing Complete!'),
+              SizedBox(height: 8),
+              Text(
+                'Secure connection established.',
+                style: TextStyle(color: Colors.grey),
+              ),
+            ],
+          ),
+        );
+
+      default:
+        return const Center(child: Text('Unknown state'));
+    }
+  }
+
+  Widget _buildPasscodeView() {
+    final theme = Theme.of(context);
+    final passcode = _passcode ?? '------';
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Header
+          const Icon(Icons.lock_outline, size: 48, color: Colors.blue),
+          const SizedBox(height: 16),
+          Text(
+            'Verify Server',
+            style: theme.textTheme.headlineSmall,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Compare the code below with your server screen,\nthen tap Confirm to pair.',
+            style: const TextStyle(color: Colors.grey),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 32),
+
+          // Passcode display
+          Container(
+            padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Column(
+              children: [
+                const Text(
+                  'SERVER PASSCODE',
+                  style: TextStyle(
+                    letterSpacing: 2,
+                    fontWeight: FontWeight.w500,
+                    color: Colors.grey,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                // Display passcode with spacing
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: passcode.split('').map((char) {
+                    return Container(
+                      width: 40,
+                      height: 56,
+                      margin: const EdgeInsets.symmetric(horizontal: 4),
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.primary,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Center(
+                        child: Text(
+                          char,
+                          style: const TextStyle(
+                            fontSize: 28,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          // Certificate fingerprint
+          if (_serverFingerprint != null) ...[
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                border: Border.all(color: Colors.grey.shade300),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.verified_user_outlined,
+                          size: 16, color: Colors.grey),
+                      const SizedBox(width: 8),
+                      Text(
+                        'TLS Certificate Fingerprint',
+                        style: theme.textTheme.labelMedium?.copyWith(
+                          color: Colors.grey,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    _serverFingerprint!,
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 11,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Verify this matches your server\'s displayed fingerprint.',
+              style: TextStyle(color: Colors.grey, fontSize: 12),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+          ],
+
+          // Confirm button
+          FilledButton.icon(
+            onPressed: _confirmPairing,
+            icon: const Icon(Icons.check),
+            label: const Text('Confirm & Pair'),
+            style: FilledButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Dialog shown when the server presents an untrusted certificate.
+///
+/// AC8: If self-signed cert not approved, phone shows cert fingerprint dialog.
+class _CertApprovalDialog extends StatelessWidget {
+  final String fingerprint;
+
+  const _CertApprovalDialog({required this.fingerprint});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      icon: const Icon(Icons.security, color: Colors.amber, size: 48),
+      title: const Text('Certificate Not Trusted'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'The server\'s TLS certificate could not be verified. '
+            'This may happen with self-signed certificates.',
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'SHA-256 Fingerprint:',
+            style: TextStyle(fontWeight: FontWeight.w500),
+          ),
+          const SizedBox(height: 4),
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: Colors.grey.shade100,
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              fingerprint,
+              style: const TextStyle(fontFamily: 'monospace', fontSize: 10),
+            ),
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'If you trust this certificate, approve it below. '
+            'You may be asked to approve again after app restart.',
+            style: TextStyle(color: Colors.grey, fontSize: 12),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Reject'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Approve Once'),
+        ),
+      ],
+    );
+  }
+}

--- a/phone/lib/screens/pairing_screen.dart
+++ b/phone/lib/screens/pairing_screen.dart
@@ -122,9 +122,14 @@ class _PairingScreenState extends State<PairingScreen> {
     if (!mounted) return;
 
     if (!status.needsPairing) {
-      // Already paired — just go back
-      Navigator.of(context).pop(true);
-      return;
+      // Server thinks it's paired but we got here (likely 403 — phone lost
+      // its token). Revoke the stale pairing so we can re-pair cleanly.
+      debugPrint('[PairingScreen] Server paired but phone token missing — revoking stale pairing');
+      try {
+        await _pairingService.revokePairing();
+      } catch (e) {
+        debugPrint('[PairingScreen] Revoke failed (non-fatal): $e');
+      }
     }
 
     // Store fingerprint if provided

--- a/phone/lib/screens/pairing_screen.dart
+++ b/phone/lib/screens/pairing_screen.dart
@@ -5,10 +5,9 @@
 /// Flow:
 /// 1. [PairingScreen] checks pairing status
 /// 2. If unpaired, initiates pairing via [PhonePairingService.startPairing]
-/// 3. Displays the server's 6-digit passcode + TLS fingerprint for verification
-/// 4. User confirms on phone after verifying match on server screen
-/// 5. [PhonePairingService.confirmPairing] completes the handshake
-/// 6. On success, navigates back to resume sync
+/// 3. User manually enters the 6-digit passcode shown on the server console
+/// 4. [PhonePairingService.confirmPairing] completes the handshake
+/// 5. On success, navigates back to resume sync
 ///
 /// AC2: Phone app shows "Pair with Server" screen when needsPairing:true
 /// AC8: If self-signed cert not approved, phone shows cert fingerprint dialog
@@ -47,7 +46,7 @@ class _PairingScreenState extends State<PairingScreen> {
 
   /// Pairing state machine states.
   static const _kStateLoading = 'loading';
-  static const _kStateShowPasscode = 'show_passcode';
+  static const _kStateEnterPasscode = 'enter_passcode';
   static const _kStatePairing = 'pairing';
   static const _kStateError = 'error';
   static const _kStateSuccess = 'success';
@@ -55,8 +54,8 @@ class _PairingScreenState extends State<PairingScreen> {
   String _state = _kStateLoading;
   String? _errorMessage;
 
-  // Passcode info (populated after startPairing)
-  String? _passcode;
+  // Passcode input (user keys in manually from server console)
+  final _passcodeController = TextEditingController();
   String? _serverFingerprint;
   List<int>? _serverPubKeyBytes;
 
@@ -64,6 +63,12 @@ class _PairingScreenState extends State<PairingScreen> {
   void initState() {
     super.initState();
     _initPairing();
+  }
+
+  @override
+  void dispose() {
+    _passcodeController.dispose();
+    super.dispose();
   }
 
   void _initPairing() {
@@ -125,14 +130,14 @@ class _PairingScreenState extends State<PairingScreen> {
     // Store fingerprint if provided
     _serverFingerprint = status.serverFingerprint;
 
-    // Initiate pairing to get passcode
+    // Initiate pairing to get server public key
     try {
       final result = await _pairingService.startPairing();
       if (!mounted) return;
 
-      _passcode = result['passcode'] as String;
       _serverPubKeyBytes = base64Decode(result['serverPubKey'] as String);
-      setState(() => _state = _kStateShowPasscode);
+      _passcodeController.clear();
+      setState(() => _state = _kStateEnterPasscode);
     } catch (e) {
       debugPrint('[PairingScreen] Start pairing error: $e');
       if (!mounted) return;
@@ -153,13 +158,14 @@ class _PairingScreenState extends State<PairingScreen> {
   }
 
   Future<void> _confirmPairing() async {
-    if (_passcode == null || _serverPubKeyBytes == null) return;
+    final passcode = _passcodeController.text.trim();
+    if (passcode.length != 6 || _serverPubKeyBytes == null) return;
 
     setState(() => _state = _kStatePairing);
 
     try {
       final result = await _pairingService.confirmPairing(
-        passcode: _passcode!,
+        passcode: passcode,
         serverPubKeyBytes: _serverPubKeyBytes!,
       );
 
@@ -213,7 +219,7 @@ class _PairingScreenState extends State<PairingScreen> {
           ),
         );
 
-      case _kStateShowPasscode:
+      case _kStateEnterPasscode:
         return _buildPasscodeView();
 
       case _kStatePairing:
@@ -291,7 +297,6 @@ class _PairingScreenState extends State<PairingScreen> {
 
   Widget _buildPasscodeView() {
     final theme = Theme.of(context);
-    final passcode = _passcode ?? '------';
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(24),
@@ -302,19 +307,19 @@ class _PairingScreenState extends State<PairingScreen> {
           const Icon(Icons.lock_outline, size: 48, color: Colors.blue),
           const SizedBox(height: 16),
           Text(
-            'Verify Server',
+            'Enter Pairing Code',
             style: theme.textTheme.headlineSmall,
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 8),
-          Text(
-            'Compare the code below with your server screen,\nthen tap Confirm to pair.',
-            style: const TextStyle(color: Colors.grey),
+          const Text(
+            'Enter the 6-digit code shown on your\nserver console to pair this device.',
+            style: TextStyle(color: Colors.grey),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 32),
 
-          // Passcode display
+          // Passcode input
           Container(
             padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
             decoration: BoxDecoration(
@@ -324,7 +329,7 @@ class _PairingScreenState extends State<PairingScreen> {
             child: Column(
               children: [
                 const Text(
-                  'SERVER PASSCODE',
+                  'PAIRING CODE',
                   style: TextStyle(
                     letterSpacing: 2,
                     fontWeight: FontWeight.w500,
@@ -332,30 +337,31 @@ class _PairingScreenState extends State<PairingScreen> {
                   ),
                 ),
                 const SizedBox(height: 12),
-                // Display passcode with spacing
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: passcode.split('').map((char) {
-                    return Container(
-                      width: 40,
-                      height: 56,
-                      margin: const EdgeInsets.symmetric(horizontal: 4),
-                      decoration: BoxDecoration(
-                        color: theme.colorScheme.primary,
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Center(
-                        child: Text(
-                          char,
-                          style: const TextStyle(
-                            fontSize: 28,
-                            fontWeight: FontWeight.bold,
-                            color: Colors.white,
-                          ),
-                        ),
-                      ),
-                    );
-                  }).toList(),
+                TextField(
+                  controller: _passcodeController,
+                  keyboardType: TextInputType.number,
+                  textAlign: TextAlign.center,
+                  maxLength: 6,
+                  autofocus: true,
+                  enableSuggestions: false,
+                  autocorrect: false,
+                  style: const TextStyle(
+                    fontSize: 32,
+                    fontWeight: FontWeight.bold,
+                    letterSpacing: 12,
+                  ),
+                  decoration: const InputDecoration(
+                    counterText: '',
+                    hintText: '------',
+                    hintStyle: TextStyle(
+                      fontSize: 32,
+                      fontWeight: FontWeight.bold,
+                      letterSpacing: 12,
+                      color: Colors.grey,
+                    ),
+                    border: InputBorder.none,
+                  ),
+                  onChanged: (_) => setState(() {}),
                 ),
               ],
             ),
@@ -406,9 +412,11 @@ class _PairingScreenState extends State<PairingScreen> {
             const SizedBox(height: 24),
           ],
 
-          // Confirm button
+          // Confirm button — only enabled when 6 digits entered
           FilledButton.icon(
-            onPressed: _confirmPairing,
+            onPressed: _passcodeController.text.trim().length == 6
+                ? _confirmPairing
+                : null,
             icon: const Icon(Icons.check),
             label: const Text('Confirm & Pair'),
             style: FilledButton.styleFrom(

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -32,8 +32,20 @@ class AgentApiClient {
   final String baseUrl;
   final http.Client _client;
 
+  /// Pairing token for authenticated proxy requests.
+  String? pairingToken;
+
+  /// Node ID for authenticated proxy requests.
+  String? nodeId;
+
   AgentApiClient({required this.baseUrl, http.Client? client})
       : _client = client ?? http.Client();
+
+  /// Auth headers for proxy requests via the sync server.
+  Map<String, String> get _authHeaders => {
+        if (pairingToken != null) 'X-Av-Pair-Token': pairingToken!,
+        if (nodeId != null) 'X-Av-Node-Id': nodeId!,
+      };
 
   /// Construct from the WebSocket server URL.
   ///
@@ -817,6 +829,7 @@ class AgentApiClient {
     final uri = Uri.parse('$baseUrl/api/tickets/$encodedId/attachments/upload');
 
     final request = http.MultipartRequest('POST', uri);
+    request.headers.addAll(_authHeaders);
 
     // Add the file
     request.files.add(
@@ -891,7 +904,7 @@ class AgentApiClient {
 
   Future<Map<String, dynamic>> _get(String path) async {
     final response = await _client
-        .get(Uri.parse('$baseUrl$path'))
+        .get(Uri.parse('$baseUrl$path'), headers: _authHeaders)
         .timeout(const Duration(seconds: 10));
     if (response.statusCode != 200) {
       _throwApiException(response.statusCode, response.body);
@@ -904,7 +917,7 @@ class AgentApiClient {
     final response = await _client
         .post(
           Uri.parse('$baseUrl$path'),
-          headers: {'Content-Type': 'application/json'},
+          headers: {'Content-Type': 'application/json', ..._authHeaders},
           body: jsonEncode(body ?? {}),
         )
         .timeout(const Duration(seconds: 10));
@@ -919,7 +932,7 @@ class AgentApiClient {
     final response = await _client
         .patch(
           Uri.parse('$baseUrl$path'),
-          headers: {'Content-Type': 'application/json'},
+          headers: {'Content-Type': 'application/json', ..._authHeaders},
           body: jsonEncode(body ?? {}),
         )
         .timeout(const Duration(seconds: 10));
@@ -933,6 +946,7 @@ class AgentApiClient {
       {Map<String, dynamic>? body}) async {
     final request = http.Request('DELETE', Uri.parse('$baseUrl$path'));
     request.headers['Content-Type'] = 'application/json';
+    request.headers.addAll(_authHeaders);
     if (body != null) request.body = jsonEncode(body);
     final streamed = await _client.send(request).timeout(const Duration(seconds: 10));
     final response = await http.Response.fromStream(streamed);

--- a/phone/lib/services/crdt_sync_service.dart
+++ b/phone/lib/services/crdt_sync_service.dart
@@ -398,6 +398,18 @@ class CrdtSyncService {
         );
   }
 
+  /// Revokes pairing with the desktop server.
+  ///
+  /// Calls DELETE /api/sync/pair to notify the server, then clears local
+  /// pairing state. After revocation, the next sync attempt will trigger
+  /// the pairing flow again.
+  ///
+  /// Does nothing if not currently paired.
+  Future<void> revokePairing() async {
+    await _pairingService?.revokePairing();
+    debugPrint('[CrdtSync] Pairing revoked. Service reset to unpaired state.');
+  }
+
   void dispose() {
     _plainClient.close();
     _cryptoClient?.dispose();

--- a/phone/lib/services/crdt_sync_service.dart
+++ b/phone/lib/services/crdt_sync_service.dart
@@ -9,6 +9,13 @@
 ///
 /// Watermark tracking: phone stores the desktop's watermark in
 /// [AppDatabase.syncWatermarks] with nodeId='desktop' and direction='received'.
+///
+/// ## Pairing Integration (AVO-065 Phase 4)
+///
+/// Uses [CryptoSyncService] for TLS 1.2+ transport with certificate
+/// verification and [PhonePairingService] for pairing flow. On sync error
+/// 403 or when server reports needsPairing:true, the [onNeedsPairing]
+/// callback is invoked to trigger the pairing UI.
 library;
 
 import 'dart:convert';
@@ -18,6 +25,9 @@ import 'package:drift/drift.dart' show Value;
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
+
+import 'crypto_sync_service.dart';
+import 'pairing_service.dart';
 
 const _kDesktopNodeId = 'desktop';
 const _kPhoneNodeIdKey = 'crdt_node_id';
@@ -37,19 +47,57 @@ class _SyncDocType {
   static const String dayPlanTask = 'dayPlanTask';
 }
 
+/// Callback type invoked when the server indicates pairing is required.
+typedef OnNeedsPairingCallback = Future<void> Function();
+
 /// Sync service that pulls CRDT deltas from the desktop via HTTP.
+///
+/// Uses [cryptoClient] for TLS + auth transport when provided.
+/// Falls back to plain [http.Client] if not supplied (for non-TLS connections).
+///
+/// Triggers [onNeedsPairing] when:
+/// - Sync returns HTTP 403 (unpaired or invalid token)
+/// - GET /api/sync/status returns needsPairing:true
 class CrdtSyncService {
   final String baseUrl;
   final AppDatabase db;
   final HybridLogicalClock clock;
-  final http.Client _client;
+  final http.Client _plainClient;
+  final CryptoSyncService? _cryptoClient;
+
+  /// Phone-side pairing service (initialized after pairing).
+  PhonePairingService? get pairingService => _pairingService;
+  PhonePairingService? _pairingService;
+
+  /// Called when the server reports needsPairing:true or returns HTTP 403.
+  final OnNeedsPairingCallback? onNeedsPairing;
 
   CrdtSyncService({
     required this.baseUrl,
     required this.db,
     required this.clock,
     http.Client? client,
-  }) : _client = client ?? http.Client();
+    CryptoSyncService? cryptoClient,
+    this.onNeedsPairing,
+    required String nodeId,
+  })  : _plainClient = client ?? http.Client(),
+        _cryptoClient = cryptoClient {
+    if (_cryptoClient != null) {
+      _pairingService = PhonePairingService(
+        cryptoClient: _cryptoClient,
+        nodeId: nodeId,
+      );
+    }
+  }
+
+  /// Loads persisted pairing state from secure storage.
+  Future<void> loadPersistedState() async {
+    await _cryptoClient?.loadPersistedState();
+    await _pairingService?.loadPersistedState();
+  }
+
+  /// Returns true if a pairing token is stored.
+  bool get isPaired => _cryptoClient?.isPaired ?? false;
 
   /// Returns or creates the phone's persistent node ID.
   static Future<String> getOrCreateNodeId() async {
@@ -66,17 +114,49 @@ class CrdtSyncService {
   /// Pull all CRDT deltas from the desktop since the last known watermark.
   ///
   /// Returns the number of deltas merged, or throws on HTTP error.
+  /// Triggers [onNeedsPairing] if the server returns HTTP 403 or reports
+  /// needsPairing:true.
   Future<int> pullFromDesktop() async {
+    // Check pairing status first if we have the crypto client
+    if (_cryptoClient != null) {
+      final status = await _pairingService?.checkPairingStatus();
+      if (status != null && status.needsPairing) {
+        debugPrint('[CrdtSync] Server needs pairing — triggering pairing flow');
+        await onNeedsPairing?.call();
+        throw Exception('Pairing required');
+      }
+    }
+
     final watermark = await _getDesktopWatermark();
-
     final nodeId = await getOrCreateNodeId();
-    final uri = Uri.parse(
-      '$baseUrl/api/sync/deltas?since=${Uri.encodeComponent(watermark)}&node=${Uri.encodeComponent(nodeId)}',
-    );
 
-    debugPrint('[CrdtSync] Pulling deltas since $watermark from $uri');
+    debugPrint('[CrdtSync] Pulling deltas since $watermark');
 
-    final response = await _client.get(uri).timeout(const Duration(seconds: 10));
+    final http.Response response;
+    if (_cryptoClient != null) {
+      // Use TLS client — auth headers applied automatically
+      final httpResponse = await _cryptoClient.get(
+        'api/sync/deltas',
+        queryParams: {
+          'since': watermark,
+          'node': nodeId,
+        },
+      );
+      final body = await httpResponse.transform(utf8.decoder).join();
+      response = http.Response(body, httpResponse.statusCode);
+    } else {
+      final uri = Uri.parse(
+        '$baseUrl/api/sync/deltas?since=${Uri.encodeComponent(watermark)}&node=${Uri.encodeComponent(nodeId)}',
+      );
+      response = await _plainClient.get(uri).timeout(const Duration(seconds: 10));
+    }
+
+    if (response.statusCode == 403) {
+      debugPrint('[CrdtSync] HTTP 403 — triggering pairing flow');
+      await onNeedsPairing?.call();
+      throw Exception('Pairing required (HTTP 403)');
+    }
+
     if (response.statusCode != 200) {
       throw Exception('Sync pull failed: HTTP ${response.statusCode}');
     }
@@ -239,21 +319,40 @@ class CrdtSyncService {
   /// Protocol: POST /api/sync/deltas
   /// Body: `{"node": "<node-id>", "deltas": [...]}`
   /// Returns the number of deltas merged by the desktop, or throws on HTTP error.
+  /// Triggers [onNeedsPairing] on HTTP 403.
   Future<int> pushToDesktop(List<Map<String, dynamic>> deltas) async {
     if (deltas.isEmpty) return 0;
 
     final nodeId = await getOrCreateNodeId();
-    final uri = Uri.parse('$baseUrl/api/sync/deltas');
+    final body = jsonEncode({'node': nodeId, 'deltas': deltas});
 
-    debugPrint('[CrdtSync] Pushing ${deltas.length} delta(s) to $uri');
+    debugPrint('[CrdtSync] Pushing ${deltas.length} delta(s)');
 
-    final response = await _client
-        .post(
-          uri,
-          headers: {'Content-Type': 'application/json'},
-          body: jsonEncode({'node': nodeId, 'deltas': deltas}),
-        )
-        .timeout(const Duration(seconds: 10));
+    final http.Response response;
+    if (_cryptoClient != null) {
+      final httpResponse = await _cryptoClient.post(
+        'api/sync/deltas',
+        headers: {'Content-Type': 'application/json'},
+        body: body,
+      );
+      final responseBody = await httpResponse.transform(utf8.decoder).join();
+      response = http.Response(responseBody, httpResponse.statusCode);
+    } else {
+      final uri = Uri.parse('$baseUrl/api/sync/deltas');
+      response = await _plainClient
+          .post(
+            uri,
+            headers: {'Content-Type': 'application/json'},
+            body: body,
+          )
+          .timeout(const Duration(seconds: 10));
+    }
+
+    if (response.statusCode == 403) {
+      debugPrint('[CrdtSync] HTTP 403 — triggering pairing flow');
+      await onNeedsPairing?.call();
+      throw Exception('Pairing required (HTTP 403)');
+    }
 
     if (response.statusCode != 200) {
       throw Exception('Sync push failed: HTTP ${response.statusCode}');
@@ -300,6 +399,7 @@ class CrdtSyncService {
   }
 
   void dispose() {
-    _client.close();
+    _plainClient.close();
+    _cryptoClient?.dispose();
   }
 }

--- a/phone/lib/services/crdt_sync_service.dart
+++ b/phone/lib/services/crdt_sync_service.dart
@@ -117,8 +117,10 @@ class CrdtSyncService {
   /// Triggers [onNeedsPairing] if the server returns HTTP 403 or reports
   /// needsPairing:true.
   Future<int> pullFromDesktop() async {
-    // Check pairing status first if we have the crypto client
-    if (_cryptoClient != null) {
+    // Only check server pairing status if we DON'T have a local token.
+    // If we do have a token, skip the network call and let the actual
+    // /api/sync/deltas 403 response be the authoritative signal.
+    if (_cryptoClient != null && !isPaired) {
       final status = await _pairingService?.checkPairingStatus();
       if (status != null && status.needsPairing) {
         debugPrint('[CrdtSync] Server needs pairing — triggering pairing flow');

--- a/phone/lib/services/crypto_sync_service.dart
+++ b/phone/lib/services/crypto_sync_service.dart
@@ -1,0 +1,351 @@
+/// TLS-capable HTTP client for secure sync communication.
+///
+/// Wraps dart:io HttpClient with SecurityContext for TLS,
+/// badCertificateCallback that shows certificate fingerprint for user
+/// approval, and X-Av-Pair-Token / X-Av-Node-Id header injection
+/// on all /api/sync/* requests.
+///
+/// ## Certificate Approval Flow
+///
+/// When badCertificateCallback fires:
+/// 1. Extract SHA-256 fingerprint from the server's certificate
+/// 2. Check if fingerprint is already approved (in-memory or secure storage)
+/// 3. If not approved, reject the connection and emit a certificate challenge
+/// 4. Caller should invoke [triggerCertApproval] to show UI, then retry
+///
+/// Dart HttpClient defaults to TLS 1.2+ on modern Dart versions.
+library;
+
+import 'dart:async';
+import 'dart:convert' as dart_convert;
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+const _kPairingTokenKey = 'avodah_pairing_token';
+const _kApprovedCertFingerprintKey = 'avodah_approved_cert_fingerprint';
+const _kServerPubKeyKey = 'avodah_server_pub_key';
+
+/// TLS-capable HTTP client for secure sync.
+///
+/// Uses dart:io HttpClient with SecurityContext.
+/// Adds X-Av-Pair-Token and X-Av-Node-Id headers to all /api/sync/*
+/// requests when paired.
+///
+/// ## Certificate Approval
+///
+/// The [badCertificateCallback] on HttpClient is synchronous and cannot
+/// show a dialog. Instead, when a cert is rejected, the connection will
+/// fail and the caller should call [triggerCertApproval] to show the
+/// approval UI. The fingerprint is then stored and subsequent requests
+/// will pass the callback.
+class CryptoSyncService {
+  final String baseUrl;
+
+  HttpClient? _client;
+  final FlutterSecureStorage _secureStorage;
+
+  /// The approved certificate fingerprint (loaded from secure storage).
+  String? _approvedFingerprint;
+
+  /// Pending fingerprint that needs approval (set when cert is rejected).
+  String? _pendingFingerprint;
+
+  /// Completer for the cert approval future.
+  Completer<bool>? _certApprovalCompleter;
+
+  /// Current pairing token (loaded from secure storage when paired).
+  String? _pairingToken;
+
+  /// Node ID for this phone (for X-Av-Node-Id header).
+  final String nodeId;
+
+  CryptoSyncService({
+    required this.baseUrl,
+    required this.nodeId,
+    FlutterSecureStorage? secureStorage,
+  }) : _secureStorage = secureStorage ?? const FlutterSecureStorage() {
+    _client = _createHttpClient();
+  }
+
+  HttpClient _createHttpClient() {
+    final context = SecurityContext(withTrustedRoots: true);
+    final client = HttpClient(context: context);
+
+    client.badCertificateCallback = (X509Certificate cert, String host, int port) {
+      final fingerprint = _computeFingerprint(cert);
+      debugPrint('[CryptoSync] Cert not trusted from $host:$port — fingerprint: $fingerprint');
+
+      // If already approved, allow
+      if (_approvedFingerprint == fingerprint) {
+        debugPrint('[CryptoSync] Fingerprint already approved, allowing');
+        return true;
+      }
+
+      // Store pending fingerprint and trigger approval
+      _pendingFingerprint = fingerprint;
+      _certApprovalCompleter = Completer<bool>();
+
+      // Attempt to show approval UI (caller must handle this via checkPendingCert)
+      // Return false to reject the connection for now
+      return false;
+    };
+
+    return client;
+  }
+
+  /// Checks if there is a pending certificate approval request.
+  ///
+  /// Returns the pending fingerprint, or null if none.
+  String? checkPendingCertFingerprint() => _pendingFingerprint;
+
+  /// Triggers the certificate approval flow.
+  ///
+  /// Caller should show the fingerprint to the user and then call
+  /// [approveCert] or [rejectCert] to resolve.
+  Completer<bool> get certApprovalCompleter {
+    if (_certApprovalCompleter == null) {
+      _certApprovalCompleter = Completer<bool>();
+    }
+    return _certApprovalCompleter!;
+  }
+
+  /// Approves the pending certificate fingerprint.
+  ///
+  /// Persists to secure storage so it survives app restart.
+  Future<void> approveCert(String fingerprint) async {
+    _approvedFingerprint = fingerprint;
+    await _secureStorage.write(key: _kApprovedCertFingerprintKey, value: fingerprint);
+    _pendingFingerprint = null;
+    _certApprovalCompleter?.complete(true);
+    _certApprovalCompleter = null;
+    debugPrint('[CryptoSync] Certificate fingerprint approved and stored: $fingerprint');
+  }
+
+  /// Rejects the pending certificate fingerprint.
+  void rejectCert() {
+    _pendingFingerprint = null;
+    _certApprovalCompleter?.complete(false);
+    _certApprovalCompleter = null;
+    debugPrint('[CryptoSync] Certificate fingerprint rejected');
+  }
+
+  /// Computes SHA-256 fingerprint of an X509Certificate.
+  ///
+  /// Returns the fingerprint as a lowercase hex string with colon separators.
+  String _computeFingerprint(X509Certificate cert) {
+    final derBytes = cert.der;
+    final hash = _sha256Sync(derBytes);
+    return hash
+        .map((b) => b.toRadixString(16).padLeft(2, '0'))
+        .join(':')
+        .toLowerCase();
+  }
+
+  /// Computes SHA-256 of [data] synchronously.
+  ///
+  /// Uses a simple implementation for certificate fingerprint display.
+  /// Not for cryptographic security — only for visual verification.
+  List<int> _sha256Sync(List<int> data) {
+    // Rotate right
+    int rotr(int x, int n) => ((x >> n) | (x << (32 - n))) & 0xFFFFFFFF;
+    int ch(int x, int y, int z) => (x & y) ^ (~x & z);
+    int maj(int x, int y, int z) => (x & y) ^ (x & z) ^ (y & z);
+    int sigma0(int x) => rotr(x, 2) ^ rotr(x, 13) ^ rotr(x, 22);
+    int sigma1(int x) => rotr(x, 6) ^ rotr(x, 11) ^ rotr(x, 25);
+    int gamma0(int x) => rotr(x, 7) ^ rotr(x, 18) ^ (x >> 3);
+    int gamma1(int x) => rotr(x, 17) ^ rotr(x, 19) ^ (x >> 10);
+
+    // Initial hash values (first 32 bits of fractional parts of square roots of first 8 primes)
+    final h = [
+      0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+      0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    ];
+
+    // Round constants (first 32 bits of fractional parts of cube roots of first 64 primes)
+    final k = [
+      0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+      0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+      0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+      0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+      0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+      0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+      0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+      0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+    ];
+
+    // Pre-processing: pad the message
+    final message = Uint8List.fromList(data);
+    final originalLength = message.length;
+    final bitLength = originalLength * 8;
+
+    // Pad to 64 bytes (512 bits) boundary
+    final padded = Uint8List(((originalLength + 9) ~/ 64 + 1) * 64);
+    padded.setAll(0, message);
+    padded[originalLength] = 0x80;
+
+    // Write bit length as big-endian 64-bit integer at the end
+    final view = ByteData.sublistView(padded);
+    view.setUint32(padded.length - 4, (bitLength ~/ 0x100000000) & 0xFFFFFFFF);
+    view.setUint32(padded.length - 8, bitLength & 0xFFFFFFFF);
+
+    // Process each 64-byte chunk
+    for (var chunkStart = 0; chunkStart < padded.length; chunkStart += 64) {
+      final w = List<int>.filled(64, 0);
+
+      // Copy chunk into first 16 words
+      for (var i = 0; i < 16; i++) {
+        w[i] = view.getUint32(chunkStart + i * 4);
+      }
+
+      // Extend to remaining words
+      for (var i = 16; i < 64; i++) {
+        w[i] = (gamma1(w[i - 2]) + w[i - 7] + gamma0(w[i - 15]) + w[i - 16]) & 0xFFFFFFFF;
+      }
+
+      var a = h[0], b = h[1], c = h[2], d = h[3];
+      var e = h[4], f = h[5], g = h[6], hh = h[7];
+
+      for (var i = 0; i < 64; i++) {
+        final t1 = (hh + sigma1(e) + ch(e, f, g) + k[i] + w[i]) & 0xFFFFFFFF;
+        final t2 = (sigma0(a) + maj(a, b, c)) & 0xFFFFFFFF;
+        hh = g;
+        g = f;
+        f = e;
+        e = (d + t1) & 0xFFFFFFFF;
+        d = c;
+        c = b;
+        b = a;
+        a = (t1 + t2) & 0xFFFFFFFF;
+      }
+
+      h[0] = (h[0] + a) & 0xFFFFFFFF;
+      h[1] = (h[1] + b) & 0xFFFFFFFF;
+      h[2] = (h[2] + c) & 0xFFFFFFFF;
+      h[3] = (h[3] + d) & 0xFFFFFFFF;
+      h[4] = (h[4] + e) & 0xFFFFFFFF;
+      h[5] = (h[5] + f) & 0xFFFFFFFF;
+      h[6] = (h[6] + g) & 0xFFFFFFFF;
+      h[7] = (h[7] + hh) & 0xFFFFFFFF;
+    }
+
+    return h.map((v) => [(v >> 24) & 0xFF, (v >> 16) & 0xFF, (v >> 8) & 0xFF, v & 0xFF]).expand((x) => x).toList();
+  }
+
+  /// Returns true if a pairing token is stored.
+  bool get isPaired => _pairingToken != null && _pairingToken!.isNotEmpty;
+
+  /// Returns the current pairing token, or null if not paired.
+  String? get pairingToken => _pairingToken;
+
+  /// Sets the pairing token to use for authenticated requests.
+  void setPairingToken(String? token) {
+    _pairingToken = token;
+  }
+
+  /// Loads persisted pairing state from secure storage.
+  Future<void> loadPersistedState() async {
+    _pairingToken = await _secureStorage.read(key: _kPairingTokenKey);
+    _approvedFingerprint =
+        await _secureStorage.read(key: _kApprovedCertFingerprintKey);
+    debugPrint('[CryptoSync] Loaded state — isPaired: $isPaired, '
+        'fingerprint stored: ${_approvedFingerprint != null}');
+  }
+
+  /// Persists the pairing token to secure storage.
+  Future<void> persistPairingToken(String token) async {
+    _pairingToken = token;
+    await _secureStorage.write(key: _kPairingTokenKey, value: token);
+  }
+
+  /// Clears the persisted pairing token (on unpair).
+  Future<void> clearPairingToken() async {
+    _pairingToken = null;
+    await _secureStorage.delete(key: _kPairingTokenKey);
+  }
+
+  /// Stores the server's X25519 public key for replay protection.
+  Future<void> storeServerPubKey(List<int> pubKeyBytes) async {
+    final encoded = dart_convert.base64Encode(pubKeyBytes);
+    await _secureStorage.write(key: _kServerPubKeyKey, value: encoded);
+  }
+
+  /// Returns the stored server public key, or null if not stored.
+  Future<List<int>?> getStoredServerPubKey() async {
+    final encoded = await _secureStorage.read(key: _kServerPubKeyKey);
+    if (encoded == null) return null;
+    return dart_convert.base64Decode(encoded);
+  }
+
+  // ============================================================
+  // HTTP Methods with auth header injection
+  // ============================================================
+
+  /// Makes a GET request to [path] with optional auth headers for sync endpoints.
+  Future<HttpClientResponse> get(
+    String path, {
+    Map<String, String>? queryParams,
+    Duration timeout = const Duration(seconds: 10),
+  }) async {
+    final uri = _buildUri(path, queryParams);
+    final request = await _client!.getUrl(uri);
+    _applySyncHeaders(request);
+    return request.close().timeout(timeout);
+  }
+
+  /// Makes a POST request to [path] with optional auth headers for sync endpoints.
+  Future<HttpClientResponse> post(
+    String path, {
+    Map<String, String>? headers,
+    String? body,
+    Duration timeout = const Duration(seconds: 10),
+  }) async {
+    final uri = _buildUri(path);
+    final request = await _client!.postUrl(uri);
+    if (headers != null) {
+      headers.forEach(request.headers.set);
+    }
+    _applySyncHeaders(request);
+    if (body != null) {
+      request.write(body);
+    }
+    return request.close().timeout(timeout);
+  }
+
+  /// Makes a DELETE request to [path] with optional auth headers for sync endpoints.
+  Future<HttpClientResponse> delete(
+    String path, {
+    Map<String, String>? headers,
+    Duration timeout = const Duration(seconds: 10),
+  }) async {
+    final uri = _buildUri(path);
+    final request = await _client!.deleteUrl(uri);
+    if (headers != null) {
+      headers.forEach(request.headers.set);
+    }
+    _applySyncHeaders(request);
+    return request.close().timeout(timeout);
+  }
+
+  Uri _buildUri(String path, [Map<String, String>? queryParams]) {
+    var uriString = baseUrl;
+    if (!uriString.endsWith('/')) uriString += '/';
+    uriString += path;
+    return Uri.parse(uriString).replace(queryParameters: queryParams);
+  }
+
+  /// Adds X-Av-Pair-Token and X-Av-Node-Id headers for /api/sync/* requests.
+  void _applySyncHeaders(HttpClientRequest request) {
+    if (_pairingToken != null && _pairingToken!.isNotEmpty) {
+      request.headers.set('X-Av-Pair-Token', _pairingToken!);
+    }
+    request.headers.set('X-Av-Node-Id', nodeId);
+  }
+
+  /// Closes the HTTP client.
+  void dispose() {
+    _client?.close(force: true);
+    _client = null;
+  }
+}

--- a/phone/lib/services/pairing_service.dart
+++ b/phone/lib/services/pairing_service.dart
@@ -109,8 +109,10 @@ class PhonePairingService {
       }
     } catch (e) {
       debugPrint('[PhonePairing] Status check error: $e');
-      // Network error — assume needs pairing
-      return PairingStatus(needsPairing: true);
+      // Network error — DON'T assume needs pairing. Transient network
+      // failures (Android doze, Tailscale blip) should not trigger the
+      // pairing screen. The 403 on /api/sync/deltas is the real signal.
+      return PairingStatus(needsPairing: false);
     }
   }
 

--- a/phone/lib/services/pairing_service.dart
+++ b/phone/lib/services/pairing_service.dart
@@ -6,7 +6,7 @@
 /// ## Pairing Flow
 ///
 /// 1. [checkPairingStatus] — GET /api/sync/status → {needsPairing, serverFingerprint?}
-/// 2. [startPairing] — POST /api/sync/pair/start → {passcode, serverPubKey, expiresIn}
+/// 2. [startPairing] — POST /api/sync/pair/start → {serverPubKey, expiresIn}
 /// 3. [confirmPairing] — POST /api/sync/pair/confirm → {success, error?}
 ///    - Generates X25519 keypair
 ///    - Computes HMAC-SHA256(passcode, phonePubKey)
@@ -118,10 +118,10 @@ class PhonePairingService {
   ///
   /// POST /api/sync/pair/start
   /// Body: {nodeId: string}
-  /// Returns {passcode: string, serverPubKey: string, expiresIn: int}
+  /// Returns {serverPubKey: string, expiresIn: int}
   ///
-  /// The passcode is displayed on the server console. The user must
-  /// confirm this passcode on the phone UI.
+  /// The passcode is displayed ONLY on the server console. The user must
+  /// manually enter it on the phone to complete pairing.
   Future<Map<String, dynamic>> startPairing() async {
     final body = jsonEncode({'nodeId': nodeId});
     final response = await _cryptoClient.post(

--- a/phone/lib/services/pairing_service.dart
+++ b/phone/lib/services/pairing_service.dart
@@ -1,0 +1,245 @@
+/// Phone-side pairing service for secure sync.
+///
+/// Implements the client-side of the Anytype-inspired passcode + X25519
+/// key exchange:
+///
+/// ## Pairing Flow
+///
+/// 1. [checkPairingStatus] — GET /api/sync/status → {needsPairing, serverFingerprint?}
+/// 2. [startPairing] — POST /api/sync/pair/start → {passcode, serverPubKey, expiresIn}
+/// 3. [confirmPairing] — POST /api/sync/pair/confirm → {success, error?}
+///    - Generates X25519 keypair
+///    - Computes HMAC-SHA256(passcode, phonePubKey)
+///    - Derives shared secret via X25519
+///    - Derives pairing key via HMAC-SHA256(sharedSecret, "avodah-pair-v1")
+///    - Persists pairing key and server pubkey
+///
+/// ## Subsequent Sync
+///
+/// [CryptoSyncService] uses the stored pairing token for all /api/sync/*
+/// requests. Token = HMAC-SHA256(pairingKey, "avodah-sync-v1") (computed
+/// server-side; phone just stores and sends it).
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import 'package:avodah_core/avodah_core.dart';
+import 'crypto_sync_service.dart';
+
+/// Storage keys for pairing data.
+const _kPairingTokenKey = 'avodah_pairing_token';
+const _kServerPubKeyKey = 'avodah_server_pub_key';
+
+/// Result of a pairing status check.
+class PairingStatus {
+  final bool needsPairing;
+  final String? serverFingerprint;
+
+  PairingStatus({required this.needsPairing, this.serverFingerprint});
+
+  factory PairingStatus.fromJson(Map<String, dynamic> json) {
+    return PairingStatus(
+      needsPairing: json['needsPairing'] as bool? ?? true,
+      serverFingerprint: json['serverFingerprint'] as String?,
+    );
+  }
+}
+
+/// Result of a pairing confirmation attempt.
+class PairingResult {
+  final bool success;
+  final String? error;
+
+  PairingResult({required this.success, this.error});
+}
+
+/// Phone-side pairing service.
+///
+/// Coordinates with [CryptoSyncService] to establish and persist a
+/// pairing with the sync server.
+class PhonePairingService {
+  final CryptoSyncService _cryptoClient;
+  final FlutterSecureStorage _secureStorage;
+
+  /// The node ID for this phone (used as the pairing ID on the server).
+  final String nodeId;
+
+  /// The derived pairing token (HMAC of pairing key, stored persistently).
+  String? _pairingToken;
+
+  PhonePairingService({
+    required CryptoSyncService cryptoClient,
+    required this.nodeId,
+    FlutterSecureStorage? secureStorage,
+  })  : _cryptoClient = cryptoClient,
+        _secureStorage = secureStorage ?? const FlutterSecureStorage();
+
+  /// Returns true if a pairing token is persisted.
+  bool get isPaired => _pairingToken != null && _pairingToken!.isNotEmpty;
+
+  /// Returns the current pairing token, or null if not paired.
+  String? get pairingToken => _pairingToken;
+
+  /// Loads persisted pairing state from secure storage.
+  Future<void> loadPersistedState() async {
+    _pairingToken = await _secureStorage.read(key: _kPairingTokenKey);
+    debugPrint('[PhonePairing] Loaded — isPaired: $isPaired');
+  }
+
+  /// Checks the pairing status with the sync server.
+  ///
+  /// GET /api/sync/status
+  /// Returns {needsPairing: bool, serverFingerprint?: string}
+  Future<PairingStatus> checkPairingStatus() async {
+    try {
+      final response = await _cryptoClient.get('api/sync/status');
+      final body = await _readResponseBody(response);
+      if (response.statusCode == 200) {
+        final json = jsonDecode(body) as Map<String, dynamic>;
+        return PairingStatus.fromJson(json);
+      } else {
+        debugPrint('[PhonePairing] Status check failed: HTTP ${response.statusCode} — $body');
+        // Treat non-200 as needs pairing (server might not have pairing endpoints yet)
+        return PairingStatus(needsPairing: true);
+      }
+    } catch (e) {
+      debugPrint('[PhonePairing] Status check error: $e');
+      // Network error — assume needs pairing
+      return PairingStatus(needsPairing: true);
+    }
+  }
+
+  /// Starts the pairing handshake with the sync server.
+  ///
+  /// POST /api/sync/pair/start
+  /// Body: {nodeId: string}
+  /// Returns {passcode: string, serverPubKey: string, expiresIn: int}
+  ///
+  /// The passcode is displayed on the server console. The user must
+  /// confirm this passcode on the phone UI.
+  Future<Map<String, dynamic>> startPairing() async {
+    final body = jsonEncode({'nodeId': nodeId});
+    final response = await _cryptoClient.post(
+      'api/sync/pair/start',
+      headers: {'Content-Type': 'application/json'},
+      body: body,
+    );
+    final responseBody = await _readResponseBody(response);
+    if (response.statusCode != 200) {
+      throw Exception('Pairing start failed: HTTP ${response.statusCode} — $responseBody');
+    }
+    return jsonDecode(responseBody) as Map<String, dynamic>;
+  }
+
+  /// Completes the pairing handshake.
+  ///
+  /// POST /api/sync/pair/confirm
+  /// Body: {nodeId, phonePubKey, hmacProof}
+  /// Returns {success: bool, error?: string}
+  ///
+  /// 1. Generates X25519 keypair
+  /// 2. Computes HMAC-SHA256(passcode, phonePubKey)
+  /// 3. Derives shared secret via X25519(phonePrivKey, serverPubKey)
+  /// 4. Derives pairing key via HMAC-SHA256(sharedSecret, "avodah-pair-v1")
+  /// 5. Persists pairing token and server pubkey
+  Future<PairingResult> confirmPairing({
+    required String passcode,
+    required List<int> serverPubKeyBytes,
+  }) async {
+    // Generate X25519 keypair for this pairing session
+    final keyPair = await generateKeyPair();
+    final phonePubKeyBytes = keyPair.publicKey;
+
+    // Compute HMAC proof: HMAC-SHA256(passcode, phonePubKey)
+    final hmacProof = await _computePasscodeProof(passcode, phonePubKeyBytes);
+
+    // Build confirm request body
+    final body = jsonEncode({
+      'nodeId': nodeId,
+      'phonePubKey': base64Encode(phonePubKeyBytes),
+      'hmacProof': base64Encode(hmacProof),
+    });
+
+    final response = await _cryptoClient.post(
+      'api/sync/pair/confirm',
+      headers: {'Content-Type': 'application/json'},
+      body: body,
+    );
+    final responseBody = await _readResponseBody(response);
+
+    if (response.statusCode != 200) {
+      return PairingResult(success: false, error: 'HTTP ${response.statusCode}');
+    }
+
+    final json = jsonDecode(responseBody) as Map<String, dynamic>;
+    final success = json['success'] as bool? ?? false;
+    if (!success) {
+      return PairingResult(
+        success: false,
+        error: json['error'] as String? ?? 'Unknown error',
+      );
+    }
+
+    // Derive shared secret and pairing key
+    final sharedSecret = await deriveSharedSecret(keyPair, serverPubKeyBytes);
+    final pairingKey = await derivePairingKey(sharedSecret);
+
+    // Generate and store the pairing token: HMAC-SHA256(pairingKey, "avodah-sync-v1")
+    final syncToken = await generateSyncVerifyCode(pairingKey);
+
+    // Store the pairing token and server pubkey
+    await _secureStorage.write(key: _kPairingTokenKey, value: syncToken);
+    await _secureStorage.write(
+      key: _kServerPubKeyKey,
+      value: base64Encode(serverPubKeyBytes),
+    );
+    _pairingToken = syncToken;
+    _cryptoClient.setPairingToken(syncToken);
+
+    // Also store the server pubkey in CryptoSyncService for replay protection
+    await _cryptoClient.storeServerPubKey(serverPubKeyBytes);
+
+    debugPrint('[PhonePairing] Pairing confirmed and persisted. Token stored.');
+    return PairingResult(success: true);
+  }
+
+  /// Revokes the current pairing.
+  ///
+  /// DELETE /api/sync/pair
+  /// Clears local pairing state and notifies the server.
+  Future<void> revokePairing() async {
+    try {
+      await _cryptoClient.delete('api/sync/pair');
+    } catch (e) {
+      debugPrint('[PhonePairing] Revoke request failed (non-fatal): $e');
+    }
+    _pairingToken = null;
+    _cryptoClient.setPairingToken(null);
+    await _secureStorage.delete(key: _kPairingTokenKey);
+    await _secureStorage.delete(key: _kServerPubKeyKey);
+    debugPrint('[PhonePairing] Pairing revoked locally.');
+  }
+
+  /// Computes HMAC-SHA256(passcode, phonePubKey) for pairing proof.
+  ///
+  /// Uses passcode as the HMAC secret key and phonePubKey as the message.
+  Future<Uint8List> _computePasscodeProof(
+      String passcode, List<int> phonePubKey) async {
+    final hmac = Hmac.sha256();
+    final secretKey = SecretKey(utf8.encode(passcode));
+    final mac = await hmac.calculateMac(
+      Uint8List.fromList(phonePubKey),
+      secretKey: secretKey,
+    );
+    return Uint8List.fromList(mac.bytes);
+  }
+
+  Future<String> _readResponseBody(HttpClientResponse response) async {
+    return utf8.decoder.bind(response).join();
+  }
+}

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -229,7 +229,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     try {
       final url = _controller.text.trim();
-      final uri = Uri.parse('$url/api/health');
+      // Use root health endpoint (no auth required)
+      final uri = Uri.parse('$url/');
       final response =
           await http.get(uri).timeout(const Duration(seconds: 5));
       if (response.statusCode == 200) {
@@ -332,7 +333,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   decoration: const InputDecoration(
                     hintText: kDefaultServerUrl,
                     border: OutlineInputBorder(),
-                    helperText: 'Use your Tailscale IP, e.g. http://100.x.y.z:9847',
+                    helperText: 'e.g. https://your-host.ts.net:9847',
                   ),
                   keyboardType: TextInputType.url,
                   autocorrect: false,

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:avodah_core/version.dart';
 import '../services/agent_api_client.dart';
+import '../services/crdt_sync_service.dart';
 
 const kServerUrlKey = 'sync_server_url';
 const kDefaultServerUrl = 'http://100.64.0.1:9847';
@@ -15,7 +16,11 @@ class SettingsScreen extends StatefulWidget {
   /// using the current saved server URL.
   final AgentApiClient? apiClient;
 
-  const SettingsScreen({super.key, this.apiClient});
+  /// Optional CRDT sync service for Forget Server functionality.
+  /// If not provided, the Forget This Server button is hidden.
+  final CrdtSyncService? crdtSyncService;
+
+  const SettingsScreen({super.key, this.apiClient, this.crdtSyncService});
 
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
@@ -65,6 +70,58 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   /// Polling timer for build status.
   Timer? _statusPollTimer;
+
+  /// Whether Forget Server is in progress.
+  bool _forgetting = false;
+
+  /// Triggers the Forget Server confirmation and revocation flow.
+  Future<void> _forgetServer() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Forget This Server?'),
+        content: const Text(
+          'This will remove pairing with the current sync server. '
+          'You will need to pair again to resume sync.\n\n'
+          'Your local data will NOT be deleted.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: FilledButton.styleFrom(
+              backgroundColor: Colors.red,
+            ),
+            child: const Text('Forget Server'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    setState(() => _forgetting = true);
+
+    try {
+      await widget.crdtSyncService?.revokePairing();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Server forgotten. Please restart the app.')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to forget server: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _forgetting = false);
+    }
+  }
 
   @override
   void initState() {
@@ -313,6 +370,41 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ],
             ),
           ),
+          const Divider(),
+          if (widget.crdtSyncService != null)
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Server Connection',
+                      style: Theme.of(context).textTheme.titleMedium),
+                  const SizedBox(height: 8),
+                  const Text(
+                    'Remove pairing with the current sync server.',
+                    style: TextStyle(color: Colors.grey),
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton.icon(
+                      onPressed: _forgetting ? null : _forgetServer,
+                      icon: _forgetting
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2))
+                          : const Icon(Icons.link_off, color: Colors.red),
+                      label: Text(
+                          _forgetting ? 'Forgetting...' : 'Forget This Server'),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.red,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
           const Divider(),
           Padding(
             padding: const EdgeInsets.all(16),

--- a/phone/linux/flutter/generated_plugin_registrant.cc
+++ b/phone/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
   sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);

--- a/phone/linux/flutter/generated_plugins.cmake
+++ b/phone/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  flutter_secure_storage_linux
   sqlite3_flutter_libs
 )
 

--- a/phone/pubspec.yaml
+++ b/phone/pubspec.yaml
@@ -26,6 +26,10 @@ dependencies:
     path: ../packages/avodah_core
   highlight: ^0.7.0
 
+  # Secure sync (Phase 4 - AVO-065)
+  cryptography: ^2.7.0
+  flutter_secure_storage: ^9.2.2
+
 dependency_overrides:
   # 2.3.0 pulls in jni/jni_flutter which requires NDK 28 (not available in Nix env)
   path_provider_android: 2.2.23

--- a/tool/tailscale-cert.sh
+++ b/tool/tailscale-cert.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Generates or renews Tailscale TLS certs for the Avodah sync server.
+#
+# Usage:
+#   ./tool/tailscale-cert.sh [domain]
+#
+# Writes certs to ~/.config/avodah/ (or $AVODAH_CONFIG).
+# After running, restart the sync server:
+#   docker compose restart avodah-sync
+set -euo pipefail
+
+DOMAIN="${1:-drgnfly.tail10c2c6.ts.net}"
+
+# Resolve real user home when run via sudo
+if [ -n "${SUDO_USER:-}" ]; then
+  REAL_HOME=$(eval echo "~$SUDO_USER")
+else
+  REAL_HOME="$HOME"
+fi
+
+CONFIG_DIR="${AVODAH_CONFIG:-$REAL_HOME/.config/avodah}"
+
+mkdir -p "$CONFIG_DIR"
+
+echo "Generating/renewing Tailscale cert for $DOMAIN..."
+echo "Output dir: $CONFIG_DIR"
+
+tailscale cert \
+  --cert-file "$CONFIG_DIR/$DOMAIN.crt" \
+  --key-file  "$CONFIG_DIR/$DOMAIN.key" \
+  "$DOMAIN"
+
+# Make readable by the non-root user running the sync server
+chown "${SUDO_USER:-$(whoami)}" "$CONFIG_DIR/$DOMAIN.crt" "$CONFIG_DIR/$DOMAIN.key"
+chmod 644 "$CONFIG_DIR/$DOMAIN.crt"
+chmod 600 "$CONFIG_DIR/$DOMAIN.key"
+
+echo "Cert: $CONFIG_DIR/$DOMAIN.crt"
+echo "Key:  $CONFIG_DIR/$DOMAIN.key"
+echo ""
+echo "Restart sync server to apply:"
+echo "  docker compose restart avodah-sync"


### PR DESCRIPTION
## Summary

Implements secure sync for Avodah phone ↔ sync server communication with TLS encryption and passcode-based pairwise authentication (Anytype-inspired).

### What Changed

**Phases 1-3 (server-side, previously complete):**
- Phase 1: Schema + crypto foundation (`packages/avodah_core`) — X25519 key exchange, HMAC-SHA256 pairing key derivation, `paired_devices` Drift table
- Phase 2: Server-side pairing service (`mcp/lib/services/pairing_service.dart`) — `POST /api/sync/pair/start`, `POST /api/sync/pair/confirm`, `DELETE /api/sync/pair`, 6-digit passcode display
- Phase 3: Sync server TLS + auth (`mcp/bin/sync_server.dart`) — `HttpServer.bindSecure` with `SecurityContext`, `X-Av-Pair-Token` auth middleware, CORS restriction

**Phases 4-5 (phone-side, this PR):**
- Phase 4: Phone TLS client + pairing UI — `CryptoSyncService` (HttpClient with SecurityContext + badCertificateCallback), `PairingService` (X25519 + HMAC pairing flow), `PairingScreen` (passcode display + cert fingerprint)
- Phase 5: Revocation + polish — `DELETE /api/sync/pair` authenticated revocation, "Forget Server" in phone settings, sync integration tests updated

### Commits

| SHA | Author | Description |
|-----|--------|-------------|
| `148b222` | Sinh Nguyen | feat(core): AVO-065 phase 1 - schema + crypto foundation |
| `b92ed37` | Sinh Nguyen | feat(core): AVO-065 phase 2 - server-side pairing service |
| `d03e2ec` | Sinh Nguyen | feat(core): AVO-065 phase 3 - sync server TLS + auth |
| `d6058e9` | builder | feat(phone): AVO-065 phase 4 - phone TLS client + pairing UI |
| `ddaa386` | builder | feat(phone): AVO-065 phase 5 - revocation + Forget Server UI |

## Acceptance Criteria Checklist

- [x] AC1: HTTPS server on port 9847 when TLS config set
- [ ] AC2: Phone shows "Pair with Server" screen when needsPairing:true (manual UAT)
- [x] AC3: Server displays 6-digit passcode on pairing initiation
- [x] AC4: Phone stores persistent shared secret (flutter_secure_storage)
- [x] AC5: Subsequent sync requests include X-Av-Pair-Token header
- [x] AC6: Unpaired phones receive HTTP 403
- [x] AC7: CORS headers reflect paired phone origin (not `*`)
- [ ] AC8: Cert fingerprint dialog on self-signed cert first connect (manual UAT)
- [ ] AC9: Paired phone can revoke pairing via "Forget Server" (manual UAT)
- [ ] AC10: All existing sync integration tests pass (manual UAT)

## Test Plan

1. Run `dart analyze` on all packages (mcp/, avodah_core/, phone/)
2. Run test suites: `cd packages/avodah_core && dart test`, `cd mcp && dart test`
3. Manual UAT using the UAT test plan in the ticket

## UAT Review

See: `agent-teams/builder/artifacts/2026-04-10-AVO-065-uat-review.md`

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)