### PR TITLE
AVO-090: App Display Color Control

### DIFF
--- a/.claude/builder-objective-temp.md
+++ b/.claude/builder-objective-temp.md
@@ -1,0 +1,34 @@
+Fix markdown code block syntax highlighting for AVO-090.
+
+## Context
+- Repo: /home/sinh/git-repos/sinh-x/tools/avodah
+- Branch: feature/AVO-090-display-color-control
+- Ticket: AVO-090
+- Phase: Gap fix (not part of original implementation plan)
+
+## Problem
+Markdown code blocks (fenced code blocks with triple backticks in .md documents) do NOT use SyntaxColors. flutter_markdown renders them with plain monospace via its default CodeElementBuilder. This means the contrast and syntax color settings don't affect markdown code blocks.
+
+## Requirements
+- FR-A: Markdown code blocks must use SyntaxColors for syntax highlighting
+- FR-B: Code blocks must respond to the High Contrast setting (normal vs high contrast syntax colors)
+- FR-C: No new package dependencies
+
+## Technical Approach
+1. Create a custom CodeBlockBuilder class in phone/lib/widgets/markdown_with_annotations.dart that extends MarkdownElementBuilder
+2. Override visitElementAfter to parse the code content with parseSyntaxHighlighted(code, language, syntaxColors) and render using RichText with TextSpans
+3. The builder reads theme.syntaxColors.isHighContrast to determine which syntax colors to use
+4. Register the builder in the Markdown widget's builders map: 'code': _CodeBlockBuilder()
+5. The existing _buildAnnotationStyleSheet should set 'code' style to match the theme's monospace font
+
+## Files to Modify
+- phone/lib/widgets/markdown_with_annotations.dart — Add CodeBlockBuilder and wire it up
+
+## Acceptance Criteria
+- Code blocks in .md documents render with syntax highlighting (keyword, string, comment colors visible)
+- High contrast mode changes code block syntax colors appropriately
+- flutter analyze passes with 0 errors
+- No new package dependencies
+
+## Verification
+Run: cd phone && flutter analyze

--- a/mcp/lib/services/sync_api_service.dart
+++ b/mcp/lib/services/sync_api_service.dart
@@ -177,7 +177,10 @@ class SyncApiService {
   /// Accepts CRDT deltas from a remote node and merges them.
   /// Body: {"node": "<node-id>", "deltas": [{"type": "...", "id": "...", "fields": {...}}]}
   Future<void> _handlePushDeltas(HttpRequest request) async {
-    final body = await utf8.decoder.bind(request).join();
+    // Read raw bytes first, then decode with allowMalformed to handle
+    // any non-UTF-8 data in CRDT field values from the phone.
+    final bytes = await request.fold<List<int>>([], (a, b) => a..addAll(b));
+    final body = utf8.decode(bytes, allowMalformed: true);
     final json = jsonDecode(body) as Map<String, dynamic>;
 
     final remoteNode = json['node'] as String?;

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -16,6 +16,7 @@ import 'services/board_provider.dart';
 import 'services/crdt_sync_service.dart';
 import 'services/crypto_sync_service.dart';
 import 'services/deployment_provider.dart';
+import 'services/display_settings_service.dart';
 import 'services/focus_provider.dart';
 import 'services/local_dashboard_provider.dart';
 import 'services/local_write_service.dart';
@@ -49,6 +50,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
   TeamBrowserProvider? _teamBrowserProvider;
   BoardProvider? _boardProvider;
   FocusProvider? _focusProvider;
+  DisplaySettingsService? _displaySettings;
   Timer? _syncTimer;
   bool _pairingInProgress = false;
   final _navigatorKey = GlobalKey<NavigatorState>();
@@ -120,6 +122,10 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     final focusProvider = FocusProvider(apiClient);
     focusProvider.startPolling();
 
+    // Display settings (brightness, accent color, contrast)
+    final displaySettings = DisplaySettingsService();
+    await displaySettings.load();
+
     setState(() {
       _db = db;
       _dashboardProvider = dashboardProvider;
@@ -132,6 +138,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
       _teamBrowserProvider = teamBrowserProvider;
       _boardProvider = boardProvider;
       _focusProvider = focusProvider;
+      _displaySettings = displaySettings;
     });
 
     // Initial pull + dashboard render
@@ -326,45 +333,73 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     _crdtSyncService?.dispose();
     _cryptoSyncService?.dispose();
     _dashboardProvider?.dispose();
+    _displaySettings?.dispose();
     _db?.close();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      scaffoldMessengerKey: _scaffoldMessengerKey,
-      navigatorKey: _navigatorKey,
-      title: 'Avodah',
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        colorSchemeSeed: const Color(0xFF6750A4),
-        useMaterial3: true,
-        brightness: Brightness.light,
-      ),
-      darkTheme: ThemeData(
-        colorSchemeSeed: const Color(0xFF6750A4),
-        useMaterial3: true,
-        brightness: Brightness.dark,
-      ),
-      home: _dashboardProvider == null
-          ? const Scaffold(
-              body: Center(child: CircularProgressIndicator()),
-            )
-          : _HomeShell(
-              dashboardProvider: _dashboardProvider!,
-              writeService: _writeService!,
-              apiClient: _apiClient!,
-              reviewProvider: _reviewProvider!,
-              deploymentProvider: _deploymentProvider!,
-              teamBrowserProvider: _teamBrowserProvider!,
-              boardProvider: _boardProvider!,
-              focusProvider: _focusProvider,
-              onPushDeltas: _pushDeltas,
-              crdtSyncService: _crdtSyncService,
-            ),
+    final display = _displaySettings;
+    final notifier = display ?? _NullNotifier();
+
+    return ListenableBuilder(
+      listenable: notifier,
+      builder: (context, _) {
+        final syntaxColors = display?.contrast == DisplayContrast.high
+            ? SyntaxColors.high
+            : SyntaxColors.normal;
+        final syntaxTheme = SyntaxThemeExtension(syntaxColors: syntaxColors);
+
+        return MaterialApp(
+          scaffoldMessengerKey: _scaffoldMessengerKey,
+          navigatorKey: _navigatorKey,
+          title: 'Avodah',
+          debugShowCheckedModeBanner: false,
+          theme: display?.lightTheme().copyWith(
+                extensions: [syntaxTheme],
+              ) ??
+              ThemeData(
+                colorSchemeSeed: const Color(0xFF6750A4),
+                useMaterial3: true,
+                brightness: Brightness.light,
+                extensions: [syntaxTheme],
+              ),
+          darkTheme: display?.darkTheme().copyWith(
+                extensions: [syntaxTheme],
+              ) ??
+              ThemeData(
+                colorSchemeSeed: const Color(0xFF6750A4),
+                useMaterial3: true,
+                brightness: Brightness.dark,
+                extensions: [syntaxTheme],
+              ),
+          themeMode: display != null ? ThemeMode.system : ThemeMode.light,
+          home: _dashboardProvider == null
+              ? const Scaffold(
+                  body: Center(child: CircularProgressIndicator()),
+                )
+              : _HomeShell(
+                  dashboardProvider: _dashboardProvider!,
+                  writeService: _writeService!,
+                  apiClient: _apiClient!,
+                  reviewProvider: _reviewProvider!,
+                  deploymentProvider: _deploymentProvider!,
+                  teamBrowserProvider: _teamBrowserProvider!,
+                  boardProvider: _boardProvider!,
+                  focusProvider: _focusProvider,
+                  onPushDeltas: _pushDeltas,
+                  crdtSyncService: _crdtSyncService,
+                ),
+        );
+      },
     );
   }
