### PR TITLE
AVO-084: Fix missing auth headers for self-update and chip operations

### DIFF
--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -400,6 +400,7 @@ class _HomeShellState extends State<_HomeShell> {
               focusProvider: widget.focusProvider,
               deploymentProvider: widget.deploymentProvider,
               crdtSyncService: widget.crdtSyncService,
+              apiClient: widget.apiClient,
             ),
           DashboardScreen(
             dashboardProvider: widget.dashboardProvider,

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -424,7 +424,9 @@ class _HomeShellState extends State<_HomeShell> {
                   onPressed: () => Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => SettingsScreen(crdtSyncService: widget.crdtSyncService)),
+                        builder: (_) => SettingsScreen(
+                        apiClient: widget.apiClient,
+                        crdtSyncService: widget.crdtSyncService)),
                   ),
                 ),
               ],
@@ -450,7 +452,9 @@ class _HomeShellState extends State<_HomeShell> {
                   onPressed: () => Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => SettingsScreen(crdtSyncService: widget.crdtSyncService)),
+                        builder: (_) => SettingsScreen(
+                        apiClient: widget.apiClient,
+                        crdtSyncService: widget.crdtSyncService)),
                   ),
                 ),
                 IconButton(
@@ -480,7 +484,9 @@ class _HomeShellState extends State<_HomeShell> {
                   onPressed: () => Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => SettingsScreen(crdtSyncService: widget.crdtSyncService)),
+                        builder: (_) => SettingsScreen(
+                        apiClient: widget.apiClient,
+                        crdtSyncService: widget.crdtSyncService)),
                   ),
                 ),
                 IconButton(

--- a/phone/lib/screens/dashboard_screen.dart
+++ b/phone/lib/screens/dashboard_screen.dart
@@ -331,7 +331,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
             onPressed: () async {
               await Navigator.push<bool>(
                 context,
-                MaterialPageRoute(builder: (_) => SettingsScreen(crdtSyncService: widget.crdtSyncService)),
+                MaterialPageRoute(builder: (_) => SettingsScreen(apiClient: widget.apiClient, crdtSyncService: widget.crdtSyncService)),
               );
             },
           ),

--- a/phone/lib/screens/kanban_board_screen.dart
+++ b/phone/lib/screens/kanban_board_screen.dart
@@ -16,6 +16,7 @@ import '../widgets/focus_item_card.dart';
 import '../widgets/ticket_card.dart';
 import '../widgets/wip_summary.dart';
 import '../services/crdt_sync_service.dart';
+import '../services/agent_api_client.dart';
 import '../settings/settings_screen.dart';
 import 'create_bulletin_screen.dart';
 import 'create_ticket_screen.dart';
