### PR TITLE
fix(phone): AVO-087 — provider selection honored in deploy sheet

### DIFF
--- a/phone/lib/widgets/deploy_sheet.dart
+++ b/phone/lib/widgets/deploy_sheet.dart
@@ -106,12 +106,21 @@ class _DeploySheetState extends State<DeploySheet> {
   Future<void> _loadDraft() async {
     final draft = await DeployDraftService.loadDraft();
     if (draft == null || !mounted) return;
+
+    // Always apply team defaults first so they take precedence when the draft
+    // has no explicit provider/model for the current team.
+    if (draft.team != null &&
+        widget.paTeams.any((t) => t.name == draft.team)) {
+      _selectedTeam = draft.team;
+      _autoSelectMode();
+    }
+    _applyTeamDefaults();
+
     setState(() {
       if (draft.team != null &&
           widget.paTeams.any((t) => t.name == draft.team)) {
         _selectedTeam = draft.team;
         _autoSelectMode();
-        _applyTeamDefaults();
       }
       if (draft.mode != null) _selectedMode = draft.mode;
       if (draft.repo != null &&


### PR DESCRIPTION
## Summary
Fix bug where selected AI provider (e.g., minimax) was not honored when launching a deployment from the phone. The deploy sheet now applies team defaults before loading draft provider values, ensuring the team's default provider is used when no explicit provider is saved for the current team.

## Bug
In , when  did not match the current team,  was skipped. This left the provider as whatever was set in  — which could be a different team's default.

## Fix
Call  unconditionally in  before loading draft provider values, so team defaults take precedence when draft has no explicit provider for the current team.

## Acceptance Criteria
- [x] When switching teams, if draft has no saved provider for new team → new team's default provider is used
- [x] When draft has explicit provider for current team → that provider is used
- [x] No breaking changes to existing deploy sheet functionality

## Testing
- [x] Provider behavior verified when switching teams with no saved provider

## Files Changed
-  —  method

🤖 Generated with [Claude Code](https://claude.com/claude-code)