+}
+
+/// A no-op Listenable used when display settings hasn't loaded yet.
+class _NullNotifier extends ChangeNotifier {
+  _NullNotifier();
 }
 
 /// Shell with bottom navigation between Kanban, Dashboard, Agent Review, Deployments, and Teams.

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -472,6 +472,7 @@ class _HomeShellState extends State<_HomeShell> {
               deploymentProvider: widget.deploymentProvider,
               crdtSyncService: widget.crdtSyncService,
               apiClient: widget.apiClient,
+              displaySettings: widget.displaySettings,
             ),
           DashboardScreen(
             dashboardProvider: widget.dashboardProvider,
@@ -479,6 +480,7 @@ class _HomeShellState extends State<_HomeShell> {
             apiClient: widget.apiClient,
             onPushDeltas: widget.onPushDeltas,
             crdtSyncService: widget.crdtSyncService,
+            displaySettings: widget.displaySettings,
           ),
           Scaffold(
             appBar: AppBar(

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -390,6 +390,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
                   focusProvider: _focusProvider,
                   onPushDeltas: _pushDeltas,
                   crdtSyncService: _crdtSyncService,
+                  displaySettings: _displaySettings,
                 ),
         );
       },
@@ -414,6 +415,7 @@ class _HomeShell extends StatefulWidget {
   final FocusProvider? focusProvider;
   final Future<void> Function(List<Map<String, dynamic>>)? onPushDeltas;
   final CrdtSyncService? crdtSyncService;
+  final DisplaySettingsService? displaySettings;
 
   const _HomeShell({
     required this.dashboardProvider,
@@ -426,6 +428,7 @@ class _HomeShell extends StatefulWidget {
     this.focusProvider,
     this.onPushDeltas,
     this.crdtSyncService,
+    this.displaySettings,
   });
 
   @override
@@ -495,7 +498,8 @@ class _HomeShellState extends State<_HomeShell> {
                     MaterialPageRoute(
                         builder: (_) => SettingsScreen(
                         apiClient: widget.apiClient,
-                        crdtSyncService: widget.crdtSyncService)),
+                        crdtSyncService: widget.crdtSyncService,
+                        displaySettings: widget.displaySettings)),
                   ),
                 ),
               ],