@@ -40,6 +41,9 @@ class KanbanBoardScreen extends StatefulWidget {
   final DeploymentProvider? deploymentProvider;
   final CrdtSyncService? crdtSyncService;
 
+  /// API client for authenticated proxy access.
+  final AgentApiClient? apiClient;
+
   const KanbanBoardScreen({
     super.key,
     required this.boardProvider,
@@ -47,6 +51,7 @@ class KanbanBoardScreen extends StatefulWidget {
     this.focusProvider,
     this.deploymentProvider,
     this.crdtSyncService,
+    this.apiClient,
   });
 
   @override
@@ -169,7 +174,7 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
             icon: const Icon(Icons.settings),
             onPressed: () => Navigator.push(
               context,
-              MaterialPageRoute(builder: (_) => SettingsScreen(crdtSyncService: widget.crdtSyncService)),
+              MaterialPageRoute(builder: (_) => SettingsScreen(apiClient: widget.apiClient, crdtSyncService: widget.crdtSyncService)),
             ),
           ),
           IconButton(

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io' show HttpStatus;
 
+import 'package:flutter/foundation.dart';
+
 import 'package:http/http.dart' as http;
 import 'package:image_picker/image_picker.dart' show XFile;
 
@@ -559,7 +561,8 @@ class AgentApiClient {
     try {
       final json = await _post('/api/self-update');
       return SelfUpdateResult.fromJson(json);
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[AgentApiClient] triggerSelfUpdate error: $e');
       return null;
     }
   }

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -553,18 +553,12 @@ class AgentApiClient {
 
   /// Triggers a self-update build (phone → server → APK push).
   ///
-  /// POST /api/self-update → 202 Accepted with {status: building, startedAt}
+  /// POST /api/self-update → 2xx with {status: building, startedAt}
   /// Returns null on network error.
   Future<SelfUpdateResult?> triggerSelfUpdate() async {
     try {
-      final response = await _client
-          .post(Uri.parse('$baseUrl/api/self-update'))
-          .timeout(const Duration(seconds: 10));
-      if (response.statusCode == HttpStatus.accepted) {
-        final json = jsonDecode(response.body) as Map<String, dynamic>;
-        return SelfUpdateResult.fromJson(json);
-      }
-      return null;
+      final json = await _post('/api/self-update');
+      return SelfUpdateResult.fromJson(json);
     } catch (_) {
       return null;
     }
@@ -576,14 +570,8 @@ class AgentApiClient {
   /// Returns null on network error.
   Future<SelfUpdateStatus?> getSelfUpdateStatus() async {
     try {
-      final response = await _client
-          .get(Uri.parse('$baseUrl/api/self-update/status'))
-          .timeout(const Duration(seconds: 10));
-      if (response.statusCode == HttpStatus.ok) {
-        final json = jsonDecode(response.body) as Map<String, dynamic>;
-        return SelfUpdateStatus.fromJson(json);
-      }
-      return null;
+      final json = await _get('/api/self-update/status');
+      return SelfUpdateStatus.fromJson(json);
     } catch (_) {
       return null;
     }

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -256,7 +256,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _triggerSelfUpdate() async {
     final url = await SettingsScreen.loadServerUrl();
-    final client = AgentApiClient(baseUrl: url);
+    final client = widget.apiClient ?? AgentApiClient(baseUrl: url);
 
     final result = await client.triggerSelfUpdate();
     if (result == null) {
@@ -279,8 +279,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   void _startStatusPolling(String url) {
     _statusPollTimer?.cancel();
+    final client = widget.apiClient ?? AgentApiClient(baseUrl: url);
     _statusPollTimer = Timer.periodic(const Duration(seconds: 5), (timer) async {
-      final client = AgentApiClient(baseUrl: url);
       final status = await client.getSelfUpdateStatus();
 
       if (status == null) return;

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -138,7 +138,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _loadChips() async {
     // Always use fresh URL for chip operations
     final url = await SettingsScreen.loadServerUrl();
-    final client = AgentApiClient(baseUrl: url);
+    final client = widget.apiClient ?? AgentApiClient(baseUrl: url);
     setState(() => _loadingChips = true);
     try {
       final chips = await client.getAllCategoryChips();
@@ -168,7 +168,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     // Always use fresh URL
     final url = await SettingsScreen.loadServerUrl();
-    final client = AgentApiClient(baseUrl: url);
+    final client = widget.apiClient ?? AgentApiClient(baseUrl: url);
 
     final success = await client.addCategoryChip(category, chip);
     if (success) {
@@ -191,7 +191,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Future<void> _removeChip(String category, String chip) async {
     // Always use fresh URL
     final url = await SettingsScreen.loadServerUrl();
-    final client = AgentApiClient(baseUrl: url);
+    final client = widget.apiClient ?? AgentApiClient(baseUrl: url);
 
     final success = await client.removeCategoryChip(category, chip);
     if (success) {


### PR DESCRIPTION
## Summary
- Fix `triggerSelfUpdate()` and `getSelfUpdateStatus()` in `agent_api_client.dart` to use `_post()`/`_get()` helpers (which include `_authHeaders`) instead of raw HTTP calls
- Pass authenticated `apiClient` to `SettingsScreen` from all navigation sites in `main.dart`
- Fix `_loadChips`, `_addChip`, `_removeChip` to use authenticated client instead of creating new unauthenticated one

## Verification
- [x] `flutter analyze` passes (no errors, no warnings)

## Acceptance Criteria
- Self-update button triggers correctly (auth headers present)
- Chip load/add/remove operations use authenticated client
- No breaking changes to existing API contract

🤖 Generated with [Claude Code](https://claude.ai/claude-code)