### PR TITLE
fix(mcp): null-coalesce taskId and startedAt in TimerService.stop() (AVO-101)

### DIFF
--- a/mcp/lib/services/timer_service.dart
+++ b/mcp/lib/services/timer_service.dart
@@ -134,9 +134,9 @@ class TimerService {
     if (timer == null) throw NoTimerRunningException();
 
     // Capture values before stop() clears them
-    final taskId = timer.taskId!;
+    final taskId = timer.taskId ?? '';
     final taskTitle = timer.taskTitle;
-    final startedAt = timer.startedAt!;
+    final startedAt = timer.startedAt ?? DateTime.now();
     final note = timer.note;
     final elapsed = timer.elapsed;
     final category = timer.category;

--- a/mcp/test/services/timer_service_test.dart
+++ b/mcp/test/services/timer_service_test.dart
@@ -92,6 +92,40 @@ void main() {
         throwsA(isA<NoTimerRunningException>()),
       );
     });
+
+    test('handles orphan timer with null taskId (AVO-101)', () async {
+      // Simulate an orphan timer loaded from DB with null taskId
+      // (orphaned timer from schema migration or DB corruption)
+      final timer = TimerDocument(
+        id: activeTimerId,
+        clock: clock,
+      );
+      timer.taskId = null;
+      timer.taskTitle = '';
+      timer.startedAtMs = DateTime.now().millisecondsSinceEpoch;
+      timer.isRunning = true;
+      timer.pausedAtMs = null;
+      timer.accumulatedMs = 0;
+      timer.category = 'Working';
+      await db
+          .into(db.timerEntries)
+          .insertOnConflictUpdate(timer.toDriftCompanion());
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Should not throw — stop() handles null taskId gracefully
+      final result = await service.stop();
+
+      expect(result.taskId, equals(''));
+      expect(result.worklogId, isNotEmpty);
+
+      // Verify worklog was created with empty taskId
+      final worklogs = await db.select(db.worklogEntries).get();
+      expect(worklogs, hasLength(1));
+      final wl = WorklogDocument.fromDrift(worklog: worklogs.first, clock: clock);
+      expect(wl.taskId, equals(''));
+      expect(wl.category, equals('Working'));
+    });
   });
 
   group('_resolveOrCreateTask skips deleted tasks', () {


### PR DESCRIPTION
## Summary
- Fix null-safety in `TimerService.stop()` — replace hard null assertions with null-coalescing defaults
- `timer.taskId!` → `timer.taskId ?? ''`
- `timer.startedAt!` → `timer.startedAt ?? DateTime.now()`
- Add test case for orphan timer with null taskId

## AC Checklist
- [ ] AC-1: `avo stop` no longer crashes on null taskId
- [ ] AC-2: Normal `avo start <task>` + `avo stop` flow unchanged
- [ ] AC-3: Orphan timer (category-only) start + stop unchanged
- [ ] AC-4: All tests pass (`dart test` in mcp/ and avodah_core/)

## Testing
- New test: `handles orphan timer with null taskId (AVO-101)` in `timer_service_test.dart`
- All existing 700+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)