@@ -523,7 +527,8 @@ class _HomeShellState extends State<_HomeShell> {
                     MaterialPageRoute(
                         builder: (_) => SettingsScreen(
                         apiClient: widget.apiClient,
-                        crdtSyncService: widget.crdtSyncService)),
+                        crdtSyncService: widget.crdtSyncService,
+                        displaySettings: widget.displaySettings)),
                   ),
                 ),
                 IconButton(
@@ -555,7 +560,8 @@ class _HomeShellState extends State<_HomeShell> {
                     MaterialPageRoute(
                         builder: (_) => SettingsScreen(
                         apiClient: widget.apiClient,
-                        crdtSyncService: widget.crdtSyncService)),
+                        crdtSyncService: widget.crdtSyncService,
+                        displaySettings: widget.displaySettings)),
                   ),
                 ),
                 IconButton(

--- a/phone/lib/screens/dashboard_screen.dart
+++ b/phone/lib/screens/dashboard_screen.dart
@@ -5,6 +5,7 @@ import '../services/local_dashboard_provider.dart';
 import '../services/local_write_service.dart';
 import '../services/crdt_sync_service.dart' show CrdtSyncService, SyncConnectionState;
 import '../services/agent_api_client.dart';
+import '../services/display_settings_service.dart';
 import '../settings/settings_screen.dart';
 import '../widgets/connection_indicator.dart';
 import '../widgets/plan_category_table.dart';
@@ -26,6 +27,9 @@ class DashboardScreen extends StatefulWidget {
 
   final CrdtSyncService? crdtSyncService;
 
+  /// Display settings service for theme and contrast control.
+  final DisplaySettingsService? displaySettings;
+
   const DashboardScreen({
     super.key,
     required this.dashboardProvider,
@@ -33,6 +37,7 @@ class DashboardScreen extends StatefulWidget {
     this.apiClient,
     this.onPushDeltas,
     this.crdtSyncService,
+    this.displaySettings,
   });
 
   @override
@@ -342,7 +347,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
             onPressed: () async {
               await Navigator.push<bool>(
                 context,
-                MaterialPageRoute(builder: (_) => SettingsScreen(apiClient: widget.apiClient, crdtSyncService: widget.crdtSyncService)),
+                MaterialPageRoute(builder: (_) => SettingsScreen(apiClient: widget.apiClient, crdtSyncService: widget.crdtSyncService, displaySettings: widget.displaySettings)),
               );
             },
           ),

--- a/phone/lib/screens/kanban_board_screen.dart
+++ b/phone/lib/screens/kanban_board_screen.dart
@@ -17,6 +17,7 @@ import '../widgets/ticket_card.dart';
 import '../widgets/wip_summary.dart';
 import '../services/crdt_sync_service.dart';
 import '../services/agent_api_client.dart';
+import '../services/display_settings_service.dart';
 import '../settings/settings_screen.dart';
 import 'create_bulletin_screen.dart';
 import 'create_ticket_screen.dart';
@@ -44,6 +45,9 @@ class KanbanBoardScreen extends StatefulWidget {
   /// API client for authenticated proxy access.
   final AgentApiClient? apiClient;
 
+  /// Display settings service for theme and contrast control.
+  final DisplaySettingsService? displaySettings;
+
   const KanbanBoardScreen({
     super.key,
     required this.boardProvider,
@@ -52,6 +56,7 @@ class KanbanBoardScreen extends StatefulWidget {
     this.deploymentProvider,
     this.crdtSyncService,
     this.apiClient,
+    this.displaySettings,
   });
 
   @override
@@ -174,7 +179,7 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
             icon: const Icon(Icons.settings),
             onPressed: () => Navigator.push(
               context,
-              MaterialPageRoute(builder: (_) => SettingsScreen(apiClient: widget.apiClient, crdtSyncService: widget.crdtSyncService)),
+              MaterialPageRoute(builder: (_) => SettingsScreen(apiClient: widget.apiClient, crdtSyncService: widget.crdtSyncService, displaySettings: widget.displaySettings)),
             ),
           ),
           IconButton(

--- a/phone/lib/services/crdt_sync_service.dart
+++ b/phone/lib/services/crdt_sync_service.dart
@@ -436,6 +436,72 @@ class CrdtSyncService {
         );
   }
 
+  /// Force a full bidirectional sync: reset watermark, pull everything from
+  /// desktop, then push all local documents.
+  ///
+  /// Returns the total number of deltas pushed to the desktop.
+  Future<int> forceFullSync() async {
+    // Reset watermark so the next pull fetches all deltas
+    await _setDesktopWatermark('0');
+
+    // Pull all from desktop
+    await pullFromDesktop();
+
+    // Collect all local documents as deltas
+    final deltas = <Map<String, dynamic>>[];
+
+    final tasks = await db.select(db.tasks).get();
+    for (final t in tasks) {
+      final doc = TaskDocument.fromDrift(task: t, clock: clock);
+      final json = doc.toJson();
+      json['type'] = _SyncDocType.task;
+      deltas.add(json);
+    }
+
+    final worklogs = await db.select(db.worklogEntries).get();
+    for (final w in worklogs) {
+      final doc = WorklogDocument.fromDrift(worklog: w, clock: clock);
+      final json = doc.toJson();
+      json['type'] = _SyncDocType.worklog;
+      deltas.add(json);
+    }
+
+    final timers = await db.select(db.timerEntries).get();
+    for (final t in timers) {
+      final doc = TimerDocument.fromDrift(timer: t, clock: clock);
+      final json = doc.toJson();
+      json['type'] = _SyncDocType.timer;
+      deltas.add(json);
+    }
+
+    final projects = await db.select(db.projects).get();
+    for (final p in projects) {
+      final doc = ProjectDocument.fromDrift(project: p, clock: clock);
+      final json = doc.toJson();
+      json['type'] = _SyncDocType.project;
+      deltas.add(json);
+    }
+
+    final dailyPlans = await db.select(db.dailyPlanEntries).get();
+    for (final d in dailyPlans) {
+      final doc = DailyPlanDocument.fromDrift(entry: d, clock: clock);
+      final json = doc.toJson();
+      json['type'] = _SyncDocType.dailyPlan;
+      deltas.add(json);
+    }
+
+    final dayPlanTasks = await db.select(db.dayPlanTasks).get();
+    for (final d in dayPlanTasks) {
+      final doc = DayPlanTaskDocument.fromDrift(entry: d, clock: clock);
+      final json = doc.toJson();
+      json['type'] = _SyncDocType.dayPlanTask;
+      deltas.add(json);
+    }
+
+    debugPrint('[Sync] Force full sync: pushing ${deltas.length} local deltas');
+    return pushToDesktop(deltas);
+  }
+
   /// Revokes pairing with the desktop server.
   ///
   /// Calls DELETE /api/sync/pair to notify the server, then clears local

--- a/phone/lib/services/crypto_sync_service.dart
+++ b/phone/lib/services/crypto_sync_service.dart
@@ -308,7 +308,9 @@ class CryptoSyncService {
     }
     _applySyncHeaders(request);
     if (body != null) {
-      request.write(body);
+      // Encode as UTF-8 bytes directly to handle any problematic characters.
+      // Replace invalid sequences instead of throwing.
+      request.add(dart_convert.utf8.encode(body));
     }
     return request.close().timeout(timeout);
   }

--- a/phone/lib/services/display_settings_service.dart
+++ b/phone/lib/services/display_settings_service.dart
@@ -1,0 +1,271 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Keys for SharedPreferences storage.
+const kDisplayBrightnessKey = 'display_brightness';
+const kDisplayAccentColorKey = 'display_accent_color';
+const kDisplayContrastKey = 'display_contrast';
+
+/// Brightness options.
+enum DisplayBrightness {
+  light,
+  dark,
+  system;
+
+  String get key {
+    switch (this) {
+      case DisplayBrightness.light:
+        return 'light';
+      case DisplayBrightness.dark:
+        return 'dark';
+      case DisplayBrightness.system:
+        return 'system';
+    }
+  }
+
+  static DisplayBrightness fromKey(String key) {
+    switch (key) {
+      case 'light':
+        return DisplayBrightness.light;
+      case 'dark':
+        return DisplayBrightness.dark;
+      default:
+        return DisplayBrightness.system;
+    }
+  }
+
+  Brightness? toFlutterBrightness() {
+    switch (this) {
+      case DisplayBrightness.light:
+        return Brightness.light;
+      case DisplayBrightness.dark:
+        return Brightness.dark;
+      case DisplayBrightness.system:
+        return null;
+    }
+  }
+}
+
+/// Contrast options.
+enum DisplayContrast {
+  normal,
+  high;
+
+  String get key {
+    switch (this) {
+      case DisplayContrast.normal:
+        return 'normal';
+      case DisplayContrast.high:
+        return 'high';
+    }
+  }
+
+  static DisplayContrast fromKey(String key) {
+    switch (key) {
+      case 'high':
+        return DisplayContrast.high;
+      default:
+        return DisplayContrast.normal;
+    }
+  }
+}
+
+/// Predefined accent color swatches.
+///
+/// Order: Purple (default), Blue, Teal, Green, Orange, Red, Pink, Grey.
+const List<Color> kAccentColors = [
+  Color(0xFF6750A4), // Purple (default)
+  Color(0xFF1976D2), // Blue
+  Color(0xFF00796B), // Teal
+  Color(0xFF388E3C), // Green
+  Color(0xFFF57C00), // Orange
+  Color(0xFFD32F2F), // Red
+  Color(0xFFC2185B), // Pink
+  Color(0xFF616161), // Grey
+];
+
+/// Default accent color (purple).
+const Color kDefaultAccentColor = Color(0xFF6750A4);
+
+/// SharedPreferences-backed display settings service.
+///
+/// Exposes reactive settings via ChangeNotifier so the UI rebuilds
+/// automatically when any setting changes.
+class DisplaySettingsService extends ChangeNotifier {
+  SharedPreferences? _prefs;
+
+  DisplayBrightness _brightness = DisplayBrightness.system;
+  Color _accentColor = kDefaultAccentColor;
+  DisplayContrast _contrast = DisplayContrast.normal;
+
+  DisplayBrightness get brightness => _brightness;
+  Color get accentColor => _accentColor;
+  DisplayContrast get contrast => _contrast;
+
+  /// Loads settings from SharedPreferences.
+  Future<void> load() async {
+    _prefs = await SharedPreferences.getInstance();
+    final brightnessKey = _prefs!.getString(kDisplayBrightnessKey) ?? 'system';
+    _brightness = DisplayBrightness.fromKey(brightnessKey);
+
+    final accentColorValue = _prefs!.getInt(kDisplayAccentColorKey);
+    _accentColor =
+        accentColorValue != null ? Color(accentColorValue) : kDefaultAccentColor;
+
+    final contrastKey = _prefs!.getString(kDisplayContrastKey) ?? 'normal';
+    _contrast = DisplayContrast.fromKey(contrastKey);
+
+    notifyListeners();
+  }
+
+  Future<SharedPreferences> get _prefsReady async {
+    _prefs ??= await SharedPreferences.getInstance();
+    return _prefs!;
+  }
+
+  Future<void> setBrightness(DisplayBrightness value) async {
+    if (_brightness == value) return;
+    _brightness = value;
+    final prefs = await _prefsReady;
+    await prefs.setString(kDisplayBrightnessKey, value.key);
+    notifyListeners();
+  }
+
+  Future<void> setAccentColor(Color value) async {
+    if (_accentColor == value) return;
+    _accentColor = value;
+    final prefs = await _prefsReady;
+    await prefs.setInt(kDisplayAccentColorKey, value.toARGB32());
+    notifyListeners();
+  }
+
+  Future<void> setContrast(DisplayContrast value) async {
+    if (_contrast == value) return;
+    _contrast = value;
+    final prefs = await _prefsReady;
+    await prefs.setString(kDisplayContrastKey, value.key);
+    notifyListeners();
+  }
+
+  /// Builds the light ThemeData from current settings.
+  ThemeData lightTheme() {
+    return ThemeData(
+      colorSchemeSeed: _accentColor,
+      useMaterial3: true,
+      brightness: _brightness.toFlutterBrightness() ?? Brightness.light,
+    );
+  }
+
+  /// Builds the dark ThemeData from current settings.
+  ThemeData darkTheme() {
+    return ThemeData(
+      colorSchemeSeed: _accentColor,
+      useMaterial3: true,
+      brightness: _brightness.toFlutterBrightness() ?? Brightness.dark,
+    );
+  }
+}
+
+/// Syntax highlighting colors based on contrast mode.
+class SyntaxColors {
+  final Color defaultColor;
+  final Color keyword;
+  final Color builtIn;
+  final Color type;
+  final Color literal;
+  final Color number;
+  final Color string;
+  final Color comment;
+  final bool isHighContrast;
+
+  const SyntaxColors({
+    required this.defaultColor,
+    required this.keyword,
+    required this.builtIn,
+    required this.type,
+    required this.literal,
+    required this.number,
+    required this.string,
+    required this.comment,
+    required this.isHighContrast,
+  });
+
+  /// Normal contrast syntax colors.
+  static const normal = SyntaxColors(
+    defaultColor: Color(0xFFE0E0E0),
+    keyword: Color(0xFF9E9E9E),
+    builtIn: Color(0xFF8D8D8D),
+    type: Color(0xFF7A8B9A),
+    literal: Color(0xFF8D8D8D),
+    number: Color(0xFF9E9E9E),
+    string: Color(0xFF8A8A8A),
+    comment: Color(0xFF6B7B6B),
+    isHighContrast: false,
+  );
+
+  /// High contrast syntax colors.
+  static const high = SyntaxColors(
+    defaultColor: Color(0xFFFFFFFF),
+    keyword: Color(0xFFB0B0B0),
+    builtIn: Color(0xFFA0A0A0),
+    type: Color(0xFF90B0C0),
+    literal: Color(0xFFA0A0A0),
+    number: Color(0xFFB0B0B0),
+    string: Color(0xFFA0A0A0),
+    comment: Color(0xFF8B9B8B),
+    isHighContrast: true,
+  );
+
+  Color forClass(String? className) {
+    if (className == null || className.isEmpty) {
+      return defaultColor;
+    }
+
+    final firstClass = className.split(' ').first;
+    return switch (firstClass) {
+      'keyword' => keyword,
+      'built_in' => builtIn,
+      'type' => type,
+      'literal' => literal,
+      'number' => number,
+      'string' => string,
+      'comment' || 'doctag' => comment,
+      'meta' => defaultColor,
+      'function' || 'class' || 'title' || 'attr' || 'variable' => type,
+      'selector-tag' || 'selector-id' || 'selector-class' ||
+      'bullet' || 'section' || 'subst' || 'emphasis' || 'strong' ||
+      'tag' || 'name' => keyword,
+      'template-variable' => keyword,
+      _ => defaultColor,
+    };
+  }
+}
+
+/// Flutter ThemeExtension for syntax highlighting colors.
+class SyntaxThemeExtension extends ThemeExtension<SyntaxThemeExtension> {
+  final SyntaxColors syntaxColors;
+
+  const SyntaxThemeExtension({required this.syntaxColors});
+
+  @override
+  SyntaxThemeExtension copyWith({SyntaxColors? syntaxColors}) {
+    return SyntaxThemeExtension(syntaxColors: syntaxColors ?? this.syntaxColors);
+  }
+
+  @override
+  SyntaxThemeExtension lerp(
+    ThemeExtension<SyntaxThemeExtension>? other,
+    double t,
+  ) {
+    if (other is! SyntaxThemeExtension) return this;
+    return this;
+  }
+}
+
+/// Extension on ThemeData to get SyntaxColors from the theme extension.
+extension ThemeDataSyntaxColors on ThemeData {
+  SyntaxColors get syntaxColors {
+    final ext = extension<SyntaxThemeExtension>();
+    return ext?.syntaxColors ?? SyntaxColors.normal;
+  }
+}

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -21,7 +21,11 @@ class SettingsScreen extends StatefulWidget {
   /// If not provided, the Forget This Server button is hidden.
   final CrdtSyncService? crdtSyncService;
 
-  const SettingsScreen({super.key, this.apiClient, this.crdtSyncService});
+  /// Optional app-level display settings service. If not provided,
+  /// _DisplaySettingsSection creates its own (dual-instance bug fix).
+  final DisplaySettingsService? displaySettings;
+
+  const SettingsScreen({super.key, this.apiClient, this.crdtSyncService, this.displaySettings});
 
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
@@ -341,316 +345,356 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Settings')),
-      body: ListView(
-        children: [
-          Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Sync Server URL',
-                    style: Theme.of(context).textTheme.titleMedium),
-                const SizedBox(height: 8),
-                TextField(
-                  controller: _controller,
-                  decoration: const InputDecoration(
-                    hintText: kDefaultServerUrl,
-                    border: OutlineInputBorder(),
-                    helperText: 'e.g. https://your-host.ts.net:9847',
-                  ),
-                  keyboardType: TextInputType.url,
-                  autocorrect: false,
-                ),
-                const SizedBox(height: 16),
-                Row(
-                  children: [
-                    OutlinedButton(
-                      onPressed: _testing ? null : _testConnection,
-                      child: _testing
-                          ? const SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(strokeWidth: 2))
-                          : const Text('Test Connection'),
-                    ),
-                    const SizedBox(width: 12),
-                    FilledButton(
-                      onPressed: _save,
-                      child: const Text('Save'),
-                    ),
-                  ],
-                ),
-                if (_testResult != null) ...[
-                  const SizedBox(height: 12),
-                  Text(
-                    _testResult!,
-                    style: TextStyle(
-                      color: _testResult!.startsWith('Connected')
-                          ? Colors.green
-                          : Colors.red,
-                    ),
-                  ),
-                ],
-              ],
-            ),
-          ),
-          const Divider(),
-          // --- Display Settings ---
-          _DisplaySettingsSection(),
-          const Divider(),
-          if (widget.crdtSyncService != null)
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+      appBar: AppBar(
+        title: const Text('Settings'),
+        bottom: const TabBar(
+          tabs: [
+            Tab(icon: Icon(Icons.palette), text: 'Appearance'),
+            Tab(icon: Icon(Icons.tune), text: 'Input'),
+            Tab(icon: Icon(Icons.settings_ethernet), text: 'Technical'),
+          ],
+        ),
+      ),
+      body: DefaultTabController(
+        length: 3,
+        child: TabBarView(
+          children: [
+            _buildAppearanceTab(),
+            _buildInputTab(),
+            _buildTechnicalTab(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAppearanceTab() {
+    if (widget.displaySettings == null) {
+      return const Center(child: Text('Display settings unavailable'));
+    }
+    return ListView(
+      children: [
+        _DisplaySettingsSection(service: widget.displaySettings!),
+        const SizedBox(height: 32),
+      ],
+    );
+  }
+
+  Widget _buildInputTab() {
+    return ListView(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text('Server Connection',
+                  Text('Comment Chip Presets',
                       style: Theme.of(context).textTheme.titleMedium),
-                  const SizedBox(height: 8),
-                  const Text(
-                    'Remove pairing with the current sync server.',
-                    style: TextStyle(color: Colors.grey),
-                  ),
-                  const SizedBox(height: 12),
-                  SizedBox(
-                    width: double.infinity,
-                    child: FilledButton.icon(
-                      onPressed: _fullSyncing ? null : _forceFullSync,
-                      icon: _fullSyncing
-                          ? const SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(
-                                  strokeWidth: 2, color: Colors.white))
-                          : const Icon(Icons.sync),
-                      label: Text(
-                          _fullSyncing ? 'Syncing...' : 'Force Full Sync'),
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  const Text(
-                    'Re-downloads all data from the server.',
-                    style: TextStyle(color: Colors.grey, fontSize: 12),
-                  ),
-                  const SizedBox(height: 16),
-                  SizedBox(
-                    width: double.infinity,
-                    child: OutlinedButton.icon(
-                      onPressed: _forgetting ? null : _forgetServer,
-                      icon: _forgetting
-                          ? const SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(strokeWidth: 2))
-                          : const Icon(Icons.link_off, color: Colors.red),
-                      label: Text(
-                          _forgetting ? 'Forgetting...' : 'Forget This Server'),
-                      style: OutlinedButton.styleFrom(
-                        foregroundColor: Colors.red,
-                      ),
-                    ),
+                  TextButton.icon(
+                    onPressed: () async {
+                      _selectedCategory = null;
+                      await _loadChips();
+                    },
+                    icon: const Icon(Icons.refresh, size: 18),
+                    label: const Text('Refresh'),
                   ),
                 ],
               ),
-            ),
-          const Divider(),
-          Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text('Comment Chip Presets',
-                        style: Theme.of(context).textTheme.titleMedium),
-                    TextButton.icon(
-                      onPressed: () async {
-                        _selectedCategory = null;
-                        await _loadChips();
-                      },
-                      icon: const Icon(Icons.refresh, size: 18),
-                      label: const Text('Refresh'),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 8),
-                const Text(
-                  'Manage quick comment chips shown when stopping a timer.',
-                  style: TextStyle(color: Colors.grey),
-                ),
-              ],
-            ),
+              const SizedBox(height: 8),
+              const Text(
+                'Manage quick comment chips shown when stopping a timer.',
+                style: TextStyle(color: Colors.grey),
+              ),
+            ],
           ),
-          // Category selector
+        ),
+        // Category selector
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: DropdownButtonFormField<String>(
+            decoration: const InputDecoration(
+              labelText: 'Category',
+              border: OutlineInputBorder(),
+              contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            ),
+            value: _selectedCategory,
+            hint: const Text('Select a category'),
+            items: _categories.map((cat) {
+              return DropdownMenuItem(value: cat, child: Text(cat));
+            }).toList(),
+            onChanged: (value) {
+              setState(() => _selectedCategory = value);
+            },
+            onTap: () async {
+              if (_categories.isEmpty) {
+                await _loadChips();
+              }
+            },
+          ),
+        ),
+        const SizedBox(height: 16),
+        // Add chip row
+        if (_selectedCategory != null) ...[
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: DropdownButtonFormField<String>(
-              decoration: const InputDecoration(
-                labelText: 'Category',
-                border: OutlineInputBorder(),
-                contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              ),
-              value: _selectedCategory,
-              hint: const Text('Select a category'),
-              items: _categories.map((cat) {
-                return DropdownMenuItem(value: cat, child: Text(cat));
-              }).toList(),
-              onChanged: (value) {
-                setState(() => _selectedCategory = value);
-              },
-              onTap: () async {
-                // Load chips when user taps the dropdown if not yet loaded
-                if (_categories.isEmpty) {
-                  await _loadChips();
-                }
-              },
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _chipController,
+                    decoration: const InputDecoration(
+                      hintText: 'New chip text',
+                      border: OutlineInputBorder(),
+                      contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    ),
+                    onSubmitted: (_) => _addChip(),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                FilledButton(
+                  onPressed: _addChip,
+                  child: const Text('Add'),
+                ),
+              ],
             ),
           ),
           const SizedBox(height: 16),
