### PR TITLE
AVO-060: Display thinking/text/tool_use_detail in deployment activity timeline

### DIFF
--- a/phone/lib/models/activity_event.dart
+++ b/phone/lib/models/activity_event.dart
@@ -44,6 +44,13 @@ class ActivityEvent {
         return 'Deployment started';
       case 'deployment_completed':
         return 'Deployment completed';
+      case 'thinking':
+        return 'Thinking';
+      case 'text':
+        return 'Text response';
+      case 'tool_use_detail':
+        final tool = data['tool'] as String?;
+        return tool != null ? 'Tool use: $tool' : 'Tool use';
       default:
         return event;
     }

--- a/phone/lib/widgets/activity_event_tile.dart
+++ b/phone/lib/widgets/activity_event_tile.dart
@@ -132,12 +132,20 @@ class ActivityEventTile extends StatelessWidget {
         return status != null
             ? 'Deployment completed ($status)'
             : 'Deployment completed';
+      case 'thinking':
+        return 'Thinking';
+      case 'text':
+        return 'Text response';
+      case 'tool_use_detail':
+        final tool = event.data['tool'] as String?;
+        return tool != null ? 'Tool use: $tool' : 'Tool use';
       default:
         return event.eventLabel;
     }
   }
 
   Widget _buildDataSection(ThemeData theme) {
+    final isThinking = event.event == 'thinking';
     final entries = event.data.entries
         .where((e) => e.value != null && e.value.toString().isNotEmpty)
         .toList();
@@ -146,14 +154,24 @@ class ActivityEventTile extends StatelessWidget {
     // Build markdown content from data entries
     final buffer = StringBuffer();
     for (final e in entries) {
-      buffer.writeln('**${e.key}:** ${e.value}');
+      var value = e.value.toString();
+      // Truncate tool_use_detail input at 500 chars
+      if (event.event == 'tool_use_detail' && e.key == 'input' && value.length > 500) {
+        value = '${value.substring(0, 500)}...[truncated]';
+      }
+      buffer.writeln('**${e.key}:** $value');
     }
+
+    // Use amber tint for thinking blocks
+    final bgColor = isThinking
+        ? Colors.amber.withValues(alpha: 0.1)
+        : theme.colorScheme.surfaceContainerHighest;
 
     return RepaintBoundary(
       child: Container(
         padding: const EdgeInsets.all(8),
         decoration: BoxDecoration(
-          color: theme.colorScheme.surfaceContainerHighest,
+          color: bgColor,
           borderRadius: BorderRadius.circular(6),
         ),
         child: MarkdownBody(
@@ -189,6 +207,12 @@ Color _eventColor(BuildContext context, String eventType) {
       return Colors.purple;
     case 'child_deploy_started':
       return Colors.teal;
+    case 'thinking':
+      return Colors.amber;
+    case 'text':
+      return Colors.blue;
+    case 'tool_use_detail':
+      return Colors.purple;
     default:
       return Theme.of(context).colorScheme.outline;
   }
@@ -212,6 +236,12 @@ IconData _eventIcon(String eventType) {
       return Icons.build;
     case 'child_deploy_started':
       return Icons.fork_right;
+    case 'thinking':
+      return Icons.psychology;
+    case 'text':
+      return Icons.short_text;
+    case 'tool_use_detail':
+      return Icons.build;
     default:
       return Icons.circle_outlined;
   }


### PR DESCRIPTION
## Summary

Implement rendering of three new activity event types (thinking, text, tool_use_detail) in the Avodah Flutter phone app's deployment activity timeline.

## Changes

- **phone/lib/models/activity_event.dart**: Added thinking/text/tool_use_detail cases to `eventLabel` getter
- **phone/lib/widgets/activity_event_tile.dart**: Added cases to `_buildLabel()`, `_eventColor()`, `_eventIcon()` for all three event types

## Acceptance Criteria Checklist

- [ ] AC1: thinking event renders with amber/orange color, Icons.psychology, label "Thinking", expandable content
- [ ] AC2: text event renders with blue color, Icons.short_text, label "Text response", expandable content  
- [ ] AC3: tool_use_detail event renders with purple color, Icons.build, label "Tool use: {tool_name}", expandable content
- [ ] AC4: All three types appear chronologically interleaved with other events
- [ ] AC5: Collapsed thinking blocks show preview (3-5 lines) with tap-to-expand
- [ ] AC6: Existing event types (tool_call, agent_spawned, etc.) render identically after changes (no regression)
- [ ] AC7: flutter build produces no compile errors

## Test Plan

- [ ] Build: `cd phone && flutter build web --release` succeeds
- [ ] Regression: verify existing event types still render correctly
- [ ] Visual: check thinking event shows amber tint and collapsible content
- [ ] Visual: check text event shows blue color
- [ ] Visual: check tool_use_detail event shows purple color with tool name

🤖 Generated with [Claude Code](https://claude.com/claude-code)