### PR TITLE
feat(avo): AVO-092 — CRDT Category Chip Sync

### DIFF
--- a/mcp/bin/sync_server.dart
+++ b/mcp/bin/sync_server.dart
@@ -19,6 +19,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:avodah_core/avodah_core.dart';
+import 'package:uuid/uuid.dart';
 import 'package:avodah_core/version.dart' as version;
 import 'package:cryptography/cryptography.dart' as crypto;
 import 'package:avodah_mcp/config/avo_config.dart';
@@ -39,6 +40,61 @@ DateTime? startTime;
 
 /// Last uncaught error message from runZonedGuarded.
 String? lastError;
+
+/// Migrates category chips from config.json to the category_chips table.
+///
+/// This is idempotent — it only runs if no migrated-* entries exist in the
+/// table and config.categoryChips is non-empty.
+Future<void> _migrateCategoryChipsFromConfig(
+  AppDatabase db,
+  HybridLogicalClock clock,
+  AvoConfig config,
+) async {
+  // Idempotency check: skip if already migrated
+  final allChips = await db.select(db.categoryChips).get();
+  final migratedRows = allChips.where((c) => c.id.startsWith('migrated-')).toList();
+
+  if (migratedRows.isNotEmpty) {
+    stderr.writeln(
+        'CategoryChip migration: skipped (${migratedRows.length} migrated entries exist)');
+    return;
+  }
+
+  // Nothing to migrate?
+  if (config.categoryChips.isEmpty) {
+    stderr.writeln('CategoryChip migration: no chips in config, skipping');
+    return;
+  }
+
+  // Migrate each chip from config.json
+  int totalMigrated = 0;
+  for (final MapEntry<String, List<String>> categoryEntry
+      in config.categoryChips.entries) {
+    final category = categoryEntry.key;
+    final chips = categoryEntry.value;
+
+    for (int i = 0; i < chips.length; i++) {
+      final chipLabel = chips[i];
+
+      // Create document with migrated-* ID for idempotency tracking
+      final doc = CategoryChipDocument(
+        id: 'migrated-${const Uuid().v4()}',
+        clock: clock,
+      );
+      doc.category = category;
+      doc.label = chipLabel;
+      doc.sortOrder = i;
+
+      await db
+          .into(db.categoryChips)
+          .insertOnConflictUpdate(doc.toDriftCompanion());
+      totalMigrated++;
+    }
+  }
+
+  stderr.writeln(
+      'CategoryChip migration: migrated $totalMigrated chips from config.json');
+}
 
 Future<void> main(List<String> args) async {
   runZonedGuarded(() async {
@@ -119,6 +175,9 @@ Future<void> main(List<String> args) async {
   final db = openDatabase(paths.databasePath);
   final nodeId = paths.getNodeIdSync();
   final clock = HybridLogicalClock(nodeId: nodeId);
+
+  // Phase 6: Migrate category chips from config.json to DB on first startup
+  await _migrateCategoryChipsFromConfig(db, clock, config);
 
   // Pairing service for secure sync device authentication
   final pairingService = PairingService(db: db);

--- a/mcp/lib/services/sync_api_service.dart
+++ b/mcp/lib/services/sync_api_service.dart
@@ -233,17 +233,43 @@ class SyncApiService {
   Future<void> _handleGetCategoryChips(HttpRequest request) async {
     final category = request.uri.queryParameters['category'];
 
-    final chips = config?.categoryChips ?? {};
+    // Read from CRDT-backed table
+    final allChips = await db.select(db.categoryChips).get();
+
+    // Build model list, filtering soft-deleted chips
+    final chipModels = <CategoryChipModel>[];
+    for (final row in allChips) {
+      final doc = CategoryChipDocument.fromDrift(chip: row, clock: clock);
+      if (!doc.isDeleted) {
+        chipModels.add(doc.toModel());
+      }
+    }
 
     if (category != null) {
       // Return chips for specific category
+      final categoryChipList =
+          chipModels.where((c) => c.category == category).toList()
+            ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
       _jsonResponse(request, HttpStatus.ok, {
         'category': category,
-        'chips': chips[category] ?? [],
+        'chips': categoryChipList.map((c) => c.label).toList(),
       });
     } else {
-      // Return all chips
-      _jsonResponse(request, HttpStatus.ok, {'categoryChips': chips});
+      // Return all chips as a map grouped by category
+      final chipsMap = <String, List<String>>{};
+      for (final chip in chipModels) {
+        final cat = chip.category ?? '';
+        chipsMap.putIfAbsent(cat, () => []).add(chip.label!);
+      }
+      // Sort each category's chips by sortOrder
+      for (final key in chipsMap.keys) {
+        final sorted = chipModels
+            .where((c) => c.category == key)
+            .toList()
+          ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+        chipsMap[key] = sorted.map((c) => c.label!).toList();
+      }
+      _jsonResponse(request, HttpStatus.ok, {'categoryChips': chipsMap});
     }
   }
 
@@ -252,12 +278,6 @@ class SyncApiService {
   /// Adds or removes a chip preset for a category.
   /// Body: {"action": "add"|"remove", "category": "Working", "chip": "standup"}
   Future<void> _handleUpdateCategoryChip(HttpRequest request) async {
-    if (config == null) {
-      _jsonResponse(request, HttpStatus.serviceUnavailable,
-          {'error': 'Config not available'});
-      return;
-    }
-
     final body = await utf8.decoder.bind(request).join();
     final json = jsonDecode(body) as Map<String, dynamic>;
 
@@ -277,37 +297,62 @@ class SyncApiService {
       return;
     }
 
-    final newChips = Map<String, List<String>>.from(config!.categoryChips);
-    final categoryChips = List<String>.from(newChips[category] ?? []);
-
     if (action == 'add') {
-      if (!categoryChips.contains(chip)) {
-        categoryChips.add(chip);
-        newChips[category] = categoryChips;
-        final newConfig = config!.copyWith(categoryChips: newChips);
-        await newConfig.save(paths ?? AvodahPaths());
-        config = newConfig;
-        _jsonResponse(request, HttpStatus.ok, {
-          'success': true,
-          'action': 'added',
-          'category': category,
-          'chip': chip,
-        });
-      } else {
+      // Find existing chip by category+label to check if it already exists
+      final existingChips = await db.select(db.categoryChips).get();
+      CategoryChip? existing;
+      for (final row in existingChips) {
+        final doc = CategoryChipDocument.fromDrift(chip: row, clock: clock);
+        if (!doc.isDeleted && doc.category == category && doc.label == chip) {
+          existing = row;
+          break;
+        }
+      }
+
+      if (existing != null) {
         _jsonResponse(request, HttpStatus.ok, {
           'success': true,
           'action': 'already_exists',
           'category': category,
           'chip': chip,
         });
+      } else {
+        // Create new CRDT document and upsert
+        final doc = CategoryChipDocument.create(
+          clock: clock,
+          category: category,
+          label: chip,
+          sortOrder: 0,
+        );
+        await db
+            .into(db.categoryChips)
+            .insertOnConflictUpdate(doc.toDriftCompanion());
+        _jsonResponse(request, HttpStatus.ok, {
+          'success': true,
+          'action': 'added',
+          'category': category,
+          'chip': chip,
+        });
       }
     } else if (action == 'remove') {
-      if (categoryChips.contains(chip)) {
-        categoryChips.remove(chip);
-        newChips[category] = categoryChips;
-        final newConfig = config!.copyWith(categoryChips: newChips);
-        await newConfig.save(paths ?? AvodahPaths());
-        config = newConfig;
+      // Soft-delete via CRDT _deleted field
+      final existingChips = await db.select(db.categoryChips).get();
+      CategoryChip? existing;
+      for (final row in existingChips) {
+        final doc = CategoryChipDocument.fromDrift(chip: row, clock: clock);
+        if (!doc.isDeleted && doc.category == category && doc.label == chip) {
+          existing = row;
+          break;
+        }
+      }
+
+      if (existing != null) {
+        final doc =
+            CategoryChipDocument.fromDrift(chip: existing, clock: clock);
+        doc.delete();
+        await db
+            .into(db.categoryChips)
+            .insertOnConflictUpdate(doc.toDriftCompanion());
       }
       _jsonResponse(request, HttpStatus.ok, {
         'success': true,
@@ -323,14 +368,8 @@ class SyncApiService {
 
   /// DELETE /api/config/category-chips?category=Working&chip=standup
   ///
-  /// Removes a chip preset from a category.
+  /// Removes a chip preset from a category (soft-delete via CRDT _deleted field).
   Future<void> _handleDeleteCategoryChip(HttpRequest request) async {
-    if (config == null) {
-      _jsonResponse(request, HttpStatus.serviceUnavailable,
-          {'error': 'Config not available'});
-      return;
-    }
-
     final category = request.uri.queryParameters['category'];
     final chip = request.uri.queryParameters['chip'];
 
@@ -340,15 +379,17 @@ class SyncApiService {
       return;
     }
 
-    final newChips = Map<String, List<String>>.from(config!.categoryChips);
-    final categoryChips = List<String>.from(newChips[category] ?? []);
-
-    if (categoryChips.contains(chip)) {
-      categoryChips.remove(chip);
-      newChips[category] = categoryChips;
-      final newConfig = config!.copyWith(categoryChips: newChips);
-      await newConfig.save(paths ?? AvodahPaths());
-      config = newConfig;
+    // Find and soft-delete via CRDT _deleted field
+    final existingChips = await db.select(db.categoryChips).get();
+    for (final row in existingChips) {
+      final doc = CategoryChipDocument.fromDrift(chip: row, clock: clock);
+      if (!doc.isDeleted && doc.category == category && doc.label == chip) {
+        doc.delete();
+        await db
+            .into(db.categoryChips)
+            .insertOnConflictUpdate(doc.toDriftCompanion());
+        break;
+      }
     }
 
     _jsonResponse(request, HttpStatus.ok, {

--- a/mcp/lib/services/sync_api_service.dart
+++ b/mcp/lib/services/sync_api_service.dart
@@ -230,6 +230,7 @@ class SyncApiService {
   ///
   /// Returns the list of chip presets for the specified category.
   /// If no category is specified, returns all category chips as a map.
+  /// Falls back to config.categoryChips when the database is empty.
   Future<void> _handleGetCategoryChips(HttpRequest request) async {
     final category = request.uri.queryParameters['category'];
 
@@ -243,6 +244,21 @@ class SyncApiService {
       if (!doc.isDeleted) {
         chipModels.add(doc.toModel());
       }
+    }
+
+    // Fall back to config.categoryChips when DB is empty
+    if (chipModels.isEmpty && config != null && config!.categoryChips.isNotEmpty) {
+      final configChips = config!.categoryChips;
+      if (category != null) {
+        final chips = configChips[category] ?? [];
+        _jsonResponse(request, HttpStatus.ok, {
+          'category': category,
+          'chips': chips,
+        });
+      } else {
+        _jsonResponse(request, HttpStatus.ok, {'categoryChips': configChips});
+      }
+      return;
     }
 
     if (category != null) {
@@ -278,7 +294,19 @@ class SyncApiService {
   /// Adds or removes a chip preset for a category.
   /// Body: {"action": "add"|"remove", "category": "Working", "chip": "standup"}
   Future<void> _handleUpdateCategoryChip(HttpRequest request) async {
+    // Check if config is available first
+    if (config == null) {
+      _jsonResponse(request, HttpStatus.serviceUnavailable,
+          {'error': 'Service unavailable: no config'});
+      return;
+    }
+
     final body = await utf8.decoder.bind(request).join();
+    if (body.isEmpty) {
+      _jsonResponse(request, HttpStatus.badRequest,
+          {'error': 'Request body is empty'});
+      return;
+    }
     final json = jsonDecode(body) as Map<String, dynamic>;
 
     final action = json['action'] as String?;

--- a/mcp/lib/services/sync_api_service.dart
+++ b/mcp/lib/services/sync_api_service.dart
@@ -30,6 +30,7 @@ class SyncDocType {
   static const String project = 'project';
   static const String dailyPlan = 'dailyPlan';
   static const String dayPlanTask = 'dayPlanTask';
+  static const String categoryChip = 'categoryChip';
 }
 
 /// Handles CRDT delta sync HTTP requests.
@@ -454,6 +455,15 @@ class SyncApiService {
       }
     }
 
+    // Category Chips
+    final categoryChips = await db.select(db.categoryChips).get();
+    for (final row in categoryChips) {
+      if (_isAfterWatermark(row.crdtClock, since)) {
+        final doc = CategoryChipDocument.fromDrift(chip: row, clock: clock);
+        deltas.add(_wrapDelta(SyncDocType.categoryChip, doc));
+      }
+    }
+
     return deltas;
   }
 
@@ -487,6 +497,8 @@ class SyncApiService {
         await _mergeDailyPlan(id, state);
       case SyncDocType.dayPlanTask:
         await _mergeDayPlanTask(id, state);
+      case SyncDocType.categoryChip:
+        await _mergeCategoryChip(id, state);
       default:
         throw ArgumentError('Unknown delta type: $type');
     }
@@ -600,6 +612,23 @@ class SyncApiService {
     await db
         .into(db.dayPlanTasks)
         .insertOnConflictUpdate(doc.toDriftCompanion());
+  }
+
+  Future<void> _mergeCategoryChip(
+      String id, Map<String, CrdtFieldState> state) async {
+    final rows = await (db.select(db.categoryChips)
+          ..where((t) => t.id.equals(id)))
+        .get();
+
+    final CategoryChipDocument doc;
+    if (rows.isNotEmpty) {
+      doc = CategoryChipDocument.fromDrift(chip: rows.first, clock: clock);
+    } else {
+      doc = CategoryChipDocument.fromState(id: id, clock: clock, state: {});
+    }
+
+    _applyState(doc, state);
+    await db.into(db.categoryChips).insertOnConflictUpdate(doc.toDriftCompanion());
   }
 
   // ============================================================

--- a/mcp/test/services/sync_api_service_test.dart
+++ b/mcp/test/services/sync_api_service_test.dart
@@ -234,6 +234,123 @@ void main() {
       expect(timers[0].taskTitle, equals('Phone timer'));
       expect(timers[0].isRunning, isTrue);
     });
+
+    test('merges categoryChip from remote', () async {
+      final remoteTs = HybridTimestamp(
+        physicalTime: DateTime.now().millisecondsSinceEpoch,
+        counter: 0,
+        nodeId: 'phone-1',
+      );
+
+      final delta = {
+        'type': SyncDocType.categoryChip,
+        'id': 'remote-chip-1',
+        'fields': {
+          'category': {'v': 'Working', 't': remoteTs.pack()},
+          'label': {'v': 'standup', 't': remoteTs.pack()},
+          'sortOrder': {'v': 0, 't': remoteTs.pack()},
+        },
+      };
+
+      await syncApi.mergeDelta(delta);
+
+      final chips = await db.select(db.categoryChips).get();
+      expect(chips, hasLength(1));
+      expect(chips[0].id, equals('remote-chip-1'));
+      expect(chips[0].category, equals('Working'));
+      expect(chips[0].label, equals('standup'));
+      expect(chips[0].sortOrder, equals(0));
+    });
+
+    test('merges remote changes into existing categoryChip (LWW)', () async {
+      // Create a local chip
+      final localChip = CategoryChipDocument.create(
+        clock: clock,
+        category: 'Working',
+        label: 'local-label',
+      );
+      await db
+          .into(db.categoryChips)
+          .insert(localChip.toDriftCompanion());
+
+      // Remote update with a later timestamp
+      final remoteTs = HybridTimestamp(
+        physicalTime: DateTime.now().millisecondsSinceEpoch + 1000,
+        counter: 0,
+        nodeId: 'phone-1',
+      );
+
+      final delta = {
+        'type': SyncDocType.categoryChip,
+        'id': localChip.id,
+        'fields': {
+          'label': {'v': 'Updated from phone', 't': remoteTs.pack()},
+        },
+      };
+
+      await syncApi.mergeDelta(delta);
+
+      // Remote wins (later timestamp)
+      final rows = await db.select(db.categoryChips).get();
+      expect(rows[0].label, equals('Updated from phone'));
+    });
+
+    test('local wins when local timestamp is newer for categoryChip', () async {
+      // Create a local chip with current clock
+      final localChip = CategoryChipDocument.create(
+        clock: clock,
+        category: 'Working',
+        label: 'Local label',
+      );
+      await db
+          .into(db.categoryChips)
+          .insert(localChip.toDriftCompanion());
+
+      // Remote update with an OLD timestamp
+      final remoteTs = HybridTimestamp(
+        physicalTime: 1000, // very old
+        counter: 0,
+        nodeId: 'phone-1',
+      );
+
+      final delta = {
+        'type': SyncDocType.categoryChip,
+        'id': localChip.id,
+        'fields': {
+          'label': {'v': 'Old remote label', 't': remoteTs.pack()},
+        },
+      };
+
+      await syncApi.mergeDelta(delta);
+
+      // Local wins (later timestamp)
+      final rows = await db.select(db.categoryChips).get();
+      expect(rows[0].label, equals('Local label'));
+    });
+
+    test('merges categoryChip sortOrder from remote', () async {
+      final remoteTs = HybridTimestamp(
+        physicalTime: DateTime.now().millisecondsSinceEpoch,
+        counter: 0,
+        nodeId: 'phone-1',
+      );
+
+      final delta = {
+        'type': SyncDocType.categoryChip,
+        'id': 'chip-sort-test',
+        'fields': {
+          'category': {'v': 'Learning', 't': remoteTs.pack()},
+          'label': {'v': 'course', 't': remoteTs.pack()},
+          'sortOrder': {'v': 5, 't': remoteTs.pack()},
+        },
+      };
+
+      await syncApi.mergeDelta(delta);
+
+      final chips = await db.select(db.categoryChips).get();
+      expect(chips, hasLength(1));
+      expect(chips[0].sortOrder, equals(5));
+    });
   });
 
   group('watermark tracking', () {

--- a/packages/avodah_core/lib/avodah_core.dart
+++ b/packages/avodah_core/lib/avodah_core.dart
@@ -35,6 +35,7 @@ export 'documents/timer_document.dart';
 export 'documents/subtask_document.dart';
 export 'documents/tag_document.dart';
 export 'documents/worklog_document.dart';
+export 'documents/category_chip_document.dart';
 
 // Version
 export 'version.dart';

--- a/packages/avodah_core/lib/documents/category_chip_document.dart
+++ b/packages/avodah_core/lib/documents/category_chip_document.dart
@@ -1,0 +1,193 @@
+/// CRDT-backed CategoryChip document for conflict-free synchronization.
+///
+/// This document represents a category chip (e.g., "Working", "Learning")
+/// with a category grouping, label, and sort order. Chips currently stored
+/// in config.json are being migrated to SQLite for bidirectional sync.
+library;
+
+import 'package:drift/drift.dart';
+import 'package:uuid/uuid.dart';
+
+import '../crdt/crdt.dart';
+import '../storage/database.dart';
+
+/// Field keys for CategoryChipDocument.
+class CategoryChipFields {
+  CategoryChipFields._();
+
+  /// Category grouping for this chip (e.g., "Working", "Learning").
+  static const String category = 'category';
+
+  /// Display label for this chip.
+  static const String label = 'label';
+
+  /// Sort order within the category.
+  static const String sortOrder = 'sortOrder';
+}
+
+/// A CRDT-backed category chip document.
+///
+/// All fields are tracked with individual timestamps for fine-grained
+/// conflict resolution during P2P sync.
+class CategoryChipDocument extends CrdtDocument<CategoryChipDocument> {
+  /// Creates a new category chip document with a generated UUID.
+  factory CategoryChipDocument.create({
+    required HybridLogicalClock clock,
+    required String category,
+    required String label,
+    int sortOrder = 0,
+  }) {
+    final doc = CategoryChipDocument(
+      id: const Uuid().v4(),
+      clock: clock,
+    );
+    doc.category = category;
+    doc.label = label;
+    doc.sortOrder = sortOrder;
+    return doc;
+  }
+
+  /// Creates a category chip document with an existing ID.
+  CategoryChipDocument({
+    required super.id,
+    required super.clock,
+  });
+
+  /// Creates a category chip document from existing CRDT state.
+  CategoryChipDocument.fromState({
+    required super.id,
+    required super.clock,
+    required super.state,
+  }) : super.fromState();
+
+  /// Creates a category chip document from a Drift CategoryChip entity.
+  factory CategoryChipDocument.fromDrift({
+    required CategoryChip chip,
+    required HybridLogicalClock clock,
+  }) {
+    final state = CrdtDocument.stateFromCrdtState(chip.crdtState);
+
+    final doc = CategoryChipDocument.fromState(
+      id: chip.id,
+      clock: clock,
+      state: state,
+    );
+
+    if (state.isEmpty) {
+      // No CRDT state at all — initialize everything from Drift fields
+      doc._initializeFromDrift(chip);
+    } else {
+      // Backfill fields added in later schema versions that may be missing
+      // from CRDT state.
+      doc._backfillFromDrift(chip);
+    }
+
+    return doc;
+  }
+
+  /// Initializes fields from Drift entity when no CRDT state exists.
+  void _initializeFromDrift(CategoryChip chip) {
+    setString(CategoryChipFields.category, chip.category);
+    setString(CategoryChipFields.label, chip.label);
+    setInt(CategoryChipFields.sortOrder, chip.sortOrder);
+  }
+
+  /// Backfills fields from Drift columns when they are missing from CRDT
+  /// state. This handles fields added in later schema versions.
+  void _backfillFromDrift(CategoryChip chip) {
+    final keys = fieldKeys.toSet();
+    if (!keys.contains(CategoryChipFields.category)) {
+      setString(CategoryChipFields.category, chip.category);
+    }
+    if (!keys.contains(CategoryChipFields.label)) {
+      setString(CategoryChipFields.label, chip.label);
+    }
+    if (!keys.contains(CategoryChipFields.sortOrder)) {
+      setInt(CategoryChipFields.sortOrder, chip.sortOrder);
+    }
+  }
+
+  // ============================================================
+  // Core Fields
+  // ============================================================
+
+  /// Category grouping for this chip (e.g., "Working", "Learning").
+  String get category => getString(CategoryChipFields.category) ?? '';
+  set category(String value) => setString(CategoryChipFields.category, value);
+
+  /// Display label for this chip.
+  String get label => getString(CategoryChipFields.label) ?? '';
+  set label(String value) => setString(CategoryChipFields.label, value);
+
+  /// Sort order within the category.
+  int get sortOrder => getInt(CategoryChipFields.sortOrder) ?? 0;
+  set sortOrder(int value) => setInt(CategoryChipFields.sortOrder, value);
+
+  // ============================================================
+  // Conversion
+  // ============================================================
+
+  /// Converts to a Drift CategoryChipsCompanion for insert/update.
+  CategoryChipsCompanion toDriftCompanion() {
+    return CategoryChipsCompanion(
+      id: Value(id),
+      category: Value(category),
+      label: Value(label),
+      sortOrder: Value(sortOrder),
+      crdtClock: Value(clock.lastTimestamp.pack()),
+      crdtState: Value(toCrdtState()),
+    );
+  }
+
+  /// Converts to an immutable CategoryChip UI model.
+  CategoryChipModel toModel() {
+    return CategoryChipModel(
+      id: id,
+      category: category,
+      label: label,
+      sortOrder: sortOrder,
+      isDeleted: isDeleted,
+    );
+  }
+
+  @override
+  CategoryChipDocument copyWith({String? id, HybridLogicalClock? clock}) {
+    return CategoryChipDocument(
+      id: id ?? this.id,
+      clock: clock ?? this.clock,
+    );
+  }
+}
+
+/// Immutable category chip model for UI consumption.
+///
+/// This is a read-only snapshot of a chip's state, suitable for
+/// use in widgets and state management.
+class CategoryChipModel {
+  final String id;
+  final String? category;
+  final String? label;
+  final int sortOrder;
+  final bool isDeleted;
+
+  const CategoryChipModel({
+    required this.id,
+    this.category,
+    this.label,
+    required this.sortOrder,
+    required this.isDeleted,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CategoryChipModel &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  String toString() => 'CategoryChipModel($id, "$category/$label", sortOrder: $sortOrder)';
+}

--- a/packages/avodah_core/lib/storage/database.dart
+++ b/packages/avodah_core/lib/storage/database.dart
@@ -12,6 +12,7 @@ import 'tables/day_plan_tasks.dart';
 import 'tables/sync_watermarks.dart';
 import 'tables/paired_devices.dart';
 import 'tables/settings.dart';
+import 'tables/category_chips.dart';
 
 part 'database.g.dart';
 
@@ -34,6 +35,7 @@ part 'database.g.dart';
   SyncWatermarks,
   PairedDevices,
   Settings,
+  CategoryChips,
 ])
 class AppDatabase extends _$AppDatabase {
   /// Creates a database with the given executor.
@@ -46,7 +48,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.executor(QueryExecutor executor) : super(executor);
 
   @override
-  int get schemaVersion => 16;
+  int get schemaVersion => 17;
 
   @override
   MigrationStrategy get migration {
@@ -148,6 +150,15 @@ class AppDatabase extends _$AppDatabase {
           // Server NEVER writes to config.json — chips moved to DB to prevent TLS overwrites
           try {
             await m.createTable(settings);
+          } on Exception catch (_) {
+            // Table may already exist
+          }
+        }
+        if (from < 17) {
+          // v17: category chips table for CRDT-backed chip sync (AVO-092)
+          // Chips moved from config.json to CRDT table for bidirectional sync
+          try {
+            await m.createTable(categoryChips);
           } on Exception catch (_) {
             // Table may already exist
           }

--- a/packages/avodah_core/lib/storage/database.g.dart
+++ b/packages/avodah_core/lib/storage/database.g.dart
@@ -8271,6 +8271,419 @@ class SettingsCompanion extends UpdateCompanion<Setting> {
   }
 }
 
+class $CategoryChipsTable extends CategoryChips
+    with TableInfo<$CategoryChipsTable, CategoryChip> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $CategoryChipsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _categoryMeta = const VerificationMeta(
+    'category',
+  );
+  @override
+  late final GeneratedColumn<String> category = GeneratedColumn<String>(
+    'category',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _labelMeta = const VerificationMeta('label');
+  @override
+  late final GeneratedColumn<String> label = GeneratedColumn<String>(
+    'label',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _sortOrderMeta = const VerificationMeta(
+    'sortOrder',
+  );
+  @override
+  late final GeneratedColumn<int> sortOrder = GeneratedColumn<int>(
+    'sort_order',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _crdtClockMeta = const VerificationMeta(
+    'crdtClock',
+  );
+  @override
+  late final GeneratedColumn<String> crdtClock = GeneratedColumn<String>(
+    'crdt_clock',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(''),
+  );
+  static const VerificationMeta _crdtStateMeta = const VerificationMeta(
+    'crdtState',
+  );
+  @override
+  late final GeneratedColumn<String> crdtState = GeneratedColumn<String>(
+    'crdt_state',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('{}'),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    category,
+    label,
+    sortOrder,
+    crdtClock,
+    crdtState,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'category_chips';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<CategoryChip> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('category')) {
+      context.handle(
+        _categoryMeta,
+        category.isAcceptableOrUnknown(data['category']!, _categoryMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_categoryMeta);
+    }
+    if (data.containsKey('label')) {
+      context.handle(
+        _labelMeta,
+        label.isAcceptableOrUnknown(data['label']!, _labelMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_labelMeta);
+    }
+    if (data.containsKey('sort_order')) {
+      context.handle(
+        _sortOrderMeta,
+        sortOrder.isAcceptableOrUnknown(data['sort_order']!, _sortOrderMeta),
+      );
+    }
+    if (data.containsKey('crdt_clock')) {
+      context.handle(
+        _crdtClockMeta,
+        crdtClock.isAcceptableOrUnknown(data['crdt_clock']!, _crdtClockMeta),
+      );
+    }
+    if (data.containsKey('crdt_state')) {
+      context.handle(
+        _crdtStateMeta,
+        crdtState.isAcceptableOrUnknown(data['crdt_state']!, _crdtStateMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  CategoryChip map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return CategoryChip(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      category: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}category'],
+      )!,
+      label: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}label'],
+      )!,
+      sortOrder: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}sort_order'],
+      )!,
+      crdtClock: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}crdt_clock'],
+      )!,
+      crdtState: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}crdt_state'],
+      )!,
+    );
+  }
+
+  @override
+  $CategoryChipsTable createAlias(String alias) {
+    return $CategoryChipsTable(attachedDatabase, alias);
+  }
+}
+
+class CategoryChip extends DataClass implements Insertable<CategoryChip> {
+  /// Unique chip identifier (UUID).
+  final String id;
+
+  /// Category grouping for this chip (e.g., "Working", "Learning").
+  final String category;
+
+  /// Display label for this chip.
+  final String label;
+
+  /// Sort order within the category.
+  final int sortOrder;
+
+  /// CRDT clock timestamp (packed HLC).
+  final String crdtClock;
+
+  /// CRDT state JSON for all field timestamps and values.
+  final String crdtState;
+  const CategoryChip({
+    required this.id,
+    required this.category,
+    required this.label,
+    required this.sortOrder,
+    required this.crdtClock,
+    required this.crdtState,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['category'] = Variable<String>(category);
+    map['label'] = Variable<String>(label);
+    map['sort_order'] = Variable<int>(sortOrder);
+    map['crdt_clock'] = Variable<String>(crdtClock);
+    map['crdt_state'] = Variable<String>(crdtState);
+    return map;
+  }
+
+  CategoryChipsCompanion toCompanion(bool nullToAbsent) {
+    return CategoryChipsCompanion(
+      id: Value(id),
+      category: Value(category),
+      label: Value(label),
+      sortOrder: Value(sortOrder),
+      crdtClock: Value(crdtClock),
+      crdtState: Value(crdtState),
+    );
+  }
+
+  factory CategoryChip.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return CategoryChip(
+      id: serializer.fromJson<String>(json['id']),
+      category: serializer.fromJson<String>(json['category']),
+      label: serializer.fromJson<String>(json['label']),
+      sortOrder: serializer.fromJson<int>(json['sortOrder']),
+      crdtClock: serializer.fromJson<String>(json['crdtClock']),
+      crdtState: serializer.fromJson<String>(json['crdtState']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'category': serializer.toJson<String>(category),
+      'label': serializer.toJson<String>(label),
+      'sortOrder': serializer.toJson<int>(sortOrder),
+      'crdtClock': serializer.toJson<String>(crdtClock),
+      'crdtState': serializer.toJson<String>(crdtState),
+    };
+  }
+
+  CategoryChip copyWith({
+    String? id,
+    String? category,
+    String? label,
+    int? sortOrder,
+    String? crdtClock,
+    String? crdtState,
+  }) => CategoryChip(
+    id: id ?? this.id,
+    category: category ?? this.category,
+    label: label ?? this.label,
+    sortOrder: sortOrder ?? this.sortOrder,
+    crdtClock: crdtClock ?? this.crdtClock,
+    crdtState: crdtState ?? this.crdtState,
+  );
+  CategoryChip copyWithCompanion(CategoryChipsCompanion data) {
+    return CategoryChip(
+      id: data.id.present ? data.id.value : this.id,
+      category: data.category.present ? data.category.value : this.category,
+      label: data.label.present ? data.label.value : this.label,
+      sortOrder: data.sortOrder.present ? data.sortOrder.value : this.sortOrder,
+      crdtClock: data.crdtClock.present ? data.crdtClock.value : this.crdtClock,
+      crdtState: data.crdtState.present ? data.crdtState.value : this.crdtState,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CategoryChip(')
+          ..write('id: $id, ')
+          ..write('category: $category, ')
+          ..write('label: $label, ')
+          ..write('sortOrder: $sortOrder, ')
+          ..write('crdtClock: $crdtClock, ')
+          ..write('crdtState: $crdtState')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, category, label, sortOrder, crdtClock, crdtState);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CategoryChip &&
+          other.id == this.id &&
+          other.category == this.category &&
+          other.label == this.label &&
+          other.sortOrder == this.sortOrder &&
+          other.crdtClock == this.crdtClock &&
+          other.crdtState == this.crdtState);
+}
+
+class CategoryChipsCompanion extends UpdateCompanion<CategoryChip> {
+  final Value<String> id;
+  final Value<String> category;
+  final Value<String> label;
+  final Value<int> sortOrder;
+  final Value<String> crdtClock;
+  final Value<String> crdtState;
+  final Value<int> rowid;
+  const CategoryChipsCompanion({
+    this.id = const Value.absent(),
+    this.category = const Value.absent(),
+    this.label = const Value.absent(),
+    this.sortOrder = const Value.absent(),
+    this.crdtClock = const Value.absent(),
+    this.crdtState = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  CategoryChipsCompanion.insert({
+    required String id,
+    required String category,
+    required String label,
+    this.sortOrder = const Value.absent(),
+    this.crdtClock = const Value.absent(),
+    this.crdtState = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       category = Value(category),
+       label = Value(label);
+  static Insertable<CategoryChip> custom({
+    Expression<String>? id,
+    Expression<String>? category,
+    Expression<String>? label,
+    Expression<int>? sortOrder,
+    Expression<String>? crdtClock,
+    Expression<String>? crdtState,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (category != null) 'category': category,
+      if (label != null) 'label': label,
+      if (sortOrder != null) 'sort_order': sortOrder,
+      if (crdtClock != null) 'crdt_clock': crdtClock,
+      if (crdtState != null) 'crdt_state': crdtState,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  CategoryChipsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? category,
+    Value<String>? label,
+    Value<int>? sortOrder,
+    Value<String>? crdtClock,
+    Value<String>? crdtState,
+    Value<int>? rowid,
+  }) {
+    return CategoryChipsCompanion(
+      id: id ?? this.id,
+      category: category ?? this.category,
+      label: label ?? this.label,
+      sortOrder: sortOrder ?? this.sortOrder,
+      crdtClock: crdtClock ?? this.crdtClock,
+      crdtState: crdtState ?? this.crdtState,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (category.present) {
+      map['category'] = Variable<String>(category.value);
+    }
+    if (label.present) {
+      map['label'] = Variable<String>(label.value);
+    }
+    if (sortOrder.present) {
+      map['sort_order'] = Variable<int>(sortOrder.value);
+    }
+    if (crdtClock.present) {
+      map['crdt_clock'] = Variable<String>(crdtClock.value);
+    }
+    if (crdtState.present) {
+      map['crdt_state'] = Variable<String>(crdtState.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CategoryChipsCompanion(')
+          ..write('id: $id, ')
+          ..write('category: $category, ')
+          ..write('label: $label, ')
+          ..write('sortOrder: $sortOrder, ')
+          ..write('crdtClock: $crdtClock, ')
+          ..write('crdtState: $crdtState, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -8290,6 +8703,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $SyncWatermarksTable syncWatermarks = $SyncWatermarksTable(this);
   late final $PairedDevicesTable pairedDevices = $PairedDevicesTable(this);
   late final $SettingsTable settings = $SettingsTable(this);
+  late final $CategoryChipsTable categoryChips = $CategoryChipsTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -8307,6 +8721,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     syncWatermarks,
     pairedDevices,
     settings,
+    categoryChips,
   ];
 }
 
@@ -12247,6 +12662,225 @@ typedef $$SettingsTableProcessedTableManager =
       Setting,
       PrefetchHooks Function()
     >;
+typedef $$CategoryChipsTableCreateCompanionBuilder =
+    CategoryChipsCompanion Function({
+      required String id,
+      required String category,
+      required String label,
+      Value<int> sortOrder,
+      Value<String> crdtClock,
+      Value<String> crdtState,
+      Value<int> rowid,
+    });
+typedef $$CategoryChipsTableUpdateCompanionBuilder =
+    CategoryChipsCompanion Function({
+      Value<String> id,
+      Value<String> category,
+      Value<String> label,
+      Value<int> sortOrder,
+      Value<String> crdtClock,
+      Value<String> crdtState,
+      Value<int> rowid,
+    });
+
+class $$CategoryChipsTableFilterComposer
+    extends Composer<_$AppDatabase, $CategoryChipsTable> {
+  $$CategoryChipsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get label => $composableBuilder(
+    column: $table.label,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get sortOrder => $composableBuilder(
+    column: $table.sortOrder,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get crdtClock => $composableBuilder(
+    column: $table.crdtClock,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get crdtState => $composableBuilder(
+    column: $table.crdtState,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$CategoryChipsTableOrderingComposer
+    extends Composer<_$AppDatabase, $CategoryChipsTable> {
+  $$CategoryChipsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get label => $composableBuilder(
+    column: $table.label,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get sortOrder => $composableBuilder(
+    column: $table.sortOrder,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get crdtClock => $composableBuilder(
+    column: $table.crdtClock,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get crdtState => $composableBuilder(
+    column: $table.crdtState,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$CategoryChipsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $CategoryChipsTable> {
+  $$CategoryChipsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get category =>
+      $composableBuilder(column: $table.category, builder: (column) => column);
+
+  GeneratedColumn<String> get label =>
+      $composableBuilder(column: $table.label, builder: (column) => column);
+
+  GeneratedColumn<int> get sortOrder =>
+      $composableBuilder(column: $table.sortOrder, builder: (column) => column);
+
+  GeneratedColumn<String> get crdtClock =>
+      $composableBuilder(column: $table.crdtClock, builder: (column) => column);
+
+  GeneratedColumn<String> get crdtState =>
+      $composableBuilder(column: $table.crdtState, builder: (column) => column);
+}
+
+class $$CategoryChipsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $CategoryChipsTable,
+          CategoryChip,
+          $$CategoryChipsTableFilterComposer,
+          $$CategoryChipsTableOrderingComposer,
+          $$CategoryChipsTableAnnotationComposer,
+          $$CategoryChipsTableCreateCompanionBuilder,
+          $$CategoryChipsTableUpdateCompanionBuilder,
+          (
+            CategoryChip,
+            BaseReferences<_$AppDatabase, $CategoryChipsTable, CategoryChip>,
+          ),
+          CategoryChip,
+          PrefetchHooks Function()
+        > {
+  $$CategoryChipsTableTableManager(_$AppDatabase db, $CategoryChipsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$CategoryChipsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$CategoryChipsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$CategoryChipsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> category = const Value.absent(),
+                Value<String> label = const Value.absent(),
+                Value<int> sortOrder = const Value.absent(),
+                Value<String> crdtClock = const Value.absent(),
+                Value<String> crdtState = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => CategoryChipsCompanion(
+                id: id,
+                category: category,
+                label: label,
+                sortOrder: sortOrder,
+                crdtClock: crdtClock,
+                crdtState: crdtState,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String category,
+                required String label,
+                Value<int> sortOrder = const Value.absent(),
+                Value<String> crdtClock = const Value.absent(),
+                Value<String> crdtState = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => CategoryChipsCompanion.insert(
+                id: id,
+                category: category,
+                label: label,
+                sortOrder: sortOrder,
+                crdtClock: crdtClock,
+                crdtState: crdtState,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$CategoryChipsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $CategoryChipsTable,
+      CategoryChip,
+      $$CategoryChipsTableFilterComposer,
+      $$CategoryChipsTableOrderingComposer,
+      $$CategoryChipsTableAnnotationComposer,
+      $$CategoryChipsTableCreateCompanionBuilder,
+      $$CategoryChipsTableUpdateCompanionBuilder,
+      (
+        CategoryChip,
+        BaseReferences<_$AppDatabase, $CategoryChipsTable, CategoryChip>,
+      ),
+      CategoryChip,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -12274,4 +12908,6 @@ class $AppDatabaseManager {
       $$PairedDevicesTableTableManager(_db, _db.pairedDevices);
   $$SettingsTableTableManager get settings =>
       $$SettingsTableTableManager(_db, _db.settings);
+  $$CategoryChipsTableTableManager get categoryChips =>
+      $$CategoryChipsTableTableManager(_db, _db.categoryChips);
 }

--- a/packages/avodah_core/lib/storage/tables/category_chips.dart
+++ b/packages/avodah_core/lib/storage/tables/category_chips.dart
@@ -1,0 +1,29 @@
+import 'package:drift/drift.dart';
+
+/// Category chips table for storing user-defined category chips.
+///
+/// Chips are organized by category (e.g., "Working", "Learning") with
+/// a display label and sort order. This table replaces the previous
+/// config.json storage for bidirectional sync between desktop and phone.
+class CategoryChips extends Table {
+  /// Unique chip identifier (UUID).
+  TextColumn get id => text()();
+
+  /// Category grouping for this chip (e.g., "Working", "Learning").
+  TextColumn get category => text()();
+
+  /// Display label for this chip.
+  TextColumn get label => text()();
+
+  /// Sort order within the category.
+  IntColumn get sortOrder => integer().withDefault(const Constant(0))();
+
+  /// CRDT clock timestamp (packed HLC).
+  TextColumn get crdtClock => text().withDefault(const Constant(''))();
+
+  /// CRDT state JSON for all field timestamps and values.
+  TextColumn get crdtState => text().withDefault(const Constant('{}'))();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/packages/avodah_core/test/documents/category_chip_document_test.dart
+++ b/packages/avodah_core/test/documents/category_chip_document_test.dart
@@ -1,0 +1,441 @@
+import 'package:avodah_core/avodah_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CategoryChipDocument', () {
+    late HybridLogicalClock clock;
+
+    setUp(() {
+      clock = HybridLogicalClock(nodeId: 'test-node');
+    });
+
+    group('creation', () {
+      test('create() generates UUID and sets initial fields', () {
+        final chip = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Working',
+          label: 'standup',
+        );
+
+        expect(chip.id, isNotEmpty);
+        expect(chip.category, equals('Working'));
+        expect(chip.label, equals('standup'));
+        expect(chip.sortOrder, equals(0));
+      });
+
+      test('create() with sortOrder sets it correctly', () {
+        final chip = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Working',
+          label: 'code review',
+          sortOrder: 5,
+        );
+
+        expect(chip.sortOrder, equals(5));
+      });
+
+      test('constructor creates empty document', () {
+        final chip = CategoryChipDocument(id: 'chip-1', clock: clock);
+
+        expect(chip.id, equals('chip-1'));
+        expect(chip.category, isEmpty);
+        expect(chip.label, isEmpty);
+        expect(chip.sortOrder, equals(0));
+      });
+    });
+
+    group('core fields', () {
+      test('category can be set and retrieved', () {
+        final chip = CategoryChipDocument(id: 'chip-1', clock: clock);
+
+        chip.category = 'Learning';
+        expect(chip.category, equals('Learning'));
+      });
+
+      test('label can be set and retrieved', () {
+        final chip = CategoryChipDocument(id: 'chip-1', clock: clock);
+
+        chip.label = 'reading';
+        expect(chip.label, equals('reading'));
+      });
+
+      test('sortOrder can be set and retrieved', () {
+        final chip = CategoryChipDocument(id: 'chip-1', clock: clock);
+
+        chip.sortOrder = 3;
+        expect(chip.sortOrder, equals(3));
+      });
+    });
+
+    group('CRDT fields (AC-1)', () {
+      test('create() stores CRDT fields with HLC timestamps', () {
+        final chip = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Working',
+          label: 'standup',
+        );
+
+        // Verify CRDT state via toJson()
+        final json = chip.toJson();
+        expect(json, isNotEmpty);
+        expect(json['id'], isNotEmpty);
+
+        // Verify fields map has the expected fields with HLC timestamps
+        final fields = json['fields'] as Map<String, dynamic>;
+        expect(fields, isNotEmpty);
+
+        // category field should be present with HLC timestamp
+        expect(fields.containsKey(CategoryChipFields.category), isTrue);
+        final catField = fields[CategoryChipFields.category] as Map<String, dynamic>;
+        expect(catField['v'], equals('Working'));
+        expect(catField['t'], isNotNull);
+
+        // label field should be present with HLC timestamp
+        expect(fields.containsKey(CategoryChipFields.label), isTrue);
+        final lblField = fields[CategoryChipFields.label] as Map<String, dynamic>;
+        expect(lblField['v'], equals('standup'));
+        expect(lblField['t'], isNotNull);
+
+        // sortOrder field should be present with HLC timestamp
+        expect(fields.containsKey(CategoryChipFields.sortOrder), isTrue);
+        final ordField = fields[CategoryChipFields.sortOrder] as Map<String, dynamic>;
+        expect(ordField['v'], equals(0));
+        expect(ordField['t'], isNotNull);
+      });
+
+      test('create() generates unique timestamps for each field', () async {
+        final chip = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Working',
+          label: 'standup',
+        );
+
+        final fields = chip.toJson()['fields'] as Map<String, dynamic>;
+        final catTs = fields[CategoryChipFields.category] as Map<String, dynamic>;
+        final lblTs = fields[CategoryChipFields.label] as Map<String, dynamic>;
+        final ordTs = fields[CategoryChipFields.sortOrder] as Map<String, dynamic>;
+
+        // All timestamps should be non-null and valid HLC format
+        expect(catTs['t'], isNotEmpty);
+        expect(lblTs['t'], isNotEmpty);
+        expect(ordTs['t'], isNotEmpty);
+      });
+    });
+
+    group('toDriftCompanion() (AC-1)', () {
+      test('produces valid CategoryChipsCompanion', () {
+        final chip = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Working',
+          label: 'standup',
+          sortOrder: 2,
+        );
+
+        final companion = chip.toDriftCompanion();
+
+        expect(companion.id.value, equals(chip.id));
+        expect(companion.category.value, equals('Working'));
+        expect(companion.label.value, equals('standup'));
+        expect(companion.sortOrder.value, equals(2));
+        expect(companion.crdtClock.value, isNotEmpty);
+        expect(companion.crdtState.value, isNotEmpty);
+      });
+
+      test('round-trips through toCrdtState()', () {
+        final chip = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Learning',
+          label: 'course',
+          sortOrder: 1,
+        );
+
+        final companion = chip.toDriftCompanion();
+        final crdtStateJson = companion.crdtState.value;
+
+        expect(crdtStateJson, isNotEmpty);
+        expect(crdtStateJson, startsWith('{'));
+      });
+    });
+
+    group('toModel() (AC-3)', () {
+      test('produces immutable CategoryChipModel', () {
+        final chip = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Working',
+          label: 'standup',
+          sortOrder: 3,
+        );
+
+        final model = chip.toModel();
+
+        expect(model.id, equals(chip.id));
+        expect(model.category, equals('Working'));
+        expect(model.label, equals('standup'));
+        expect(model.sortOrder, equals(3));
+        expect(model.isDeleted, isFalse);
+      });
+
+      test('CategoryChipModel equality based on id', () {
+        final chip1 = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Working',
+          label: 'standup',
+        );
+        final chip2 = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Learning',
+          label: 'reading',
+        );
+
+        final model1 = chip1.toModel();
+        final model2 = chip2.toModel();
+        final model1Copy = chip1.toModel();
+
+        expect(model1, equals(model1Copy));
+        expect(model1, isNot(equals(model2)));
+      });
+
+      test('toModel() reflects field updates', () {
+        final chip = CategoryChipDocument(id: 'chip-1', clock: clock);
+        chip.category = 'Working';
+        chip.label = 'debugging';
+        chip.sortOrder = 7;
+
+        final model = chip.toModel();
+
+        expect(model.category, equals('Working'));
+        expect(model.label, equals('debugging'));
+        expect(model.sortOrder, equals(7));
+      });
+    });
+
+    group('fromDrift() (AC-7 backfill)', () {
+      test('reconstructs document from Drift entity', () {
+        // Create a chip and store it
+        final chip = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Working',
+          label: 'standup',
+          sortOrder: 1,
+        );
+
+        // Simulate a Drift row
+        final companion = chip.toDriftCompanion();
+
+        // Manually construct a CategoryChip row as Drift would return it
+        final driftRow = CategoryChip(
+          id: companion.id.value,
+          category: companion.category.value,
+          label: companion.label.value,
+          sortOrder: companion.sortOrder.value,
+          crdtClock: companion.crdtClock.value,
+          crdtState: companion.crdtState.value,
+        );
+
+        // Reconstruct from Drift
+        final reconstructed =
+            CategoryChipDocument.fromDrift(chip: driftRow, clock: clock);
+
+        expect(reconstructed.id, equals(chip.id));
+        expect(reconstructed.category, equals('Working'));
+        expect(reconstructed.label, equals('standup'));
+        expect(reconstructed.sortOrder, equals(1));
+      });
+
+      test('backfills fields when CRDT state is empty', () {
+        // Simulate a pre-v17 row with no CRDT state
+        final driftRow = CategoryChip(
+          id: 'legacy-chip-1',
+          category: 'Working',
+          label: 'old-label',
+          sortOrder: 0,
+          crdtClock: '',
+          crdtState: '{}',
+        );
+
+        final reconstructed =
+            CategoryChipDocument.fromDrift(chip: driftRow, clock: clock);
+
+        expect(reconstructed.category, equals('Working'));
+        expect(reconstructed.label, equals('old-label'));
+        expect(reconstructed.sortOrder, equals(0));
+      });
+
+      test('does not overwrite existing CRDT fields during backfill', () {
+        // Create a chip, modify it, then reconstruct from Drift
+        final chip = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Working',
+          label: 'standup',
+        );
+        chip.sortOrder = 5;
+
+        // Get the state after modification
+        final stateJson = chip.toCrdtState();
+
+        // Simulate a Drift row with partial state
+        final driftRow = CategoryChip(
+          id: chip.id,
+          category: 'Working',
+          label: 'standup',
+          sortOrder: 5,
+          crdtClock: clock.lastTimestamp.pack(),
+          crdtState: stateJson,
+        );
+
+        final reconstructed =
+            CategoryChipDocument.fromDrift(chip: driftRow, clock: clock);
+
+        expect(reconstructed.sortOrder, equals(5));
+      });
+    });
+
+    group('soft delete', () {
+      test('delete() marks chip as deleted', () {
+        final chip = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Working',
+          label: 'standup',
+        );
+
+        chip.delete();
+
+        expect(chip.isDeleted, isTrue);
+        expect(chip.toModel().isDeleted, isTrue);
+      });
+
+      test('restore() undeletes chip', () {
+        final chip = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Working',
+          label: 'standup',
+        );
+        chip.delete();
+
+        chip.restore();
+
+        expect(chip.isDeleted, isFalse);
+        expect(chip.toModel().isDeleted, isFalse);
+      });
+    });
+
+    group('merge operations', () {
+      test('merging two chips preserves independent changes', () {
+        final clock1 = HybridLogicalClock(nodeId: 'phone');
+        final clock2 = HybridLogicalClock(nodeId: 'laptop');
+
+        final chip1 = CategoryChipDocument.create(
+          clock: clock1,
+          category: 'Working',
+          label: 'standup',
+        );
+
+        // Sync to laptop
+        final json = chip1.toJson();
+        final state = CrdtDocument.stateFromJson(json);
+        final chip2 = CategoryChipDocument.fromState(
+          id: chip1.id,
+          clock: clock2,
+          state: state,
+        );
+
+        // Phone updates label
+        chip1.label = 'code review';
+
+        // Laptop updates sortOrder
+        chip2.sortOrder = 3;
+
+        // Merge laptop into phone
+        chip1.merge(chip2);
+
+        expect(chip1.label, equals('code review'));
+        expect(chip1.sortOrder, equals(3));
+      });
+
+      test('concurrent edits on same field - last writer wins', () {
+        final baseTime = DateTime.now().millisecondsSinceEpoch;
+        var time1 = baseTime;
+        var time2 = baseTime;
+        final clock1 = HybridLogicalClock(
+          nodeId: 'node-1',
+          physicalTimeFn: () => time1,
+        );
+        final clock2 = HybridLogicalClock(
+          nodeId: 'node-2',
+          physicalTimeFn: () => time2,
+        );
+
+        final chip1 = CategoryChipDocument(id: 'chip-1', clock: clock1);
+        final chip2 = CategoryChipDocument(id: 'chip-1', clock: clock2);
+
+        // Node 1 sets label
+        chip1.label = 'First';
+
+        // Node 2 sets label 1ms later
+        time2 = baseTime + 1;
+        chip2.label = 'Second';
+
+        chip1.merge(chip2);
+
+        expect(chip1.label, equals('Second'));
+      });
+
+      test('offline sync scenario preserves independent changes', () {
+        final clock1 = HybridLogicalClock(nodeId: 'device-a');
+        final clock2 = HybridLogicalClock(nodeId: 'device-b');
+
+        final chipA = CategoryChipDocument.create(
+          clock: clock1,
+          category: 'Working',
+          label: 'standup',
+        );
+        chipA.sortOrder = 1;
+
+        // Sync to device B
+        final json = chipA.toJson();
+        final state = CrdtDocument.stateFromJson(json);
+        final chipB = CategoryChipDocument.fromState(
+          id: chipA.id,
+          clock: clock2,
+          state: state,
+        );
+
+        // Device A updates category (offline)
+        chipA.category = 'Learning';
+
+        // Device B updates label (offline)
+        chipB.label = 'debugging';
+
+        // Come back online - merge both ways
+        chipA.merge(chipB);
+        chipB.merge(chipA);
+
+        // Both should have both changes
+        expect(chipA.category, equals('Learning'));
+        expect(chipA.label, equals('debugging'));
+
+        expect(chipB.category, equals('Learning'));
+        expect(chipB.label, equals('debugging'));
+      });
+    });
+
+    group('idempotent state transitions', () {
+      test('multiple field updates are all preserved after merge', () {
+        final chip = CategoryChipDocument.create(
+          clock: clock,
+          category: 'Working',
+          label: 'standup',
+        );
+
+        chip.category = 'Learning';
+        chip.label = 'course';
+        chip.sortOrder = 2;
+
+        final fields = chip.toJson()['fields'] as Map<String, dynamic>;
+        expect((fields[CategoryChipFields.category] as Map)['v'], equals('Learning'));
+        expect((fields[CategoryChipFields.label] as Map)['v'], equals('course'));
+        expect((fields[CategoryChipFields.sortOrder] as Map)['v'], equals(2));
+      });
+    });
+  });
+}

--- a/phone/lib/services/crdt_sync_service.dart
+++ b/phone/lib/services/crdt_sync_service.dart
@@ -45,6 +45,7 @@ class _SyncDocType {
   static const String project = 'project';
   static const String dailyPlan = 'dailyPlan';
   static const String dayPlanTask = 'dayPlanTask';
+  static const String categoryChip = 'categoryChip';
 }
 
 /// Callback type invoked when the server indicates pairing is required.
@@ -197,6 +198,7 @@ class CrdtSyncService {
     var worklogCount = 0;
     var timerCount = 0;
     var projectCount = 0;
+    var categoryChipCount = 0;
     for (final deltaJson in deltas) {
       final delta = deltaJson as Map<String, dynamic>;
       switch (delta['type'] as String) {
@@ -218,6 +220,9 @@ class CrdtSyncService {
         case _SyncDocType.project:
           projectCount++;
           break;
+        case _SyncDocType.categoryChip:
+          categoryChipCount++;
+          break;
         default:
           break;
       }
@@ -225,7 +230,8 @@ class CrdtSyncService {
 
     debugPrint('[Sync] Pulled $merged deltas '
         '(dailyPlan=$dailyPlanCount, dayPlanTask=$dayPlanTaskCount, '
-        'task=$taskCount, worklog=$worklogCount, timer=$timerCount, project=$projectCount)');
+        'task=$taskCount, worklog=$worklogCount, timer=$timerCount, '
+        'project=$projectCount, categoryChip=$categoryChipCount)');
     debugPrint('[Sync] Merged $merged deltas into local DB. New watermark=$newWatermark');
     return merged;
   }
@@ -265,6 +271,8 @@ class CrdtSyncService {
         await _mergeDailyPlan(id, state);
       case _SyncDocType.dayPlanTask:
         await _mergeDayPlanTask(id, state);
+      case _SyncDocType.categoryChip:
+        await _mergeCategoryChip(id, state);
       default:
         debugPrint('[CrdtSync] Unknown delta type: $type — skipping');
     }
@@ -340,6 +348,18 @@ class CrdtSyncService {
         : DayPlanTaskDocument.fromState(id: id, clock: clock, state: {});
     _applyState(doc, state);
     await db.into(db.dayPlanTasks).insertOnConflictUpdate(doc.toDriftCompanion());
+  }
+
+  Future<void> _mergeCategoryChip(
+      String id, Map<String, CrdtFieldState> state) async {
+    final rows = await (db.select(db.categoryChips)
+          ..where((t) => t.id.equals(id)))
+        .get();
+    final doc = rows.isNotEmpty
+        ? CategoryChipDocument.fromDrift(chip: rows.first, clock: clock)
+        : CategoryChipDocument.fromState(id: id, clock: clock, state: {});
+    _applyState(doc, state);
+    await db.into(db.categoryChips).insertOnConflictUpdate(doc.toDriftCompanion());
   }
 
   void _applyState(CrdtDocument doc, Map<String, CrdtFieldState> state) {
@@ -495,6 +515,14 @@ class CrdtSyncService {
       final doc = DayPlanTaskDocument.fromDrift(entry: d, clock: clock);
       final json = doc.toJson();
       json['type'] = _SyncDocType.dayPlanTask;
+      deltas.add(json);
+    }
+
+    final categoryChips = await db.select(db.categoryChips).get();
+    for (final c in categoryChips) {
+      final doc = CategoryChipDocument.fromDrift(chip: c, clock: clock);
+      final json = doc.toJson();
+      json['type'] = _SyncDocType.categoryChip;
       deltas.add(json);
     }
 


### PR DESCRIPTION
## Summary

Bidirectional CRDT sync for category chips between desktop and phone. Introduces a new `CategoryChipDocument` CRDT type so chips sync offline-first via the existing delta mechanism, matching all other Avodah entities (tasks, worklogs, projects, etc.).

### What changed

- **New `CategoryChipDocument` CRDT type** in `avodah_core` — Fields, Document, and Model classes following the existing TagDocument pattern
- **New `CategoryChips` Drift table** — schema v17 migration with CRDT columns (id, category, label, sortOrder, crdtClock, crdtState)
- **Server-side CRDT sync** (`SyncApiService`) — `SyncDocType.categoryChip`, delta extraction, merge handler, switch case in `mergeDelta()`
- **Phone-side CRDT sync** (`CrdtSyncService`) — merge handler, `_mergeDelta()` switch case, `forceFullSync()` push, diagnostic counter
- **REST API update** — `/api/config/category-chips` now reads/writes CRDT-backed `category_chips` table, maintains backwards-compatible JSON format
- **One-time migration** — config.json chips migrated to `CategoryChipDocument` entries on sync server startup (idempotent, `migrated-*` prefix check)
- **Tests** — 22 unit tests + 4 integration tests passing

### Phases

| Phase | Description | Commit |
|-------|-------------|--------|
| 1 | CategoryChipDocument + table + codegen | ecf3b97, 58fa530 |
| 3 | Server-side CRDT sync (extract + merge) | 5bdbcce |
| 4 | REST API endpoints read/write CRDT table | db2dc90 |
| 5 | Phone-side CRDT sync (merge + push) | 198a498 |
| 6 | config.json migration on startup | f2f236d |
| 7 | Unit + integration tests | b722bed |

## Acceptance Criteria

- [x] **AC-1:** CategoryChipDocument.create() stores category, label, sortOrder as CRDT fields with HLC timestamps
- [x] **AC-2:** Existing chips in config.json migrate to CategoryChipDocument entries on first startup
- [ ] **AC-3:** Desktop-to-phone chip sync via delta pull (server-side done, phone-side done — needs E2E verification)
- [ ] **AC-4:** Phone-to-desktop chip sync via delta push (needs E2E verification)
- [ ] **AC-5:** LWW conflict resolution for concurrent modifications (needs E2E verification)
- [ ] **AC-6:** Soft-delete propagation across devices (needs E2E verification)
- [x] **AC-7:** Schema migration v16 → v17 with new category_chips table

## Test Scenarios (UAT)

- [ ] TS-1: CategoryChipDocument creation (AC-1)
- [ ] TS-2: Config.json migration on first startup (AC-2)
- [ ] TS-3: Desktop-to-phone chip sync via delta pull (AC-3)
- [ ] TS-4: Phone-to-desktop chip sync via delta push (AC-4)
- [ ] TS-5: LWW conflict resolution (AC-5)
- [ ] TS-6: Soft-delete propagation (AC-6)
- [ ] TS-7: Schema migration v16 → v17 (AC-7)

## Regression Checks

- [ ] Existing CRDT sync for all 6 document types still works
- [ ] REST API `/api/config/category-chips` returns correct data (backwards-compatible JSON format)
- [ ] REST API `/api/config/categories` still works
- [ ] Phone app builds without errors (`flutter build web --release`)
- [ ] Core + MCP packages build
- [ ] All tests pass

## Files changed

| File | Change |
|------|--------|
| `packages/avodah_core/lib/documents/category_chip_document.dart` | NEW — CRDT document |
| `packages/avodah_core/lib/storage/tables/category_chips.dart` | NEW — Drift table |
| `packages/avodah_core/lib/storage/database.dart` | Schema v17 migration |
| `packages/avodah_core/lib/storage/database.g.dart` | Codegen (CategoryChips) |
| `mcp/lib/services/sync_api_service.dart` | SyncDocType, extractDeltas, merge |
| `mcp/bin/sync_server.dart` | Startup migration from config.json |
| `phone/lib/services/crdt_sync_service.dart` | Phone-side merge + push |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)