-          // Add chip row
-          if (_selectedCategory != null) ...[
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
+          // Chips list for selected category
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: _loadingChips
+                ? const Center(child: CircularProgressIndicator())
+                : _buildChipsList(),
+          ),
+        ],
+        const SizedBox(height: 32),
+      ],
+    );
+  }
+
+  Widget _buildTechnicalTab() {
+    return ListView(
+      children: [
+        // Sync Server URL
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Sync Server URL',
+                  style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _controller,
+                decoration: const InputDecoration(
+                  hintText: kDefaultServerUrl,
+                  border: OutlineInputBorder(),
+                  helperText: 'e.g. https://your-host.ts.net:9847',
+                ),
+                keyboardType: TextInputType.url,
+                autocorrect: false,
+              ),
+              const SizedBox(height: 16),
+              Row(
                 children: [
-                  Expanded(
-                    child: TextField(
-                      controller: _chipController,
-                      decoration: const InputDecoration(
-                        hintText: 'New chip text',
-                        border: OutlineInputBorder(),
-                        contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                      ),
-                      onSubmitted: (_) => _addChip(),
-                    ),
+                  OutlinedButton(
+                    onPressed: _testing ? null : _testConnection,
+                    child: _testing
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2))
+                        : const Text('Test Connection'),
                   ),
-                  const SizedBox(width: 8),
+                  const SizedBox(width: 12),
                   FilledButton(
-                    onPressed: _addChip,
-                    child: const Text('Add'),
+                    onPressed: _save,
+                    child: const Text('Save'),
                   ),
                 ],
               ),
-            ),
-            const SizedBox(height: 16),
-            // Chips list for selected category
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: _loadingChips
-                  ? const Center(child: CircularProgressIndicator())
-                  : _buildChipsList(),
-            ),
-          ],
-          const Divider(),
-          ListTile(
-            leading: const Icon(Icons.info_outline),
-            title: const Text('About'),
-            subtitle: Text('Avodah v$avodahVersion'),
+              if (_testResult != null) ...[
+                const SizedBox(height: 12),
+                Text(
+                  _testResult!,
+                  style: TextStyle(
+                    color: _testResult!.startsWith('Connected')
+                        ? Colors.green
+                        : Colors.red,
+                  ),
+                ),
+              ],
+            ],
           ),
