### PR TITLE
fix(docker): fix web version loading and routing

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -34,15 +34,23 @@
     }
     respond @health 200 "OK"
 
-    # Proxy /api/* to sync server
+    # Proxy /api/* to sync server (HTTPS backend with self-signed cert)
     @api {
         path /api/*
     }
-    reverse_proxy @api {$SYNC_SERVER_HOST:-avodah-sync}:{$SYNC_SERVER_PORT:-9847}
+    reverse_proxy @api https://{$SYNC_SERVER_HOST:-avodah-sync}:{$SYNC_SERVER_PORT:-9847} {
+        transport http {
+            tls_insecure_skip_verify
+        }
+    }
 
-    # Proxy /ws WebSocket to sync server
+    # Proxy /ws WebSocket to sync server (HTTPS backend with self-signed cert)
     @ws {
         path /ws
     }
-    reverse_proxy @ws {$SYNC_SERVER_HOST:-avodah-sync}:{$SYNC_SERVER_PORT:-9847}
+    reverse_proxy @ws https://{$SYNC_SERVER_HOST:-avodah-sync}:{$SYNC_SERVER_PORT:-9847} {
+        transport http {
+            tls_insecure_skip_verify
+        }
+    }
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,14 +1,19 @@
 # Avodah Web UI — Caddy configuration
 #
 # Serves Flutter web static assets with COOP/COEP headers for OPFS support
-# Proxies /api/* and /ws to the sync server (avodah-sync:9847)
+# Proxies /api/* and /ws to the sync server
 #
 # Environment variables:
 #   WEB_PORT — port to listen on (default: 8080)
+#   TLS_CERT — path to TLS certificate (optional, enables HTTPS)
+#   TLS_KEY  — path to TLS private key (optional, enables HTTPS)
 #   SYNC_SERVER_HOST — hostname of sync server (default: avodah-sync)
 #   SYNC_SERVER_PORT — port of sync server (default: 9847)
 
-:{$WEB_PORT:-8080} {
+https://:{$WEB_PORT:-8080} {
+    # TLS with Tailscale certificates mounted from host
+    tls {$TLS_CERT} {$TLS_KEY}
+
     # Serve Flutter web static assets from /srv
     root * /srv
     file_server

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,14 +1,19 @@
 # Avodah Web UI — Caddy configuration
 #
 # Serves Flutter web static assets with COOP/COEP headers for OPFS support
-# Proxies /api/* and /ws to the sync server
+# Routes API traffic:
+#   /api/sync/* → sync server (HTTPS, port 9847) — CRDT delta sync
+#   /api/*      → pa-serve (HTTP, port 9848)     — tickets, board, deployments
+#   /ws         → sync server (HTTPS, port 9847) — WebSocket
 #
 # Environment variables:
 #   WEB_PORT — port to listen on (default: 8080)
-#   TLS_CERT — path to TLS certificate (optional, enables HTTPS)
-#   TLS_KEY  — path to TLS private key (optional, enables HTTPS)
-#   SYNC_SERVER_HOST — hostname of sync server (default: avodah-sync)
+#   TLS_CERT — path to TLS certificate (enables HTTPS)
+#   TLS_KEY  — path to TLS private key (enables HTTPS)
+#   SYNC_SERVER_HOST — hostname of sync server (default: localhost)
 #   SYNC_SERVER_PORT — port of sync server (default: 9847)
+#   AGENT_API_HOST — hostname of pa-serve (default: localhost)
+#   AGENT_API_PORT — port of pa-serve (default: 9848)
 
 https://:{$WEB_PORT:-8080} {
     # TLS with Tailscale certificates mounted from host
@@ -39,21 +44,27 @@ https://:{$WEB_PORT:-8080} {
     }
     respond @health 200 "OK"
 
-    # Proxy /api/* to sync server (HTTPS backend with self-signed cert)
-    @api {
-        path /api/*
+    # CRDT sync routes → sync server (HTTPS, requires pairing auth)
+    @sync {
+        path /api/sync/*
     }
-    reverse_proxy @api https://{$SYNC_SERVER_HOST:-avodah-sync}:{$SYNC_SERVER_PORT:-9847} {
+    reverse_proxy @sync https://{$SYNC_SERVER_HOST:-localhost}:{$SYNC_SERVER_PORT:-9847} {
         transport http {
             tls_insecure_skip_verify
         }
     }
 
-    # Proxy /ws WebSocket to sync server (HTTPS backend with self-signed cert)
+    # All other /api/* routes → pa-serve directly (no auth required)
+    @api {
+        path /api/*
+    }
+    reverse_proxy @api {$AGENT_API_HOST:-localhost}:{$AGENT_API_PORT:-9848}
+
+    # Proxy /ws WebSocket to sync server (HTTPS)
     @ws {
         path /ws
     }
-    reverse_proxy @ws https://{$SYNC_SERVER_HOST:-avodah-sync}:{$SYNC_SERVER_PORT:-9847} {
+    reverse_proxy @ws https://{$SYNC_SERVER_HOST:-localhost}:{$SYNC_SERVER_PORT:-9847} {
         transport http {
             tls_insecure_skip_verify
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,15 @@ services:
     network_mode: host
     ports:
       - "${WEB_PORT:-8080}:${WEB_PORT:-8080}"
+    volumes:
+      # Mount config dir (read-only) for TLS certificates
+      - ${AVODAH_CONFIG:-~/.config/avodah}:/config:ro
+      # Mount Caddyfile from repo (avoids rebuilding image for config changes)
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
     environment:
       - WEB_PORT=${WEB_PORT:-8080}
+      - TLS_CERT=/config/${TLS_CERT_NAME:-drgnfly.tail10c2c6.ts.net.crt}
+      - TLS_KEY=/config/${TLS_KEY_NAME:-drgnfly.tail10c2c6.ts.net.key}
       - SYNC_SERVER_HOST=localhost
       - SYNC_SERVER_PORT=${SYNC_PORT:-9847}
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - TLS_KEY=/config/${TLS_KEY_NAME:-drgnfly.tail10c2c6.ts.net.key}
       - SYNC_SERVER_HOST=localhost
       - SYNC_SERVER_PORT=${SYNC_PORT:-9847}
+      - AGENT_API_HOST=localhost
+      - AGENT_API_PORT=${AGENT_PORT:-9848}
     depends_on:
       - avodah-sync
     restart: unless-stopped

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:avodah_core/avodah_core.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
@@ -64,6 +65,22 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
   }
 
   Future<void> _initApp() async {
+    try {
+      await _initAppInner();
+    } catch (e, st) {
+      debugPrint('[Init] Fatal error during app initialization: $e\n$st');
+      // Show error state instead of infinite loading spinner
+      if (mounted) {
+        setState(() {
+          _initError = e.toString();
+        });
+      }
+    }
+  }
+
+  String? _initError;
+
+  Future<void> _initAppInner() async {
     // Open local database
     final db = await openPhoneDatabase();
 
@@ -83,12 +100,18 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     // Load stored server URL (already HTTP format)
     final httpBaseUrl = await SettingsScreen.loadServerUrl();
 
-    // TLS-capable HTTP client with certificate verification
-    final cryptoSyncService = CryptoSyncService(
-      baseUrl: httpBaseUrl,
-      nodeId: nodeId,
-    );
-    await cryptoSyncService.loadPersistedState();
+    // TLS-capable HTTP client with certificate verification.
+    // dart:io HttpClient is not available on web — skip CryptoSyncService
+    // entirely. On web, the browser handles TLS natively, and the Caddy
+    // reverse proxy makes cert pinning unnecessary.
+    CryptoSyncService? cryptoSyncService;
+    if (!kIsWeb) {
+      cryptoSyncService = CryptoSyncService(
+        baseUrl: httpBaseUrl,
+        nodeId: nodeId,
+      );
+      await cryptoSyncService.loadPersistedState();
+    }
 
     // CRDT sync service with TLS + pairing integration
     final crdtSyncService = CrdtSyncService(
@@ -103,7 +126,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
 
     // Agent workflow API — inject pairing credentials for authenticated proxy
     final apiClient = AgentApiClient(baseUrl: httpBaseUrl)
-      ..pairingToken = cryptoSyncService.pairingToken
+      ..pairingToken = cryptoSyncService?.pairingToken
       ..nodeId = nodeId;
     final reviewProvider = ReviewProvider(apiClient);
     reviewProvider.startAutoRefresh();
@@ -375,7 +398,29 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
                 extensions: [syntaxTheme],
               ),
           themeMode: display != null ? ThemeMode.system : ThemeMode.light,
-          home: _dashboardProvider == null
+          home: _initError != null
+              ? Scaffold(
+                  body: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(Icons.error_outline,
+                              size: 48, color: Colors.red),
+                          const SizedBox(height: 16),
+                          const Text('Failed to initialize',
+                              style: TextStyle(fontSize: 18)),
+                          const SizedBox(height: 8),
+                          Text(_initError!,
+                              textAlign: TextAlign.center,
+                              style: const TextStyle(color: Colors.grey)),
+                        ],
+                      ),
+                    ),
+                  ),
+                )
+              : _dashboardProvider == null
               ? const Scaffold(
                   body: Center(child: CircularProgressIndicator()),
                 )

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
@@ -33,9 +34,12 @@ class SettingsScreen extends StatefulWidget {
   /// Loads the saved server URL, or returns the default.
   ///
   /// Auto-migrates legacy `ws://` URLs to `http://` (Phase 9 removed WebSocket).
+  /// On web, defaults to the page's own origin (same-origin requests go through
+  /// the Caddy reverse proxy) instead of the hardcoded Tailscale IP.
   static Future<String> loadServerUrl() async {
     final prefs = await SharedPreferences.getInstance();
-    var url = prefs.getString(kServerUrlKey) ?? kDefaultServerUrl;
+    final defaultUrl = kIsWeb ? Uri.base.origin : kDefaultServerUrl;
+    var url = prefs.getString(kServerUrlKey) ?? defaultUrl;
     if (url.startsWith('ws://') || url.startsWith('wss://')) {
       url = url.replaceFirst(RegExp(r'^wss?://'), 'http://');
     }


### PR DESCRIPTION
## Summary
- Fix Docker web version stuck on infinite loading spinner (`CryptoSyncService` uses `dart:io` APIs unavailable on web)
- Add error screen for initialization failures instead of silent spinner
- Default server URL on web to same-origin (`Uri.base.origin`) instead of hardcoded Tailscale IP
- Configure Caddy reverse proxy with HTTPS (Tailscale certs) and split routing:
  - `/api/sync/*` → sync server (HTTPS :9847)
  - `/api/*` → pa-serve directly (HTTP :9848, no auth)
  - `/ws` → sync server (HTTPS :9847)

## Test plan
- [x] `flutter analyze` — no new issues
- [x] `dart test` (mcp) — 435 tests pass
- [x] Docker build succeeds
- [x] Web app loads at `https://drgnfly.tail10c2c6.ts.net:8080`
- [x] Board/kanban/deployments screens load (pa-serve routing)
- [x] CRDT sync routes still reach sync server
- [ ] Verify on fresh browser (no saved URL) defaults to same-origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)