### PR TITLE
feat(phone): rich doc_ref display with grouped sections and image gallery (AVO-097)

### DIFF
--- a/phone/android/app/src/main/AndroidManifest.xml
+++ b/phone/android/app/src/main/AndroidManifest.xml
@@ -43,5 +43,13 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="https"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="http"/>
+        </intent>
     </queries>
 </manifest>

--- a/phone/lib/models/ticket.dart
+++ b/phone/lib/models/ticket.dart
@@ -31,6 +31,35 @@ class DocRef {
   }
 }
 
+/// Display type for doc_ref rendering.
+enum DocRefDisplayType { image, markdown, url, pdf, unknown }
+
+/// Classifies a [DocRef] by its content type based on path extension and URL prefix.
+extension DocRefClassifier on DocRef {
+  DocRefDisplayType get displayType {
+    final path = this.path;
+    if (path.startsWith('http://') || path.startsWith('https://')) {
+      return DocRefDisplayType.url;
+    }
+    final lower = path.toLowerCase();
+    if (lower.endsWith('.png') ||
+        lower.endsWith('.jpg') ||
+        lower.endsWith('.jpeg') ||
+        lower.endsWith('.gif') ||
+        lower.endsWith('.webp') ||
+        lower.endsWith('.svg')) {
+      return DocRefDisplayType.image;
+    }
+    if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
+      return DocRefDisplayType.markdown;
+    }
+    if (lower.endsWith('.pdf')) {
+      return DocRefDisplayType.pdf;
+    }
+    return DocRefDisplayType.unknown;
+  }
+}
+
 class TicketComment {
   final String id;
   final String author;

--- a/phone/lib/screens/image_gallery_screen.dart
+++ b/phone/lib/screens/image_gallery_screen.dart
@@ -1,0 +1,153 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:photo_view/photo_view.dart';
+import 'package:photo_view/photo_view_gallery.dart';
+
+import '../models/ticket.dart';
+import '../services/agent_api_client.dart';
+
+/// Full-screen image gallery with swipe navigation and pinch-to-zoom.
+///
+/// Uses [PhotoViewGallery] to display image [DocRef]s fetched from pa-serve.
+class ImageGalleryScreen extends StatefulWidget {
+  final List<DocRef> images;
+  final int initialIndex;
+  final AgentApiClient client;
+
+  const ImageGalleryScreen({
+    super.key,
+    required this.images,
+    required this.initialIndex,
+    required this.client,
+  });
+
+  @override
+  State<ImageGalleryScreen> createState() => _ImageGalleryScreenState();
+}
+
+class _ImageGalleryScreenState extends State<ImageGalleryScreen> {
+  late PageController _pageController;
+  late int _currentIndex;
+
+  /// Caches fetched bytes so revisiting a page doesn't re-fetch.
+  final Map<int, List<int>> _cache = {};
+
+  /// Tracks loading state per page.
+  final Map<int, bool> _loading = {};
+  final Map<int, bool> _error = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _currentIndex = widget.initialIndex;
+    _pageController = PageController(initialPage: widget.initialIndex);
+    // Pre-load adjacent pages
+    _ensureLoaded(_currentIndex - 1);
+    _ensureLoaded(_currentIndex);
+    _ensureLoaded(_currentIndex + 1);
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _ensureLoaded(int index) {
+    if (index < 0 || index >= widget.images.length) return;
+    if (_cache.containsKey(index) || _loading[index] == true) return;
+    _loading[index] = true;
+    widget.client.getImageBytes(widget.images[index].path).then((bytes) {
+      if (mounted) {
+        setState(() {
+          _cache[index] = bytes;
+          _loading[index] = false;
+        });
+      }
+    }).catchError((_) {
+      if (mounted) {
+        setState(() {
+          _error[index] = true;
+          _loading[index] = false;
+        });
+      }
+    });
+  }
+
+  void _onPageChanged(int index) {
+    setState(() => _currentIndex = index);
+    _ensureLoaded(index - 1);
+    _ensureLoaded(index + 1);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        title: Text(
+          '${_currentIndex + 1} / ${widget.images.length}',
+          style: const TextStyle(color: Colors.white, fontSize: 16),
+        ),
+        centerTitle: true,
+      ),
+      body: PhotoViewGallery.builder(
+        pageController: _pageController,
+        itemCount: widget.images.length,
+        onPageChanged: _onPageChanged,
+        builder: (context, index) {
+          return PhotoViewGalleryPageOptions(
+            imageProvider: _cache[index] != null
+                ? MemoryImage(Uint8List.fromList(_cache[index]!))
+                : null,
+            minScale: PhotoViewComputedScale.contained,
+            maxScale: PhotoViewComputedScale.covered * 3,
+            errorBuilder: (_, __, ___) => _ErrorPage(
+              onRetry: () {
+                setState(() {
+                  _cache.remove(index);
+                  _error.remove(index);
+                  _loading.remove(index);
+                });
+                _ensureLoaded(index);
+              },
+            ),
+          );
+        },
+        backgroundDecoration: const BoxDecoration(color: Colors.black),
+      ),
+    );
+  }
+}
+
+class _ErrorPage extends StatelessWidget {
+  final VoidCallback onRetry;
+
+  const _ErrorPage({required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.broken_image, color: Colors.grey, size: 64),
+          const SizedBox(height: 16),
+          const Text(
+            'Could not load image',
+            style: TextStyle(color: Colors.grey),
+          ),
+          const SizedBox(height: 12),
+          TextButton.icon(
+            onPressed: onRetry,
+            icon: const Icon(Icons.refresh, color: Colors.white),
+            label: const Text('Retry', style: TextStyle(color: Colors.white)),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/phone/lib/screens/ticket_detail_screen.dart
+++ b/phone/lib/screens/ticket_detail_screen.dart
@@ -15,6 +15,7 @@ import '../widgets/priority_picker_sheet.dart';
 import '../widgets/status_picker_sheet.dart';
 import '../widgets/assignee_picker_sheet.dart';
 import '../widgets/image_attachment_picker.dart';
+import '../widgets/doc_ref_section.dart';
 import '../widgets/no_select_text_field.dart';
 import '../widgets/text_input_sheet.dart';
 import '../widgets/ticket_deployments_section.dart';
@@ -1251,21 +1252,9 @@ class _TicketDetailScreenState extends State<TicketDetailScreen> {
           ],
           if (ticket.docRefs.isNotEmpty) ...[
             const SizedBox(height: 16),
-            _SectionLabel('Doc Refs'),
-            const SizedBox(height: 4),
-            ...ticket.docRefs.map(
-              (ref) => _DocRefRow(
-                docRef: ref,
-                onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => DocumentViewerScreen(
-                      path: ref.path,
-                      client: widget.boardProvider.client,
-                    ),
-                  ),
-                ),
-              ),
+            DocRefSection(
+              docRefs: ticket.docRefs,
+              client: widget.boardProvider.client,
             ),
           ],
           // Image attachments — "Add photo" button + picker

--- a/phone/lib/services/agent_api_client.dart
+++ b/phone/lib/services/agent_api_client.dart
@@ -915,6 +915,22 @@ class AgentApiClient {
     return DocumentContent.fromJson(response);
   }
 
+  /// Fetch raw image bytes from pa-serve.
+  ///
+  /// GET /api/images?path=<encoded>
+  /// Returns image binary bytes. Throws on non-200 response.
+  Future<List<int>> getImageBytes(String path) async {
+    final encoded = Uri.encodeComponent(path);
+    final uri = Uri.parse('$baseUrl/api/images?path=$encoded');
+    final response = await _client
+        .get(uri, headers: _authHeaders)
+        .timeout(const Duration(seconds: 15));
+    if (response.statusCode != 200) {
+      _throwApiException(response.statusCode, response.body);
+    }
+    return response.bodyBytes;
+  }
+
   // --- Bulletins ---
 
   /// List all bulletins.

--- a/phone/lib/widgets/doc_ref_section.dart
+++ b/phone/lib/widgets/doc_ref_section.dart
@@ -1,0 +1,350 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../models/ticket.dart';
+import '../screens/document_viewer_screen.dart';
+import '../screens/image_gallery_screen.dart';
+import '../services/agent_api_client.dart';
+import 'image_doc_ref_tile.dart';
+
+/// Grouped doc_ref display widget for ticket detail.
+///
+/// Classifies [docRefs] into Images, Documents (markdown/PDF), and Links,
+/// then renders each group under a section header.
+class DocRefSection extends StatelessWidget {
+  final List<DocRef> docRefs;
+  final AgentApiClient client;
+  final VoidCallback? onImagesChanged;
+
+  const DocRefSection({
+    super.key,
+    required this.docRefs,
+    required this.client,
+    this.onImagesChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final images = docRefs.where((r) => r.displayType == DocRefDisplayType.image).toList();
+    final markdown = docRefs.where((r) => r.displayType == DocRefDisplayType.markdown || r.displayType == DocRefDisplayType.unknown).toList();
+    final urls = docRefs.where((r) => r.displayType == DocRefDisplayType.url).toList();
+    final pdfs = docRefs.where((r) => r.displayType == DocRefDisplayType.pdf).toList();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (images.isNotEmpty) ...[
+          _SectionHeader(label: 'Images', count: images.length),
+          const SizedBox(height: 8),
+          _ImageGrid(
+            images: images,
+            client: client,
+            onTap: (index) {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => ImageGalleryScreen(
+                    images: images,
+                    initialIndex: index,
+                    client: client,
+                  ),
+                ),
+              );
+            },
+          ),
+          const SizedBox(height: 16),
+        ],
+        if (markdown.isNotEmpty) ...[
+          _SectionHeader(label: 'Documents', count: markdown.length),
+          const SizedBox(height: 4),
+          ...markdown.map((ref) => _DocRefRow(
+                docRef: ref,
+                onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => DocumentViewerScreen(
+                      path: ref.path,
+                      client: client,
+                    ),
+                  ),
+                ),
+              )),
+          const SizedBox(height: 16),
+        ],
+        if (urls.isNotEmpty) ...[
+          _SectionHeader(label: 'Links', count: urls.length),
+          const SizedBox(height: 4),
+          ...urls.map((ref) => _UrlRow(docRef: ref)),
+          const SizedBox(height: 16),
+        ],
+        if (pdfs.isNotEmpty) ...[
+          _SectionHeader(label: 'PDFs', count: pdfs.length),
+          const SizedBox(height: 4),
+          ...pdfs.map((ref) => _PdfRow(docRef: ref)),
+          const SizedBox(height: 16),
+        ],
+      ],
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  final String label;
+  final int count;
+
+  const _SectionHeader({required this.label, required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+            color: theme.colorScheme.primary,
+          ),
+        ),
+        const SizedBox(width: 6),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.primaryContainer,
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Text(
+            '$count',
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: theme.colorScheme.onPrimaryContainer,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ImageGrid extends StatelessWidget {
+  final List<DocRef> images;
+  final AgentApiClient client;
+  final void Function(int index) onTap;
+
+  const _ImageGrid({
+    required this.images,
+    required this.client,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (var i = 0; i < images.length; i++)
+          ImageDocRefTile(
+            docRef: images[i],
+            client: client,
+            onTap: () => onTap(i),
+          ),
+      ],
+    );
+  }
+}
+
+class _DocRefRow extends StatelessWidget {
+  final DocRef docRef;
+  final VoidCallback onTap;
+
+  const _DocRefRow({required this.docRef, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          children: [
+            _DocRefTypeBadge(type: docRef.type),
+            const SizedBox(width: 8),
+            if (docRef.primary) ...[
+              const Icon(Icons.star, size: 12, color: Colors.amber),
+              const SizedBox(width: 4),
+            ],
+            Expanded(
+              child: Text(
+                docRef.path,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                  decoration: TextDecoration.underline,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UrlRow extends StatelessWidget {
+  final DocRef docRef;
+
+  const _UrlRow({required this.docRef});
+
+  Future<void> _launch(BuildContext context) async {
+    final uri = Uri.parse(docRef.path);
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!launched && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Could not open URL')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: () => _launch(context),
+      borderRadius: BorderRadius.circular(6),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          children: [
+            _DocRefTypeBadge(type: docRef.type),
+            const SizedBox(width: 8),
+            if (docRef.primary) ...[
+              const Icon(Icons.star, size: 12, color: Colors.amber),
+              const SizedBox(width: 4),
+            ],
+            const Icon(Icons.language, size: 14, color: Colors.grey),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Text(
+                docRef.path,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                  decoration: TextDecoration.underline,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PdfRow extends StatelessWidget {
+  final DocRef docRef;
+
+  const _PdfRow({required this.docRef});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          _DocRefTypeBadge(type: docRef.type),
+          const SizedBox(width: 8),
+          if (docRef.primary) ...[
+            const Icon(Icons.star, size: 12, color: Colors.amber),
+            const SizedBox(width: 4),
+          ],
+          const Icon(Icons.picture_as_pdf, size: 14, color: Colors.red),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              docRef.path,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: Colors.red.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(4),
+              border: Border.all(color: Colors.red.withValues(alpha: 0.3)),
+            ),
+            child: const Text(
+              'PDF viewer coming soon',
+              style: TextStyle(fontSize: 10, color: Colors.red),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Colored badge chip showing the doc ref type abbreviation.
+class _DocRefTypeBadge extends StatelessWidget {
+  final String type;
+
+  const _DocRefTypeBadge({required this.type});
+
+  String get _label {
+    switch (type) {
+      case 'requirements':
+        return 'REQ';
+      case 'implementation':
+        return 'IMPL';
+      case 'spike':
+        return 'SPIKE';
+      case 'review-report':
+        return 'REVIEW';
+      default:
+        return 'ATTACH';
+    }
+  }
+
+  Color get _color {
+    switch (type) {
+      case 'requirements':
+        return Colors.indigo;
+      case 'implementation':
+        return Colors.green;
+      case 'spike':
+        return Colors.teal;
+      case 'review-report':
+        return Colors.purple;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _color;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: color.withValues(alpha: 0.5)),
+      ),
+      child: Text(
+        _label,
+        style: TextStyle(
+          color: color,
+          fontSize: 10,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}

--- a/phone/lib/widgets/image_doc_ref_tile.dart
+++ b/phone/lib/widgets/image_doc_ref_tile.dart
@@ -1,0 +1,158 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+
+import '../models/ticket.dart';
+import '../services/agent_api_client.dart';
+
+/// 80x80 thumbnail tile for an image [DocRef] with shimmer loading.
+class ImageDocRefTile extends StatefulWidget {
+  final DocRef docRef;
+  final AgentApiClient client;
+  final VoidCallback onTap;
+
+  const ImageDocRefTile({
+    super.key,
+    required this.docRef,
+    required this.client,
+    required this.onTap,
+  });
+
+  @override
+  State<ImageDocRefTile> createState() => _ImageDocRefTileState();
+}
+
+class _ImageDocRefTileState extends State<ImageDocRefTile> {
+  List<int>? _bytes;
+  bool _loading = true;
+  bool _error = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetch();
+  }
+
+  Future<void> _fetch() async {
+    try {
+      final bytes = await widget.client.getImageBytes(widget.docRef.path);
+      if (mounted) {
+        setState(() {
+          _bytes = bytes;
+          _loading = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          _error = true;
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: widget.onTap,
+      child: SizedBox(
+        width: 80,
+        height: 80,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: _loading
+              ? _ShimmerPlaceholder()
+              : _error
+                  ? _ErrorPlaceholder()
+                  : Image.memory(
+                      Uint8List.fromList(_bytes!),
+                      width: 80,
+                      height: 80,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) => _ErrorPlaceholder(),
+                    ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ShimmerPlaceholder extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return const _ShimmerBox();
+  }
+}
+
+class _ShimmerBox extends StatefulWidget {
+  const _ShimmerBox();
+
+  @override
+  State<_ShimmerBox> createState() => _ShimmerBoxState();
+}
+
+class _ShimmerBoxState extends State<_ShimmerBox>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1200),
+      vsync: this,
+    )..repeat();
+    _animation = Tween<double>(begin: -1.0, end: 2.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _animation,
+      builder: (context, child) {
+        return Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.centerLeft,
+              end: Alignment.centerRight,
+              colors: const [
+                Color(0xFFEEEEEE),
+                Color(0xFFF5F5F5),
+                Color(0xFFEEEEEE),
+              ],
+              stops: [
+                (_animation.value - 1).clamp(0.0, 1.0),
+                _animation.value.clamp(0.0, 1.0),
+                (_animation.value + 1).clamp(0.0, 1.0),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ErrorPlaceholder extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.grey[200],
+      child: const Icon(
+        Icons.broken_image,
+        color: Colors.grey,
+        size: 32,
+      ),
+    );
+  }
+}

--- a/phone/lib/widgets/ticket_card.dart
+++ b/phone/lib/widgets/ticket_card.dart
@@ -111,11 +111,7 @@ class _TicketCardBody extends StatelessWidget {
                   if (ticket.estimate != null)
                     _EstimateBadge(estimate: ticket.estimate!),
                   if (ticket.docRefs.isNotEmpty)
-                    Icon(
-                      Icons.description_outlined,
-                      size: 14,
-                      color: theme.colorScheme.primary,
-                    ),
+                    _DocRefIndicator(docRefs: ticket.docRefs),
                 ],
               ),
               if (ticket.assignee != null) ...[
@@ -404,6 +400,51 @@ class _BadgeChip extends StatelessWidget {
           letterSpacing: 0.5,
         ),
       ),
+    );
+  }
+}
+
+/// Shows a camera/image count badge when a ticket has image doc_refs,
+/// otherwise shows a generic document icon.
+class _DocRefIndicator extends StatelessWidget {
+  final List<DocRef> docRefs;
+
+  const _DocRefIndicator({required this.docRefs});
+
+  @override
+  Widget build(BuildContext context) {
+    final imageCount = docRefs.where(
+      (r) => r.displayType == DocRefDisplayType.image,
+    ).length;
+    if (imageCount > 0) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+        decoration: BoxDecoration(
+          color: Colors.blue.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: Colors.blue.withValues(alpha: 0.4)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.photo_camera, size: 11, color: Colors.blue),
+            const SizedBox(width: 2),
+            Text(
+              '$imageCount',
+              style: const TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
+                color: Colors.blue,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+    return const Icon(
+      Icons.description_outlined,
+      size: 14,
+      color: Colors.blue,
     );
   }
 }

--- a/phone/pubspec.yaml
+++ b/phone/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   flutter_markdown: ^0.7.0
   flutter_pdfview: ^1.4.4
   image_picker: ^1.0.7
+  url_launcher: ^6.2.0
+  photo_view: ^0.15.0
 
   # Local Database (Drift - SQLite)
   drift: ^2.22.1


### PR DESCRIPTION
## Summary
- Rich doc_ref display in ticket detail: grouped Images/Documents/Links sections
- 80x80 image thumbnails with shimmer loading from pa-serve `/api/images`
- Full-screen PhotoViewGallery with swipe navigation and pinch-to-zoom
- URL doc_refs open in Android browser via url_launcher
- PDF doc_refs show placeholder badge ("PDF viewer coming soon")
- TicketCard enhanced with image count badge
- Adds `url_launcher` and `photo_view` packages

## Acceptance Criteria
- [ ] AC-1: Doc refs grouped into Images/Documents/Links sections
- [ ] AC-2: Image thumbnails (80x80) fetched from pa-serve
- [ ] AC-3: Full-screen gallery with swipe navigation
- [ ] AC-4: URL doc_refs open Android browser
- [ ] AC-5: Markdown doc_refs retain current behavior (DocumentViewerScreen)
- [ ] AC-6: PDF doc_refs show placeholder
- [ ] AC-7: New packages added to pubspec.yaml
- [ ] AC-8: TicketCard image count badge

## Files Changed
- `phone/pubspec.yaml` — url_launcher + photo_view deps
- `phone/android/app/src/main/AndroidManifest.xml` — URL queries
- `phone/lib/models/ticket.dart` — DocRefDisplayType enum + classifier
- `phone/lib/services/agent_api_client.dart` — getImageBytes() method
- `phone/lib/widgets/doc_ref_section.dart` — NEW grouped widget
- `phone/lib/widgets/image_doc_ref_tile.dart` — NEW thumbnail tile
- `phone/lib/screens/image_gallery_screen.dart` — NEW gallery screen
- `phone/lib/widgets/ticket_card.dart` — image count badge enhancement
- `phone/lib/screens/ticket_detail_screen.dart` — use DocRefSection

## UAT
UAT test plan: `agent-teams/requirements/artifacts/2026-04-13-doc-ref-rich-display-uat.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)