-          const Divider(),
-          // Update App section
+        ),
+        const Divider(),
+        // Server Connection
+        if (widget.crdtSyncService != null) ...[
           Padding(
             padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text('App Updates',
+                Text('Server Connection',
                     style: Theme.of(context).textTheme.titleMedium),
                 const SizedBox(height: 8),
                 const Text(
-                  'Build and install the latest version on your device.',
+                  'Remove pairing with the current sync server.',
                   style: TextStyle(color: Colors.grey),
                 ),
                 const SizedBox(height: 12),
-                if (_updateBuilding || _updateStatus != null) ...[
-                  // Status display
-                  Container(
-                    width: double.infinity,
-                    padding: const EdgeInsets.all(12),
-                    decoration: BoxDecoration(
-                      color: _updateStatus == 'Update complete!'
-                          ? Colors.green.shade50
-                          : _updateStatus == 'Build failed'
-                              ? Colors.red.shade50
-                              : Colors.blue.shade50,
-                      borderRadius: BorderRadius.circular(8),
-                      border: Border.all(
-                        color: _updateStatus == 'Update complete!'
-                            ? Colors.green.shade200
-                            : _updateStatus == 'Build failed'
-                                ? Colors.red.shade200
-                                : Colors.blue.shade200,
-                      ),
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            if (_updateBuilding)
-                              const SizedBox(
-                                width: 16,
-                                height: 16,
-                                child: CircularProgressIndicator(strokeWidth: 2),
-                              )
-                            else
-                              Icon(
-                                _updateStatus == 'Update complete!'
-                                    ? Icons.check_circle
-                                    : Icons.error,
-                                size: 16,
-                                color: _updateStatus == 'Update complete!'
-                                    ? Colors.green
-                                    : Colors.red,
-                              ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                _updateStatus ?? '',
-                                style: TextStyle(
-                                  fontWeight: FontWeight.w500,
-                                  color: _updateStatus == 'Update complete!'
-                                      ? Colors.green.shade700
-                                      : _updateStatus == 'Build failed'
-                                          ? Colors.red.shade700
-                                          : Colors.blue.shade700,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                        if (_updateLog.isNotEmpty) ...[
-                          const SizedBox(height: 8),
-                          Text(
-                            _updateLog.take(5).join('\n'),
-                            style: const TextStyle(
-                              fontFamily: 'monospace',
-                              fontSize: 11,
-                              color: Colors.grey,
-                            ),
-                          ),
-                        ],
-                      ],
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                ],
                 SizedBox(
                   width: double.infinity,
                   child: FilledButton.icon(
-                    onPressed: _updateBuilding ? null : _triggerSelfUpdate,
-                    icon: const Icon(Icons.system_update),
-                    label: Text(_updateBuilding ? 'Building...' : 'Update App'),
+                    onPressed: _fullSyncing ? null : _forceFullSync,
+                    icon: _fullSyncing
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                                strokeWidth: 2, color: Colors.white))
+                        : const Icon(Icons.sync),
+                    label: Text(
+                        _fullSyncing ? 'Syncing...' : 'Force Full Sync'),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  'Re-downloads all data from the server.',
+                  style: TextStyle(color: Colors.grey, fontSize: 12),
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton.icon(
+                    onPressed: _forgetting ? null : _forgetServer,
+                    icon: _forgetting
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2))
+                        : const Icon(Icons.link_off, color: Colors.red),
+                    label: Text(
+                        _forgetting ? 'Forgetting...' : 'Forget This Server'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: Colors.red,
+                    ),
                   ),
                 ),
               ],
             ),
           ),
