### PR TITLE
AVO-096: Backlog Interaction for Inactive Tickets

### DIFF
--- a/phone/lib/screens/backlog_screen.dart
+++ b/phone/lib/screens/backlog_screen.dart
@@ -6,6 +6,7 @@ import '../services/kanban_constants.dart';
 import '../widgets/assignee_picker_sheet.dart';
 import '../widgets/priority_picker_sheet.dart';
 import '../widgets/status_picker_sheet.dart';
+import '../widgets/tag_picker_sheet.dart';
 
 /// Backlog view — shows all inactive tickets (tag-based + status-based).
 ///
@@ -218,8 +219,8 @@ class _BacklogScreenState extends State<BacklogScreen> {
 
   Future<void> _showActivateDialog(BuildContext context, Ticket ticket) async {
     String? selectedStatus;
-    // Default to 'idea' if already in backlog statuses, otherwise keep current
-    selectedStatus = backlogStatuses.contains(ticket.status) ? 'idea' : ticket.status;
+    // Default to 'implementing' (active status) if in backlog, otherwise keep current
+    selectedStatus = backlogStatuses.contains(ticket.status) ? 'implementing' : ticket.status;
 
     final result = await showModalBottomSheet<String>(
       context: context,
@@ -340,15 +341,7 @@ class _BacklogScreenState extends State<BacklogScreen> {
   Future<void> _activateTicket(
       BuildContext context, Ticket ticket, String newStatus) async {
     try {
-      // Build updated fields: new status + remove 'backlog' tag
-      final updates = <String, dynamic>{'status': newStatus};
-      if (ticket.tags.contains('backlog')) {
-        final newTags = List<String>.from(ticket.tags)..remove('backlog');
-        updates['tags'] = newTags;
-      }
-
-      await widget.backlogProvider.client.updateTicket(ticket.id, updates);
-      await widget.backlogProvider.refresh();
+      await widget.backlogProvider.activateTicket(ticket.id, newStatus);
 
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -417,6 +410,12 @@ class _BacklogScreenState extends State<BacklogScreen> {
               label: const Text('Assignee'),
               onPressed: () => _showBulkAssigneePicker(context),
             ),
+            // Tags picker
+            TextButton.icon(
+              icon: const Icon(Icons.label_outlined, size: 18),
+              label: const Text('Tags'),
+              onPressed: () => _showBulkTagsPicker(context),
+            ),
             // Apply button
             FilledButton(
               onPressed: () => _applyBulkUpdate(context),
@@ -471,6 +470,34 @@ class _BacklogScreenState extends State<BacklogScreen> {
     );
     if (result != null && context.mounted) {
       await _bulkUpdate(context, {'assignee': result});
+    }
+  }
+
+  Future<void> _showBulkTagsPicker(BuildContext context) async {
+    final allTags = _uniqueTags(widget.backlogProvider.allTickets);
+    final selectedTags = <String>[];
+
+    // Pre-select tags that all selected tickets share
+    final selectedTickets = widget.backlogProvider.allTickets
+        .where((t) => widget.backlogProvider.selectedIds.contains(t.id))
+        .toList();
+    if (selectedTickets.isNotEmpty) {
+      final firstTags = selectedTickets.first.tags;
+      selectedTags.addAll(firstTags.where(
+        (t) => selectedTickets.every((ticket) => ticket.tags.contains(t)),
+      ));
+    }
+
+    final result = await showModalBottomSheet<List<String>>(
+      context: context,
+      builder: (ctx) => TagPickerSheet(
+        availableTags: allTags,
+        selectedTags: selectedTags,
+        onSelect: (tags) => Navigator.pop(ctx, tags),
+      ),
+    );
+    if (result != null && context.mounted) {
+      await _bulkUpdate(context, {'tags': result});
     }
   }
 
@@ -607,16 +634,17 @@ class _BacklogScreenState extends State<BacklogScreen> {
           }
 
           // Fetch projects for the filter row dropdown
-          Future<List<TicketProject>> projectsFuture =
-              provider.client.getProjects();
-
           return Column(
             children: [
               // Filter bar
               FutureBuilder<List<TicketProject>>(
-                future: projectsFuture,
+                future: provider.projects.isNotEmpty
+                    ? Future.value(provider.projects)
+                    : provider.client.getProjects(),
                 builder: (context, snapshot) {
-                  final projects = snapshot.data ?? [];
+                  final projects = provider.projects.isNotEmpty
+                      ? provider.projects
+                      : (snapshot.data ?? []);
                   return _buildFilterRow(projects);
                 },
               ),

--- a/phone/lib/screens/backlog_screen.dart
+++ b/phone/lib/screens/backlog_screen.dart
@@ -1,0 +1,754 @@
+import 'package:flutter/material.dart';
+
+import '../models/ticket.dart';
+import '../services/backlog_provider.dart';
+import '../services/kanban_constants.dart';
+import '../widgets/assignee_picker_sheet.dart';
+import '../widgets/priority_picker_sheet.dart';
+import '../widgets/status_picker_sheet.dart';
+
+/// Backlog view — shows all inactive tickets (tag-based + status-based).
+///
+/// Displays a virtual scrolling list of tickets with filter controls,
+/// multi-select checkboxes, bulk action bar, pull-to-refresh, and
+/// tap-to-activate interaction.
+class BacklogScreen extends StatefulWidget {
+  final BacklogProvider backlogProvider;
+
+  const BacklogScreen({
+    super.key,
+    required this.backlogProvider,
+  });
+
+  @override
+  State<BacklogScreen> createState() => _BacklogScreenState();
+}
+
+class _BacklogScreenState extends State<BacklogScreen> {
+  final _searchController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    // Fetch backlog on first load if not yet loaded
+    if (widget.backlogProvider.allTickets.isEmpty &&
+        !widget.backlogProvider.loading) {
+      widget.backlogProvider.fetchBacklog();
+    }
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  // --- Filter row (mirrors KanbanBoardScreen._buildFilterRow) ---
+
+  Widget _buildFilterRow(List<TicketProject> projects) {
+    final provider = widget.backlogProvider;
+    final assignees = _uniqueAssignees(provider.allTickets);
+    final priorities = ['critical', 'high', 'medium', 'low'];
+    final allTags = _uniqueTags(provider.allTickets);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: [
+              // Project dropdown
+              if (projects.isEmpty)
+                const Text('No projects')
+              else
+                DropdownButton<String>(
+                  value: provider.filter.project != null &&
+                          projects.any((p) => p.key == provider.filter.project)
+                      ? provider.filter.project
+                      : null,
+                  isDense: true,
+                  underline: const SizedBox.shrink(),
+                  hint: const Text('All projects'),
+                  items: [
+                    const DropdownMenuItem(value: null, child: Text('All projects')),
+                    ...projects.map(
+                      (p) => DropdownMenuItem(value: p.key, child: Text(p.key)),
+                    ),
+                  ],
+                  onChanged: (p) => provider.setProject(p),
+                ),
+
+              // Assignee chips
+              if (assignees.isNotEmpty) ...[
+                const SizedBox(width: 12),
+                FilterChip(
+                  label: const Text('All'),
+                  selected: provider.filter.assignees.isEmpty,
+                  onSelected: (_) => provider.setAssignees([]),
+                ),
+                ...assignees.map(
+                  (a) => Padding(
+                    padding: const EdgeInsets.only(left: 6),
+                    child: FilterChip(
+                      label: Text(a),
+                      selected: provider.filter.assignees.contains(a),
+                      onSelected: (_) {
+                        final current = List<String>.from(provider.filter.assignees);
+                        if (current.contains(a)) {
+                          current.remove(a);
+                        } else {
+                          current.add(a);
+                        }
+                        provider.setAssignees(current);
+                      },
+                    ),
+                  ),
+                ),
+              ],
+
+              // Priority chips
+              if (priorities.isNotEmpty) ...[
+                const SizedBox(width: 12),
+                FilterChip(
+                  label: const Text('All'),
+                  selected: provider.filter.priorities.isEmpty,
+                  onSelected: (_) => provider.setPriorities([]),
+                ),
+                ...priorities.map(
+                  (p) => Padding(
+                    padding: const EdgeInsets.only(left: 6),
+                    child: FilterChip(
+                      label: Text(p),
+                      selected: provider.filter.priorities.contains(p),
+                      onSelected: (_) {
+                        final current = List<String>.from(provider.filter.priorities);
+                        if (current.contains(p)) {
+                          current.remove(p);
+                        } else {
+                          current.add(p);
+                        }
+                        provider.setPriorities(current);
+                      },
+                    ),
+                  ),
+                ),
+              ],
+
+              // Tag chips
+              if (allTags.isNotEmpty) ...[
+                const SizedBox(width: 12),
+                FilterChip(
+                  label: const Text('All'),
+                  selected: provider.filter.tags.isEmpty,
+                  onSelected: (_) => provider.setTags([]),
+                ),
+                ...allTags.take(6).map(
+                  (t) => Padding(
+                    padding: const EdgeInsets.only(left: 6),
+                    child: FilterChip(
+                      label: Text(t),
+                      selected: provider.filter.tags.contains(t),
+                      onSelected: (_) {
+                        final current = List<String>.from(provider.filter.tags);
+                        if (current.contains(t)) {
+                          current.remove(t);
+                        } else {
+                          current.add(t);
+                        }
+                        provider.setTags(current);
+                      },
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+          child: TextField(
+            controller: _searchController,
+            onChanged: (v) => provider.setSearchQuery(v),
+            decoration: InputDecoration(
+              hintText: 'Search backlog tickets…',
+              prefixIcon: const Icon(Icons.search, size: 20),
+              suffixIcon: provider.filter.searchQuery.isNotEmpty
+                  ? IconButton(
+                      icon: const Icon(Icons.clear, size: 20),
+                      onPressed: () {
+                        _searchController.clear();
+                        provider.setSearchQuery('');
+                      },
+                    )
+                  : null,
+              isDense: true,
+              border: const OutlineInputBorder(),
+              contentPadding:
+                  const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // --- Ticket list with virtual scrolling ---
+
+  Widget _buildTicketList() {
+    return ListView.builder(
+      itemCount: widget.backlogProvider.tickets.length,
+      itemBuilder: (context, index) {
+        final ticket = widget.backlogProvider.tickets[index];
+        final isSelected =
+            widget.backlogProvider.selectedIds.contains(ticket.id);
+
+        return _BacklogTicketTile(
+          ticket: ticket,
+          isSelected: isSelected,
+          onToggleSelect: () => widget.backlogProvider.toggleTicket(ticket.id),
+          onTap: () => _showActivateDialog(context, ticket),
+        );
+      },
+    );
+  }
+
+  // --- Activate dialog (inline sheet) ---
+
+  Future<void> _showActivateDialog(BuildContext context, Ticket ticket) async {
+    String? selectedStatus;
+    // Default to 'idea' if already in backlog statuses, otherwise keep current
+    selectedStatus = backlogStatuses.contains(ticket.status) ? 'idea' : ticket.status;
+
+    final result = await showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: true,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setSheetState) => SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  margin: const EdgeInsets.symmetric(vertical: 12),
+                  decoration: BoxDecoration(
+                    color: Theme.of(ctx).colorScheme.outlineVariant,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                child: Text(
+                  'Activate Ticket',
+                  style: Theme.of(ctx).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  ticket.id,
+                  style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(ctx).colorScheme.outline,
+                      ),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  ticket.title,
+                  style: Theme.of(ctx).textTheme.bodyMedium,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (ticket.tags.contains('backlog')) ...[
+                const SizedBox(height: 8),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    children: [
+                      Icon(Icons.info_outline,
+                          size: 16, color: Theme.of(ctx).colorScheme.primary),
+                      const SizedBox(width: 6),
+                      Text(
+                        'The "backlog" tag will be removed',
+                        style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
+                              color: Theme.of(ctx).colorScheme.primary,
+                            ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+              const Divider(height: 24),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                child: Text(
+                  'New Status',
+                  style: Theme.of(ctx).textTheme.titleSmall,
+                ),
+              ),
+              SizedBox(
+                height: 240,
+                child: StatusPickerSheet(
+                  currentStatus: selectedStatus ?? ticket.status,
+                  onSelect: (status) {
+                    setSheetState(() => selectedStatus = status);
+                  },
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () => Navigator.pop(ctx),
+                        child: const Text('Cancel'),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: FilledButton(
+                        onPressed: selectedStatus != null
+                            ? () => Navigator.pop(ctx, selectedStatus)
+                            : null,
+                        child: const Text('Activate'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    if (result != null && result.isNotEmpty && context.mounted) {
+      await _activateTicket(context, ticket, result);
+    }
+  }
+
+  Future<void> _activateTicket(
+      BuildContext context, Ticket ticket, String newStatus) async {
+    try {
+      // Build updated fields: new status + remove 'backlog' tag
+      final updates = <String, dynamic>{'status': newStatus};
+      if (ticket.tags.contains('backlog')) {
+        final newTags = List<String>.from(ticket.tags)..remove('backlog');
+        updates['tags'] = newTags;
+      }
+
+      await widget.backlogProvider.client.updateTicket(ticket.id, updates);
+      await widget.backlogProvider.refresh();
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('${ticket.id} activated as ${statusLabel(newStatus)}'),
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to activate ${ticket.id}: $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    }
+  }
+
+  // --- Bulk action bar ---
+
+  Widget _buildBulkActionBar() {
+    final provider = widget.backlogProvider;
+    if (!provider.hasSelection) return const SizedBox.shrink();
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.1),
+            blurRadius: 4,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          children: [
+            Text(
+              '${provider.selectionCount} selected',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            const Spacer(),
+            // Status picker
+            TextButton.icon(
+              icon: const Icon(Icons.flag_outlined, size: 18),
+              label: const Text('Status'),
+              onPressed: () => _showBulkStatusPicker(context),
+            ),
+            // Priority picker
+            TextButton.icon(
+              icon: const Icon(Icons.priority_high_outlined, size: 18),
+              label: const Text('Priority'),
+              onPressed: () => _showBulkPriorityPicker(context),
+            ),
+            // Assignee picker
+            TextButton.icon(
+              icon: const Icon(Icons.group_outlined, size: 18),
+              label: const Text('Assignee'),
+              onPressed: () => _showBulkAssigneePicker(context),
+            ),
+            // Apply button
+            FilledButton(
+              onPressed: () => _applyBulkUpdate(context),
+              child: const Text('Apply'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showBulkStatusPicker(BuildContext context) async {
+    final result = await showModalBottomSheet<String>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: StatusPickerSheet(
+          currentStatus: 'idea',
+          onSelect: (status) => Navigator.pop(ctx, status),
+        ),
+      ),
+    );
+    if (result != null && context.mounted) {
+      await _bulkUpdate(context, {'status': result});
+    }
+  }
+
+  Future<void> _showBulkPriorityPicker(BuildContext context) async {
+    final result = await showModalBottomSheet<String>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: PriorityPickerSheet(
+          currentPriority: 'medium',
+          onSelect: (priority) => Navigator.pop(ctx, priority),
+        ),
+      ),
+    );
+    if (result != null && context.mounted) {
+      await _bulkUpdate(context, {'priority': result});
+    }
+  }
+
+  Future<void> _showBulkAssigneePicker(BuildContext context) async {
+    final result = await showModalBottomSheet<String?>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: AssigneePickerSheet(
+          client: widget.backlogProvider.client,
+          currentAssignee: null,
+          onSelect: (assignee) => Navigator.pop(ctx, assignee),
+        ),
+      ),
+    );
+    if (result != null && context.mounted) {
+      await _bulkUpdate(context, {'assignee': result});
+    }
+  }
+
+  Future<void> _bulkUpdate(BuildContext context, Map<String, dynamic> update) async {
+    final provider = widget.backlogProvider;
+    final selectedTickets =
+        provider.allTickets.where((t) => provider.selectedIds.contains(t.id)).toList();
+
+    int success = 0;
+    int failed = 0;
+
+    for (final ticket in selectedTickets) {
+      try {
+        await provider.client.updateTicket(ticket.id, update);
+        success++;
+      } catch (e) {
+        failed++;
+        debugPrint('bulkUpdate failed for ${ticket.id}: $e');
+      }
+    }
+
+    provider.deselectAll();
+    await provider.refresh();
+
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            failed == 0
+                ? 'Updated $success ticket(s)'
+                : 'Updated $success ticket(s), $failed failed',
+          ),
+          backgroundColor: failed > 0
+              ? Theme.of(context).colorScheme.error
+              : null,
+        ),
+      );
+    }
+  }
+
+  Future<void> _applyBulkUpdate(BuildContext context) async {
+    // This is called when the user taps "Apply" without picking a specific field.
+    // For now just show a snackbar — the individual pickers handle actual updates.
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Pick a field to update first'),
+        duration: Duration(seconds: 2),
+      ),
+    );
+  }
+
+  // --- Helpers ---
+
+  List<String> _uniqueAssignees(List<Ticket> tickets) {
+    final s = <String>{};
+    for (final t in tickets) {
+      if (t.assignee != null && t.assignee!.isNotEmpty) s.add(t.assignee!);
+    }
+    final list = s.toList()..sort();
+    return list;
+  }
+
+  List<String> _uniqueTags(List<Ticket> tickets) {
+    final s = <String>{};
+    for (final t in tickets) {
+      for (final tag in t.tags) {
+        if (tag != 'backlog') s.add(tag);
+      }
+    }
+    final list = s.toList()..sort();
+    return list;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Backlog'),
+        actions: [
+          // Select all / deselect all toggle
+          if (widget.backlogProvider.tickets.isNotEmpty)
+            widget.backlogProvider.hasSelection
+                ? IconButton(
+                    icon: const Icon(Icons.deselect),
+                    tooltip: 'Deselect all',
+                    onPressed: widget.backlogProvider.deselectAll,
+                  )
+                : IconButton(
+                    icon: const Icon(Icons.select_all),
+                    tooltip: 'Select all',
+                    onPressed: widget.backlogProvider.selectAll,
+                  ),
+        ],
+      ),
+      body: ListenableBuilder(
+        listenable: widget.backlogProvider,
+        builder: (context, _) {
+          final provider = widget.backlogProvider;
+
+          if (provider.loading && provider.allTickets.isEmpty) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (provider.error != null && provider.allTickets.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.cloud_off,
+                      size: 48, color: Theme.of(context).colorScheme.error),
+                  const SizedBox(height: 12),
+                  Text('Failed to load backlog',
+                      style: Theme.of(context).textTheme.titleMedium),
+                  const SizedBox(height: 4),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 32),
+                    child: Text(
+                      provider.error ?? '',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Theme.of(context).colorScheme.outline,
+                          ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  OutlinedButton.icon(
+                    onPressed: provider.refresh,
+                    icon: const Icon(Icons.refresh),
+                    label: const Text('Retry'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          // Fetch projects for the filter row dropdown
+          Future<List<TicketProject>> projectsFuture =
+              provider.client.getProjects();
+
+          return Column(
+            children: [
+              // Filter bar
+              FutureBuilder<List<TicketProject>>(
+                future: projectsFuture,
+                builder: (context, snapshot) {
+                  final projects = snapshot.data ?? [];
+                  return _buildFilterRow(projects);
+                },
+              ),
+              // Loading indicator overlay when refreshing
+              if (provider.loading)
+                const LinearProgressIndicator(),
+              // Ticket list
+              Expanded(
+                child: RefreshIndicator(
+                  onRefresh: provider.refresh,
+                  child: provider.tickets.isEmpty
+                      ? Center(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                Icons.inbox_outlined,
+                                size: 48,
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .outlineVariant,
+                              ),
+                              const SizedBox(height: 12),
+                              Text(
+                                'No backlog tickets',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleMedium
+                                    ?.copyWith(
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .outline,
+                                    ),
+                              ),
+                            ],
+                          ),
+                        )
+                      : _buildTicketList(),
+                ),
+              ),
+              // Bulk action bar
+              _buildBulkActionBar(),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// A single backlog ticket row with leading checkbox and tap-to-activate.
+class _BacklogTicketTile extends StatelessWidget {
+  final Ticket ticket;
+  final bool isSelected;
+  final VoidCallback onToggleSelect;
+  final VoidCallback onTap;
+
+  const _BacklogTicketTile({
+    required this.ticket,
+    required this.isSelected,
+    required this.onToggleSelect,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: ListTile(
+        leading: Checkbox(
+          value: isSelected,
+          onChanged: (_) => onToggleSelect(),
+        ),
+        title: Text(
+          ticket.title,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Row(
+          children: [
+            Text(
+              ticket.id,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.primary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(width: 8),
+            _StatusChip(status: ticket.status),
+            if (ticket.assignee != null && ticket.assignee!.isNotEmpty) ...[
+              const SizedBox(width: 8),
+              Icon(Icons.person_outline,
+                  size: 14, color: theme.colorScheme.outline),
+              const SizedBox(width: 2),
+              Text(
+                ticket.assignee!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
+              ),
+            ],
+          ],
+        ),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: onTap,
+      ),
+    );
+  }
+}
+
+/// Small colored chip showing ticket status.
+class _StatusChip extends StatelessWidget {
+  final String status;
+
+  const _StatusChip({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: statusColor(status).withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        statusLabel(status),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: statusColor(status),
+              fontWeight: FontWeight.w600,
+            ),
+      ),
+    );
+  }
+}

--- a/phone/lib/screens/kanban_board_screen.dart
+++ b/phone/lib/screens/kanban_board_screen.dart
@@ -328,10 +328,25 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
               const SizedBox(width: 12),
               ActionChip(
                 avatar: const Icon(Icons.inventory_2_outlined, size: 18),
-                label: const Text('Backlog'),
+                label: ListenableBuilder(
+                  listenable: widget.boardProvider,
+                  builder: (context, _) {
+                    final count = widget.boardProvider.backlogCount;
+                    return Text(count > 0 ? 'Backlog ($count)' : 'Backlog');
+                  },
+                ),
                 onPressed: () {
                   final backlogProvider = BacklogProvider(widget.boardProvider.client);
-                  backlogProvider.fetchBacklog();
+                  backlogProvider.fetchBacklog().then((_) {
+                    if (backlogProvider.totalCount > 0 && context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('${backlogProvider.totalCount} backlog ticket(s)'),
+                          duration: const Duration(seconds: 2),
+                        ),
+                      );
+                    }
+                  });
                   Navigator.push(
                     context,
                     MaterialPageRoute<void>(

--- a/phone/lib/screens/kanban_board_screen.dart
+++ b/phone/lib/screens/kanban_board_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../models/deployment.dart';
 import '../models/ticket.dart';
+import '../services/backlog_provider.dart';
 import '../services/board_provider.dart';
 import '../services/deployment_provider.dart';
 import '../services/focus_provider.dart';
@@ -19,6 +20,7 @@ import '../services/crdt_sync_service.dart';
 import '../services/agent_api_client.dart';
 import '../services/display_settings_service.dart';
 import '../settings/settings_screen.dart';
+import 'backlog_screen.dart';
 import 'create_bulletin_screen.dart';
 import 'create_ticket_screen.dart';
 import 'ticket_detail_screen.dart';
@@ -322,6 +324,22 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
                       ),
                     )),
               ],
+              // Backlog navigation button
+              const SizedBox(width: 12),
+              ActionChip(
+                avatar: const Icon(Icons.inventory_2_outlined, size: 18),
+                label: const Text('Backlog'),
+                onPressed: () {
+                  final backlogProvider = BacklogProvider(widget.boardProvider.client);
+                  backlogProvider.fetchBacklog();
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute<void>(
+                      builder: (_) => BacklogScreen(backlogProvider: backlogProvider),
+                    ),
+                  );
+                },
+              ),
             ],
           ),
         ),

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -24,6 +24,7 @@ import '../models/review_item.dart';
 import '../models/team_folder.dart';
 import '../models/ticket.dart';
 import '../models/timer_info.dart';
+import 'kanban_constants.dart';
 
 /// HTTP client for the agent workflow API endpoints.
 ///
@@ -744,6 +745,50 @@ class AgentApiClient {
     return tickets
         .map((e) => Ticket.fromJson(e as Map<String, dynamic>))
         .toList();
+  }
+
+  /// Get the backlog — tickets that are inactive.
+  ///
+  /// The backlog is the union of:
+  /// - Tag-based backlog: tickets with 'backlog' tag
+  /// - Status-based backlog: tickets with status in backlogStatuses
+  ///
+  /// Combines both queries and deduplicates by ticket ID.
+  Future<List<Ticket>> getBacklog({
+    String? project,
+    String? assignee,
+    String? priority,
+    String? tags,
+  }) async {
+    // Tag-based backlog: tickets with 'backlog' tag
+    final tagBased = await listTickets(
+      project: project,
+      assignee: assignee,
+      priority: priority,
+      tags: 'backlog',
+    );
+
+    // Status-based backlog: tickets in backlog statuses, excluding backlog/archived tags
+    // (a ticket that has 'backlog' tag but also a backlog status is already captured above)
+    final statusBased = await listTickets(
+      project: project,
+      assignee: assignee,
+      priority: priority,
+      tags: tags,
+      excludeTags: 'backlog,archived',
+      status: backlogStatuses.join(','),
+    );
+
+    // Combine and deduplicate by ticket ID
+    final Map<String, Ticket> byId = {};
+    for (final t in tagBased) {
+      byId[t.id] = t;
+    }
+    for (final t in statusBased) {
+      byId[t.id] = t;
+    }
+
+    return byId.values.toList();
   }
 
   /// Create a new ticket.

--- a/phone/lib/services/backlog_provider.dart
+++ b/phone/lib/services/backlog_provider.dart
@@ -5,6 +5,9 @@ import 'package:flutter/foundation.dart';
 import '../models/ticket.dart';
 import 'agent_api_client.dart';
 
+/// Sentinel value to distinguish "not provided" from explicit null in copyWith.
+const _sentinel = Object();
+
 /// Filter state for the backlog view.
 class BacklogFilter {
   final String? project;
@@ -22,14 +25,14 @@ class BacklogFilter {
   });
 
   BacklogFilter copyWith({
-    String? project,
+    Object? project = _sentinel,
     List<String>? assignees,
     List<String>? priorities,
     List<String>? tags,
     String? searchQuery,
   }) {
     return BacklogFilter(
-      project: project ?? this.project,
+      project: identical(project, _sentinel) ? this.project : project as String?,
       assignees: assignees ?? this.assignees,
       priorities: priorities ?? this.priorities,
       tags: tags ?? this.tags,
@@ -60,6 +63,7 @@ class BacklogProvider extends ChangeNotifier {
   bool _loading = false;
   String? _error;
   Timer? _debounceTimer;
+  List<TicketProject> _projects = [];
 
   BacklogProvider(this._client);
 
@@ -79,6 +83,9 @@ class BacklogProvider extends ChangeNotifier {
   /// Total backlog count (unfiltered) for badge display.
   int get totalCount => _allTickets.length;
 
+  /// Available projects for filtering.
+  List<TicketProject> get projects => _projects;
+
   // --- Client access ---
 
   AgentApiClient get client => _client;
@@ -92,12 +99,18 @@ class BacklogProvider extends ChangeNotifier {
     notifyListeners();
 
     try {
-      _allTickets = await _client.getBacklog(
-        project: _filter.project,
-        assignee: _filter.assignees.isNotEmpty ? _filter.assignees.join(',') : null,
-        priority: _filter.priorities.isNotEmpty ? _filter.priorities.join(',') : null,
-        tags: _filter.tags.isNotEmpty ? _filter.tags.join(',') : null,
-      );
+      // Fetch projects and backlog in parallel
+      final results = await Future.wait([
+        _client.getProjects(),
+        _client.getBacklog(
+          project: _filter.project,
+          assignee: _filter.assignees.isNotEmpty ? _filter.assignees.join(',') : null,
+          priority: _filter.priorities.isNotEmpty ? _filter.priorities.join(',') : null,
+          tags: _filter.tags.isNotEmpty ? _filter.tags.join(',') : null,
+        ),
+      ]);
+      _projects = results[0] as List<TicketProject>;
+      _allTickets = results[1] as List<Ticket>;
       _error = null;
     } catch (e) {
       _error = e.toString();

--- a/phone/lib/services/backlog_provider.dart
+++ b/phone/lib/services/backlog_provider.dart
@@ -265,4 +265,20 @@ class BacklogProvider extends ChangeNotifier {
     _debounceTimer?.cancel();
     super.dispose();
   }
+
+  // --- Activate a single ticket ---
+
+  /// Activate a backlog ticket — removes 'backlog' tag if present and
+  /// updates the status to [newStatus].
+  Future<Ticket> activateTicket(String ticketId, String newStatus) async {
+    final ticket = _allTickets.firstWhere((t) => t.id == ticketId);
+    final updates = <String, dynamic>{'status': newStatus};
+    if (ticket.tags.contains('backlog')) {
+      final newTags = List<String>.from(ticket.tags)..remove('backlog');
+      updates['tags'] = newTags;
+    }
+    final updated = await _client.updateTicket(ticketId, updates);
+    await refresh();
+    return updated;
+  }
 }

--- a/phone/lib/services/backlog_provider.dart
+++ b/phone/lib/services/backlog_provider.dart
@@ -1,0 +1,268 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../models/ticket.dart';
+import 'agent_api_client.dart';
+
+/// Filter state for the backlog view.
+class BacklogFilter {
+  final String? project;
+  final List<String> assignees;
+  final List<String> priorities;
+  final List<String> tags;
+  final String searchQuery;
+
+  const BacklogFilter({
+    this.project,
+    this.assignees = const [],
+    this.priorities = const [],
+    this.tags = const [],
+    this.searchQuery = '',
+  });
+
+  BacklogFilter copyWith({
+    String? project,
+    List<String>? assignees,
+    List<String>? priorities,
+    List<String>? tags,
+    String? searchQuery,
+  }) {
+    return BacklogFilter(
+      project: project ?? this.project,
+      assignees: assignees ?? this.assignees,
+      priorities: priorities ?? this.priorities,
+      tags: tags ?? this.tags,
+      searchQuery: searchQuery ?? this.searchQuery,
+    );
+  }
+
+  /// Returns true if no filters are active.
+  bool get isEmpty =>
+      project == null &&
+      assignees.isEmpty &&
+      priorities.isEmpty &&
+      tags.isEmpty &&
+      searchQuery.isEmpty;
+}
+
+/// Manages backlog state: ticket list, filters, and multi-select.
+///
+/// Fetches the combined tag-based and status-based backlog from the API,
+/// applies client-side filtering, and maintains selection state for
+/// bulk operations.
+class BacklogProvider extends ChangeNotifier {
+  final AgentApiClient _client;
+
+  List<Ticket> _allTickets = [];
+  BacklogFilter _filter = const BacklogFilter();
+  Set<String> _selectedIds = {};
+  bool _loading = false;
+  String? _error;
+  Timer? _debounceTimer;
+
+  BacklogProvider(this._client);
+
+  // --- Getters ---
+
+  List<Ticket> get tickets => _applyFilter(_allTickets);
+  List<Ticket> get allTickets => _allTickets;
+  BacklogFilter get filter => _filter;
+  Set<String> get selectedIds => _selectedIds;
+  bool get loading => _loading;
+  String? get error => _error;
+  bool get hasSelection => _selectedIds.isNotEmpty;
+  int get selectionCount => _selectedIds.length;
+  bool get allSelected =>
+      tickets.isNotEmpty && _selectedIds.length == tickets.length;
+
+  /// Total backlog count (unfiltered) for badge display.
+  int get totalCount => _allTickets.length;
+
+  // --- Client access ---
+
+  AgentApiClient get client => _client;
+
+  // --- Data loading ---
+
+  /// Fetch the full backlog from the API.
+  Future<void> fetchBacklog() async {
+    _loading = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      _allTickets = await _client.getBacklog(
+        project: _filter.project,
+        assignee: _filter.assignees.isNotEmpty ? _filter.assignees.join(',') : null,
+        priority: _filter.priorities.isNotEmpty ? _filter.priorities.join(',') : null,
+        tags: _filter.tags.isNotEmpty ? _filter.tags.join(',') : null,
+      );
+      _error = null;
+    } catch (e) {
+      _error = e.toString();
+      debugPrint('BacklogProvider fetchBacklog error: $e');
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+
+  /// Refresh — re-fetch from API preserving selection.
+  Future<void> refresh() async {
+    await fetchBacklog();
+  }
+
+  // --- Filter methods ---
+
+  /// Update the filter and re-apply client-side filtering.
+  ///
+  /// [searchQuery] is debounced (300ms) before applying.
+  void applyFilter({
+    String? project,
+    List<String>? assignees,
+    List<String>? priorities,
+    List<String>? tags,
+    String? searchQuery,
+  }) {
+    _filter = _filter.copyWith(
+      project: project,
+      assignees: assignees,
+      priorities: priorities,
+      tags: tags,
+      searchQuery: searchQuery,
+    );
+
+    // Debounce search to avoid excessive re-renders
+    _debounceTimer?.cancel();
+    if (searchQuery != null) {
+      _debounceTimer = Timer(const Duration(milliseconds: 300), () {
+        notifyListeners();
+      });
+    } else {
+      notifyListeners();
+    }
+  }
+
+  /// Set search query with debouncing.
+  void setSearchQuery(String query) {
+    applyFilter(searchQuery: query);
+  }
+
+  /// Set project filter.
+  void setProject(String? project) {
+    applyFilter(project: project);
+  }
+
+  /// Set assignee filter (replaces existing).
+  void setAssignees(List<String> assignees) {
+    applyFilter(assignees: assignees);
+  }
+
+  /// Set priority filter (replaces existing).
+  void setPriorities(List<String> priorities) {
+    applyFilter(priorities: priorities);
+  }
+
+  /// Set tags filter (replaces existing).
+  void setTags(List<String> tags) {
+    applyFilter(tags: tags);
+  }
+
+  /// Clear all filters.
+  void clearFilters() {
+    _filter = const BacklogFilter();
+    _debounceTimer?.cancel();
+    notifyListeners();
+  }
+
+  // --- Selection methods ---
+
+  /// Select a single ticket by ID.
+  void selectTicket(String id) {
+    if (!_selectedIds.contains(id)) {
+      _selectedIds = {..._selectedIds, id};
+      notifyListeners();
+    }
+  }
+
+  /// Deselect a single ticket by ID.
+  void deselectTicket(String id) {
+    if (_selectedIds.contains(id)) {
+      _selectedIds = {..._selectedIds}..remove(id);
+      notifyListeners();
+    }
+  }
+
+  /// Toggle selection for a single ticket.
+  void toggleTicket(String id) {
+    if (_selectedIds.contains(id)) {
+      deselectTicket(id);
+    } else {
+      selectTicket(id);
+    }
+  }
+
+  /// Select all currently filtered tickets.
+  void selectAll() {
+    final filteredIds = tickets.map((t) => t.id).toSet();
+    _selectedIds = {..._selectedIds, ...filteredIds};
+    notifyListeners();
+  }
+
+  /// Deselect all tickets.
+  void deselectAll() {
+    _selectedIds = {};
+    notifyListeners();
+  }
+
+  // --- Private helpers ---
+
+  /// Apply client-side filter to ticket list.
+  List<Ticket> _applyFilter(List<Ticket> source) {
+    if (_filter.isEmpty) return List.from(source);
+
+    final query = _filter.searchQuery.toLowerCase();
+
+    return source.where((ticket) {
+      // Project filter
+      if (_filter.project != null &&
+          ticket.project != _filter.project) {
+        return false;
+      }
+
+      // Assignee filter
+      if (_filter.assignees.isNotEmpty &&
+          !_filter.assignees.contains(ticket.assignee)) {
+        return false;
+      }
+
+      // Priority filter
+      if (_filter.priorities.isNotEmpty &&
+          !_filter.priorities.contains(ticket.priority)) {
+        return false;
+      }
+
+      // Tags filter
+      if (_filter.tags.isNotEmpty &&
+          !_filter.tags.any((tag) => ticket.tags.contains(tag))) {
+        return false;
+      }
+
+      // Free-text search: title and ticket ID
+      if (query.isNotEmpty) {
+        final matchesTitle = ticket.title.toLowerCase().contains(query);
+        final matchesId = ticket.id.toLowerCase().contains(query);
+        if (!matchesTitle && !matchesId) return false;
+      }
+
+      return true;
+    }).toList();
+  }
+
+  @override
+  void dispose() {
+    _debounceTimer?.cancel();
+    super.dispose();
+  }
+}

--- a/phone/lib/services/board_provider.dart
+++ b/phone/lib/services/board_provider.dart
@@ -44,6 +44,7 @@ class BoardProvider extends ChangeNotifier {
   String _searchQuery = '';
   Timer? _pollTimer;
   SharedPreferences? _prefs;
+  int _backlogCount = 0;
 
   BoardProvider(this._client) {
     _initPrefs();
@@ -70,6 +71,9 @@ class BoardProvider extends ChangeNotifier {
   String? get selectedAssignee => _selectedAssignee;
   bool get showTerminal => _showTerminal;
   String get searchQuery => _searchQuery;
+
+  /// Backlog ticket count for display on the Kanban board badge.
+  int get backlogCount => _backlogCount;
 
   /// Active (non-terminal, non-on-hold) columns in kanban order.
   List<BoardColumn> get activeColumns {
@@ -169,9 +173,11 @@ class BoardProvider extends ChangeNotifier {
         _client.getBoard(
             project: _selectedProject ?? '', assignee: _selectedAssignee),
         _client.getBulletins(),
+        _client.getBacklog(),
       ]);
       _board = results[0] as BoardView;
       _bulletins = results[1] as List<Bulletin>;
+      _backlogCount = (results[2] as List).length;
       _error = null;
     } catch (e) {
       _error = e.toString();

--- a/phone/lib/services/kanban_constants.dart
+++ b/phone/lib/services/kanban_constants.dart
@@ -1,0 +1,23 @@
+// Kanban board status constants.
+//
+// Used by both the main Kanban board (BoardProvider) and the backlog
+// view (BacklogProvider) to categorize ticket statuses.
+
+/// Active kanban columns — tickets in active sprint workflow.
+const activeStatuses = {'implementing', 'review-uat'};
+
+/// Terminal columns — tickets that are done and out of workflow.
+const terminalStatuses = {'done', 'rejected', 'cancelled'};
+
+/// Backlog statuses — tickets that are inactive but not yet terminal.
+///
+/// The backlog is the union of:
+/// - tickets with 'backlog' tag (tag-based backlog)
+/// - tickets with status in this set (status-based backlog)
+const backlogStatuses = {
+  'idea',
+  'on-hold',
+  'requirement-review',
+  'pending-approval',
+  'pending-implementation',
+};

--- a/phone/lib/widgets/tag_picker_sheet.dart
+++ b/phone/lib/widgets/tag_picker_sheet.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+
+/// A bottom sheet for picking tags with multi-select support.
+///
+/// Shows all available [tags] with checkboxes. The [selectedTags] are
+/// pre-checked. Calls [onSelect] with the updated list of selected tags.
+///
+/// Usage:
+/// ```dart
+/// showModalBottomSheet(
+///   context: context,
+///   builder: (_) => TagPickerSheet(
+///     availableTags: allTags,
+///     selectedTags: currentTags,
+///     onSelect: (tags) { ... },
+///   ),
+/// );
+/// ```
+class TagPickerSheet extends StatefulWidget {
+  final List<String> availableTags;
+  final List<String> selectedTags;
+  final void Function(List<String> tags) onSelect;
+
+  const TagPickerSheet({
+    super.key,
+    required this.availableTags,
+    required this.selectedTags,
+    required this.onSelect,
+  });
+
+  @override
+  State<TagPickerSheet> createState() => _TagPickerSheetState();
+}
+
+class _TagPickerSheetState extends State<TagPickerSheet> {
+  late List<String> _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = List.from(widget.selectedTags);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              margin: const EdgeInsets.symmetric(vertical: 12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.outlineVariant,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: Row(
+              children: [
+                Text(
+                  'Change Tags',
+                  style: theme.textTheme.titleMedium
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                ),
+                const Spacer(),
+                TextButton(
+                  onPressed: () {
+                    widget.onSelect(_selected);
+                    Navigator.of(context).pop();
+                  },
+                  child: const Text('Apply'),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: widget.availableTags.isEmpty
+                ? Center(
+                    child: Text(
+                      'No tags available',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.outline,
+                      ),
+                    ),
+                  )
+                : ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: widget.availableTags.length,
+                    itemBuilder: (context, index) {
+                      final tag = widget.availableTags[index];
+                      final isSelected = _selected.contains(tag);
+                      return CheckboxListTile(
+                        value: isSelected,
+                        title: Text(tag),
+                        onChanged: (checked) {
+                          setState(() {
+                            if (checked == true) {
+                              _selected.add(tag);
+                            } else {
+                              _selected.remove(tag);
+                            }
+                          });
+                        },
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- [x] AC1: Backlog button visible on Kanban board navigating to backlog view
- [x] AC2: Backlog view shows all tickets with backlog tag OR backlog statuses (idea, on-hold, requirement-review, pending-approval, pending-implementation)
- [x] AC3: Filter bar with project, assignee, priority, tags, free-text search
- [x] AC4: Free-text search matches title and ticket ID
- [x] AC5: Tap backlog ticket opens activate dialog (removes backlog tag, updates status)
- [x] AC6: Multi-select with bulk action bar (status, priority, assignee, tags)
- [x] AC7: Backlog count badge on Kanban board header
- [x] AC8: Pull-to-refresh on backlog view
- [x] AC9: Bulk update persists to PA server

## What changed
- **New files:** `kanban_constants.dart`, `backlog_provider.dart`, `backlog_screen.dart`
- **Modified files:** `agent_api_client.dart` (getBacklog()), `kanban_board_screen.dart` (backlog button + badge)

## Phases
- Phase A: BacklogProvider + AgentApiClient.getBacklog() — commit f62c6d2
- Phase B: BacklogScreen UI + Kanban integration — commit 6f5b4d3

🤖 Generated with [Claude Code](https://claude.com/claude-code)