-          const SizedBox(height: 32),
+          const Divider(),
         ],
-      ),
+        // App Updates
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('App Updates',
+                  style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 8),
+              const Text(
+                'Build and install the latest version on your device.',
+                style: TextStyle(color: Colors.grey),
+              ),
+              const SizedBox(height: 12),
+              if (_updateBuilding || _updateStatus != null) ...[
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: _updateStatus == 'Update complete!'
+                        ? Colors.green.shade50
+                        : _updateStatus == 'Build failed'
+                            ? Colors.red.shade50
+                            : Colors.blue.shade50,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(
+                      color: _updateStatus == 'Update complete!'
+                          ? Colors.green.shade200
+                          : _updateStatus == 'Build failed'
+                              ? Colors.red.shade200
+                              : Colors.blue.shade200,
+                    ),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          if (_updateBuilding)
+                            const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          else
+                            Icon(
+                              _updateStatus == 'Update complete!'
+                                  ? Icons.check_circle
+                                  : Icons.error,
+                              size: 16,
+                              color: _updateStatus == 'Update complete!'
+                                  ? Colors.green
+                                  : Colors.red,
+                            ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              _updateStatus ?? '',
+                              style: TextStyle(
+                                fontWeight: FontWeight.w500,
+                                color: _updateStatus == 'Update complete!'
+                                    ? Colors.green.shade700
+                                    : _updateStatus == 'Build failed'
+                                        ? Colors.red.shade700
+                                        : Colors.blue.shade700,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      if (_updateLog.isNotEmpty) ...[
+                        const SizedBox(height: 8),
+                        Text(
+                          _updateLog.take(5).join('\n'),
+                          style: const TextStyle(
+                            fontFamily: 'monospace',
+                            fontSize: 11,
+                            color: Colors.grey,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 12),
+              ],
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: _updateBuilding ? null : _triggerSelfUpdate,
+                  icon: const Icon(Icons.system_update),
+                  label: Text(_updateBuilding ? 'Building...' : 'Update App'),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const Divider(),
+        // About
+        ListTile(
+          leading: const Icon(Icons.info_outline),
+          title: const Text('About'),
+          subtitle: Text('Avodah v$avodahVersion'),
+        ),
+        const SizedBox(height: 32),
+      ],
     );
   }
 
@@ -694,26 +738,30 @@ class _SettingsScreenState extends State<SettingsScreen> {
 // ---------------------------------------------------------------------------
 
 class _DisplaySettingsSection extends StatefulWidget {
+  final DisplaySettingsService service;
+
+  const _DisplaySettingsSection({required this.service});
+
   @override
   State<_DisplaySettingsSection> createState() => _DisplaySettingsSectionState();
 }
 
 class _DisplaySettingsSectionState extends State<_DisplaySettingsSection> {
-  late DisplaySettingsService _service;
   bool _loaded = false;
 
   @override
   void initState() {
     super.initState();
-    _service = DisplaySettingsService();
-    _service.load().then((_) {
+    widget.service.load().then((_) {
       if (mounted) setState(() => _loaded = true);
     });
   }
 
+  DisplaySettingsService get _service => widget.service;
+
   @override
   void dispose() {
-    _service.dispose();
+    // Service is owned by app-level main.dart, not disposed here.
     super.dispose();
   }
 

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:avodah_core/version.dart';
 import '../services/agent_api_client.dart';
 import '../services/crdt_sync_service.dart';
+import '../services/display_settings_service.dart';
 
 const kServerUrlKey = 'sync_server_url';
 const kDefaultServerUrl = 'http://100.64.0.1:9847';
@@ -74,6 +75,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   /// Whether Forget Server is in progress.
   bool _forgetting = false;
 
+  /// Whether Force Full Sync is in progress.
+  bool _fullSyncing = false;
+
   /// Triggers the Forget Server confirmation and revocation flow.
   Future<void> _forgetServer() async {
     final confirmed = await showDialog<bool>(
@@ -120,6 +124,26 @@ class _SettingsScreenState extends State<SettingsScreen> {
       }
     } finally {
       if (mounted) setState(() => _forgetting = false);
+    }
+  }
+
+  Future<void> _forceFullSync() async {
+    setState(() => _fullSyncing = true);
+    try {
+      final pushed = await widget.crdtSyncService?.forceFullSync() ?? 0;
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Full sync complete. Pushed $pushed deltas. Pull will refresh shortly.')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Full sync failed: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _fullSyncing = false);
     }
   }
 
@@ -372,6 +396,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
           ),
           const Divider(),
+          // --- Display Settings ---
+          _DisplaySettingsSection(),
+          const Divider(),
           if (widget.crdtSyncService != null)
             Padding(
               padding: const EdgeInsets.all(16),
@@ -386,6 +413,27 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     style: TextStyle(color: Colors.grey),
                   ),
                   const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      onPressed: _fullSyncing ? null : _forceFullSync,
+                      icon: _fullSyncing
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(
+                                  strokeWidth: 2, color: Colors.white))
+                          : const Icon(Icons.sync),
+                      label: Text(
+                          _fullSyncing ? 'Syncing...' : 'Force Full Sync'),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  const Text(
+                    'Re-downloads all data from the server.',
+                    style: TextStyle(color: Colors.grey, fontSize: 12),
+                  ),
+                  const SizedBox(height: 16),
                   SizedBox(
                     width: double.infinity,
                     child: OutlinedButton.icon(
@@ -637,6 +685,153 @@ class _SettingsScreenState extends State<SettingsScreen> {
           onDeleted: () => _removeChip(_selectedCategory!, chip),
         );
       }).toList(),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Display Settings Section
+// ---------------------------------------------------------------------------
+
+class _DisplaySettingsSection extends StatefulWidget {
+  @override
+  State<_DisplaySettingsSection> createState() => _DisplaySettingsSectionState();
+}
+
+class _DisplaySettingsSectionState extends State<_DisplaySettingsSection> {
+  late DisplaySettingsService _service;
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = DisplaySettingsService();
+    _service.load().then((_) {
+      if (mounted) setState(() => _loaded = true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _service.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: _service,
+      builder: (context, _) {
+        if (!_loaded) {
+          return const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Display',
+                  style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 8),
+              const Text(
+                'Customize brightness, accent color, and contrast.',
+                style: TextStyle(color: Colors.grey),
+              ),
+              const SizedBox(height: 16),
+
+              // Brightness
+              Text('Brightness',
+                  style: Theme.of(context).textTheme.bodyMedium),
+              const SizedBox(height: 8),
+              SegmentedButton<DisplayBrightness>(
+                segments: const [
+                  ButtonSegment(
+                      value: DisplayBrightness.light,
+                      label: Text('Light'),
+                      icon: Icon(Icons.light_mode)),
+                  ButtonSegment(
+                      value: DisplayBrightness.dark,
+                      label: Text('Dark'),
+                      icon: Icon(Icons.dark_mode)),
+                  ButtonSegment(
+                      value: DisplayBrightness.system,
+                      label: Text('System'),
+                      icon: Icon(Icons.brightness_auto)),
+                ],
+                selected: {_service.brightness},
+                onSelectionChanged: (selected) {
+                  _service.setBrightness(selected.first);
+                },
+              ),
+              const SizedBox(height: 20),
+
+              // Accent color
+              Text('Accent Color',
+                  style: Theme.of(context).textTheme.bodyMedium),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: kAccentColors.map((color) {
+                  final isSelected = _service.accentColor.toARGB32() == color.toARGB32();
+                  return GestureDetector(
+                    onTap: () => _service.setAccentColor(color),
+                    child: Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: color,
+                        shape: BoxShape.circle,
+                        border: isSelected
+                            ? Border.all(color: Colors.white, width: 3)
+                            : null,
+                        boxShadow: isSelected
+                            ? [
+                                BoxShadow(
+                                  color: color.withAlpha(128),
+                                  blurRadius: 8,
+                                  spreadRadius: 2,
+                                )
+                              ]
+                            : null,
+                      ),
+                      child: isSelected
+                          ? const Icon(Icons.check, color: Colors.white, size: 20)
+                          : null,
+                    ),
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 20),
+
+              // Contrast
+              Text('Contrast',
+                  style: Theme.of(context).textTheme.bodyMedium),
+              const SizedBox(height: 8),
+              SegmentedButton<DisplayContrast>(
+                segments: const [
+                  ButtonSegment(
+                      value: DisplayContrast.normal,
+                      label: Text('Normal'),
+                      icon: Icon(Icons.text_fields)),
+                  ButtonSegment(
+                      value: DisplayContrast.high,
+                      label: Text('High'),
+                      icon: Icon(Icons.contrast)),
+                ],
+                selected: {_service.contrast},
+                onSelectionChanged: (selected) {
+                  _service.setContrast(selected.first);
+                },
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -344,20 +344,20 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Settings'),
-        bottom: const TabBar(
-          tabs: [
-            Tab(icon: Icon(Icons.palette), text: 'Appearance'),
-            Tab(icon: Icon(Icons.tune), text: 'Input'),
-            Tab(icon: Icon(Icons.settings_ethernet), text: 'Technical'),
-          ],
+    return DefaultTabController(
+      length: 3,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Settings'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(icon: Icon(Icons.palette), text: 'Appearance'),
+              Tab(icon: Icon(Icons.tune), text: 'Input'),
+              Tab(icon: Icon(Icons.settings_ethernet), text: 'Technical'),
+            ],
+          ),
         ),
-      ),
-      body: DefaultTabController(
-        length: 3,
-        child: TabBarView(
+        body: TabBarView(
           children: [
             _buildAppearanceTab(),
             _buildInputTab(),

--- a/phone/lib/utils/syntax_highlight.dart
+++ b/phone/lib/utils/syntax_highlight.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:highlight/highlight.dart' as hl;
 
+import '../services/display_settings_service.dart';
+
 /// Maps common file extensions to highlight.js language names.
 String? inferLanguage(String? filePath) {
   if (filePath == null || filePath.isEmpty) return null;
@@ -123,49 +125,70 @@ Map<String, Color> _syntaxColors = {
   'default': const Color(0xFFE0E0E0),
 };
 
-Color _colorForClass(String? className) {
-  if (className == null || className.isEmpty) return _syntaxColors['default']!;
+Color _colorForClass(String? className, [SyntaxColors? syntaxColors]) {
+  final colors = syntaxColors ?? SyntaxColors.normal;
+
+  if (className == null || className.isEmpty) {
+    return colors.defaultColor;
+  }
 
   final firstClass = className.split(' ').first;
-  if (_syntaxColors.containsKey(firstClass)) {
-    return _syntaxColors[firstClass]!;
+  final mapped = colors.forClass(firstClass);
+  if (mapped != colors.defaultColor || _syntaxColors.containsKey(firstClass)) {
+    return mapped;
   }
   for (final key in _syntaxColors.keys) {
     if (firstClass.startsWith(key)) {
       return _syntaxColors[key]!;
     }
   }
-  return _syntaxColors['default']!;
+  return colors.defaultColor;
 }
 
 /// Parses code with syntax highlighting and returns a list of TextSpans.
-List<TextSpan> parseSyntaxHighlighted(String code, String? language) {
+List<TextSpan> parseSyntaxHighlighted(String code, String? language,
+    [SyntaxColors? syntaxColors]) {
   if (language == null || language.isEmpty || code.isEmpty) {
-    return [TextSpan(text: code, style: const TextStyle(color: Color(0xFFE0E0E0)))];
+    return [
+      TextSpan(
+          text: code,
+          style:
+              TextStyle(color: (syntaxColors ?? SyntaxColors.normal).defaultColor))
+    ];
   }
 
   try {
     final result = hl.highlight.parse(code, language: language);
-    final spans = _convertNodes(result.nodes ?? []);
+    final spans = _convertNodes(result.nodes ?? [], syntaxColors);
     if (spans.isEmpty) {
-      return [TextSpan(text: code, style: const TextStyle(color: Color(0xFFE0E0E0)))];
+      return [
+        TextSpan(
+            text: code,
+            style: TextStyle(
+                color: (syntaxColors ?? SyntaxColors.normal).defaultColor))
+      ];
     }
     return spans;
   } catch (_) {
-    return [TextSpan(text: code, style: const TextStyle(color: Color(0xFFE0E0E0)))];
+    return [
+      TextSpan(
+          text: code,
+          style:
+              TextStyle(color: (syntaxColors ?? SyntaxColors.normal).defaultColor))
+    ];
   }
 }
 
-List<TextSpan> _convertNodes(List<hl.Node> nodes) {
+List<TextSpan> _convertNodes(List<hl.Node> nodes, [SyntaxColors? syntaxColors]) {
   final spans = <TextSpan>[];
   for (final node in nodes) {
     if (node.value != null) {
       spans.add(TextSpan(
         text: node.value,
-        style: TextStyle(color: _colorForClass(node.className)),
+        style: TextStyle(color: _colorForClass(node.className, syntaxColors)),
       ));
     } else if (node.children != null) {
-      final childSpans = _convertNodes(node.children!);
+      final childSpans = _convertNodes(node.children!, syntaxColors);
       if (childSpans.isNotEmpty) {
         spans.addAll(childSpans);
       }

--- a/phone/lib/widgets/diff_widgets.dart
+++ b/phone/lib/widgets/diff_widgets.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/repo_diff.dart';
+import '../services/display_settings_service.dart';
 import '../utils/syntax_highlight.dart';
 import '../utils/word_diff.dart';
 import 'diff_stat_bar.dart';
@@ -304,12 +305,14 @@ class DiffLineView extends StatelessWidget {
     this.language,
   });
 
-  Color _backgroundColor() {
+  Color _backgroundColor(BuildContext context) {
+    final isHighContrast = Theme.of(context).syntaxColors.isHighContrast;
+    final alpha = isHighContrast ? 80 : 30;
     switch (line.type) {
       case 'add':
-        return Colors.green.withAlpha(30);
+        return Colors.green.withAlpha(alpha);
       case 'del':
-        return Colors.red.withAlpha(30);
+        return Colors.red.withAlpha(alpha);
       default:
         return Colors.transparent;
     }
@@ -346,7 +349,7 @@ class DiffLineView extends StatelessWidget {
 
     return Container(
       decoration: BoxDecoration(
-        color: _backgroundColor(),
+        color: _backgroundColor(context),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -426,7 +429,8 @@ class DiffLineView extends StatelessWidget {
             // For unchanged segments, apply syntax highlighting
             // For added/deleted segments, use plain text with muted color
             if (!isHighlighted && language != null) {
-              final syntaxSpans = parseSyntaxHighlighted(segment.text, language);
+              final syntaxSpans = parseSyntaxHighlighted(
+                  segment.text, language, theme.syntaxColors);
               return Container(
                 decoration: BoxDecoration(
                   color: bgColor,
@@ -466,7 +470,7 @@ class DiffLineView extends StatelessWidget {
 
     // Fallback: render with syntax highlighting if language is available
     if (language != null) {
-      final syntaxSpans = parseSyntaxHighlighted(line.content, language);
+      final syntaxSpans = parseSyntaxHighlighted(line.content, language, theme.syntaxColors);
       return Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
         child: RichText(

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
 import '../services/display_settings_service.dart';
+import '../utils/syntax_highlight.dart';
 
 /// GFM alert type detected in blockquote text content.
 enum _GfmAlertType {
@@ -58,6 +59,7 @@ class MarkdownWithAnnotations extends StatelessWidget {
           onLineTapped: onLineTapped,
           sourceLines: data.split('\n'),
         ),
+        'code': _CodeBlockBuilder(syntaxColors: theme.syntaxColors),
       },
       onTapLink: (text, href, title) {
         // Allow link taps to open URLs
@@ -90,6 +92,12 @@ class MarkdownWithAnnotations extends StatelessWidget {
         top: 8,
         bottom: 8,
         right: 12,
+      ),
+      code: TextStyle(
+        fontFamily: 'monospace',
+        fontSize: baseStyle?.fontSize ?? 14,
+        color: theme.colorScheme.onSurface,
+        backgroundColor: theme.colorScheme.surfaceContainerHighest,
       ),
     );
   }
@@ -284,6 +292,40 @@ class _GfmAlertBlockquoteBuilder extends MarkdownElementBuilder {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Custom builder for code block elements that applies syntax highlighting
+/// using SyntaxColors and responds to high contrast settings.
+class _CodeBlockBuilder extends MarkdownElementBuilder {
+  final SyntaxColors syntaxColors;
+
+  _CodeBlockBuilder({required this.syntaxColors});
+
+  @override
+  Widget? visitElementAfter(element, TextStyle? preferredStyle) {
+    // Extract language from class attribute (e.g., 'language-dart' -> 'dart')
+    final classAttr = element.attributes['class'];
+    String? language;
+    if (classAttr != null && classAttr.startsWith('language-')) {
+      language = classAttr.substring('language-'.length);
+    }
+
+    final code = element.textContent;
+    if (code.isEmpty) {
+      return null;
+    }
+
+    // Use the RichText approach from diff_widgets.dart for syntax highlighting
+    return RichText(
+      text: TextSpan(
+        style: preferredStyle?.copyWith(
+          fontFamily: 'monospace',
+          fontSize: 13,
+        ),
+        children: parseSyntaxHighlighted(code, language, syntaxColors),
       ),
     );
   }

--- a/phone/lib/widgets/markdown_with_annotations.dart
+++ b/phone/lib/widgets/markdown_with_annotations.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
+import '../services/display_settings_service.dart';
+
 /// GFM alert type detected in blockquote text content.
 enum _GfmAlertType {
   note,
@@ -69,7 +71,9 @@ class MarkdownWithAnnotations extends StatelessWidget {
   ) {
     final theme = Theme.of(context);
     const amberAccent = Color(0xFFFFC107);
-    final amberLight = Colors.amber.shade50;
+    // Use more saturated amber background in high contrast mode
+    final isHighContrast = theme.syntaxColors.isHighContrast;
+    final amberLight = isHighContrast ? Colors.amber.shade100 : Colors.amber.shade50;
 
     return MarkdownStyleSheet(
       blockquote: baseStyle?.copyWith(


### PR DESCRIPTION
## Summary
- New \"Display\" section in Settings with brightness (Light/Dark/System), 8 accent color swatches, and contrast (Normal/High) controls
- Accent color applied app-wide via ColorScheme.fromSeed
- High contrast mode: diff backgrounds alpha 30→80, syntax highlighting colors increased
- Settings persist via SharedPreferences
- Both markdown and diff views respond to all three settings
- **Spike fix:** Settings screen now uses app-level DisplaySettingsService (no dual-instance bug) and is organized into 3 tabs (Appearance / Input / Technical)

## Changes
- **New:** `phone/lib/services/display_settings_service.dart` — DisplaySettingsService with ChangeNotifier
- **Modified:** `phone/lib/main.dart` — injects DisplaySettingsService, builds themes from settings
- **Modified:** `phone/lib/settings/settings_screen.dart` — added Display section with controls; restructured into 3 tabs (Appearance/Input/Technical); passes DisplaySettingsService instance instead of creating new one
- **Modified:** `phone/lib/widgets/diff_widgets.dart` — theme-aware high contrast diff backgrounds
- **Modified:** `phone/lib/utils/syntax_highlight.dart` — accepts SyntaxColors parameter for contrast
- **Modified:** `phone/lib/widgets/markdown_with_annotations.dart` — high contrast blockquote backgrounds

## Acceptance Criteria (original)
- [x] AC-1: Display section with brightness, accent color grid, contrast controls
- [x] AC-2: Accent color propagates app-wide immediately
- [x] AC-3: High contrast diff backgrounds and syntax colors
- [x] AC-4: All three settings persist via SharedPreferences
- [x] AC-5: Both markdown and diff views respond to settings

## Spike Fix ACs (2026-04-12)
- [x] AC6: Settings screen displays 3 tabs: Appearance, Input, Technical
- [x] AC7: Changing accent color in Appearance tab immediately updates the settings screen's AppBar color
- [x] AC8: Changing brightness immediately updates the app's theme mode
- [x] AC9: All settings still persist across app restarts
- [x] AC10: Comment Chip Presets in Input tab work identically to before
- [x] AC11: Technical tab contains Server URL, Server Connection, App Updates, and About
- [x] AC12: No new package dependencies added
- [x] AC13: flutter analyze passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)