### PR TITLE
AVO-103: Quick Capture — Share-to-Avodah Workflow

### DIFF
--- a/phone/android/app/src/main/AndroidManifest.xml
+++ b/phone/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,17 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Share target: receive text/URL shared from any Android app -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/plain"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/*"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/phone/android/build.gradle.kts
+++ b/phone/android/build.gradle.kts
@@ -5,6 +5,20 @@ allprojects {
     }
 }
 
+// Fix JVM target inconsistency between Java and Kotlin for all subprojects
+// (receive_sharing_intent has compileDebugKotlin targeting 17 but Java targeting 1.8)
+subprojects {
+    tasks.withType<JavaCompile>().configureEach {
+        sourceCompatibility = JavaVersion.VERSION_17.toString()
+        targetCompatibility = JavaVersion.VERSION_17.toString()
+    }
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
+    }
+}
+
 val newBuildDir: Directory =
     rootProject.layout.buildDirectory
         .dir("../../build")

--- a/phone/android/gradle.properties
+++ b/phone/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.ndkVersion=27.0.12077973
+
+# Suppress JVM target consistency check between Kotlin and Java tasks
+# (receive_sharing_intent plugin has Kotlin targeting 17 but Java targeting 1.8)
+kotlin.jvm.target.validation.mode=IGNORE

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -4,11 +4,13 @@ import 'package:avodah_core/avodah_core.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 
 import 'screens/dashboard_screen.dart';
 import 'screens/deployment_screen.dart';
 import 'screens/kanban_board_screen.dart';
 import 'screens/pairing_screen.dart';
+import 'screens/quick_capture_screen.dart';
 import 'screens/review_queue_screen.dart';
 import 'screens/team_browser_screen.dart';
 import 'screens/timers_screen.dart';
@@ -57,6 +59,11 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
   final _navigatorKey = GlobalKey<NavigatorState>();
   final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
   final List<Map<String, dynamic>> _pendingTimerDeltas = [];
+
+  // Share intent handling
+  StreamSubscription<List<SharedMediaFile>>? _shareIntentSubscription;
+  SharedMediaFile? _pendingShareIntent;
+  bool _shareIntentHandled = false;
 
   @override
   void initState() {
@@ -168,11 +175,73 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     // Initial pull + dashboard render
     await _syncAndRefresh();
 
+    // Listen for share intents while app is running
+    _shareIntentSubscription = ReceiveSharingIntent.instance
+        .getMediaStream()
+        .listen(_handleShareIntent);
+
+    // Handle share intent that started the app (if any)
+    if (!_shareIntentHandled) {
+      _checkInitialShareIntent();
+    }
+
     // Periodic sync + refresh every 5 seconds while app is running
     _syncTimer = Timer.periodic(
       const Duration(seconds: 5),
       (_) => _syncAndRefresh(),
     );
+  }
+
+  /// Check for share intent that started the app (cold start).
+  Future<void> _checkInitialShareIntent() async {
+    try {
+      final initialMedia =
+          await ReceiveSharingIntent.instance.getInitialMedia();
+      if (initialMedia.isNotEmpty && !_shareIntentHandled) {
+        _handleShareIntent(initialMedia);
+      }
+    } catch (e) {
+      debugPrint('[ShareIntent] Failed to get initial media: $e');
+    }
+  }
+
+  /// Handle incoming share intent — show QuickCaptureScreen.
+  void _handleShareIntent(List<SharedMediaFile> mediaFiles) {
+    if (_shareIntentHandled || mediaFiles.isEmpty) return;
+
+    final file = mediaFiles.first;
+    // For text/url types, content is in path; for others (image/video), path is file path
+    final isTextOrUrl =
+        file.type == SharedMediaType.text || file.type == SharedMediaType.url;
+    final sharedText = isTextOrUrl ? file.path : file.path;
+    final isUrl = file.type == SharedMediaType.url;
+
+    if (sharedText.isEmpty) return;
+
+    _shareIntentHandled = true;
+
+    // Clear the intent so it doesn't reprocess on next app start
+    ReceiveSharingIntent.instance.reset();
+
+    // Navigate to QuickCaptureScreen
+    final nav = _navigatorKey.currentState;
+    final apiClient = _apiClient;
+    if (nav != null && apiClient != null) {
+      nav.push(
+        MaterialPageRoute(
+          builder: (_) => QuickCaptureScreen(
+            sharedText: sharedText,
+            sharedUrl: isUrl ? sharedText : null,
+            apiClient: apiClient,
+          ),
+        ),
+      );
+    } else {
+      // Store for later if navigation not ready yet
+      setState(() {
+        _pendingShareIntent = file;
+      });
+    }
   }
 
   /// Pull CRDT deltas from desktop, then refresh the dashboard from local DB.
@@ -408,6 +477,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _shareIntentSubscription?.cancel();
     _syncTimer?.cancel();
     _focusProvider?.dispose();
     _boardProvider?.dispose();

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -66,7 +66,6 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
 
   // Share intent handling
   StreamSubscription<List<SharedMediaFile>>? _shareIntentSubscription;
-  SharedMediaFile? _pendingShareIntent;
   bool _shareIntentHandled = false;
 
   @override
@@ -243,7 +242,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     final nav = _navigatorKey.currentState;
     final captureSync = _captureSyncService;
     if (nav != null && captureSync != null) {
-      nav.push(
+      nav.push<bool>(
         MaterialPageRoute(
           builder: (_) => QuickCaptureScreen(
             sharedText: sharedText,
@@ -251,12 +250,13 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
             captureSyncService: captureSync,
           ),
         ),
-      );
-    } else {
-      // Store for later if navigation not ready yet
-      setState(() {
-        _pendingShareIntent = file;
+      ).then((_) {
+        // Reset so subsequent shares in the same session are handled
+        _shareIntentHandled = false;
       });
+    } else {
+      // Navigation not ready — defer until init completes
+      debugPrint('[ShareIntent] Navigation not ready, deferring share intent');
     }
   }
 

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -241,13 +241,15 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     // Navigate to QuickCaptureScreen
     final nav = _navigatorKey.currentState;
     final captureSync = _captureSyncService;
-    if (nav != null && captureSync != null) {
+    final apiClient = _apiClient;
+    if (nav != null && captureSync != null && apiClient != null) {
       nav.push<bool>(
         MaterialPageRoute(
           builder: (_) => QuickCaptureScreen(
             sharedText: sharedText,
             sharedUrl: isUrl ? sharedText : null,
             captureSyncService: captureSync,
+            apiClient: apiClient,
           ),
         ),
       ).then((_) {

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -337,6 +337,23 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
       await sync.syncPendingCaptures();
     } catch (e) {
       debugPrint('[CaptureSync] Sync failed: $e');
+      // Surface capture sync failure to user via snackbar
+      final messenger = _scaffoldMessengerKey.currentState;
+      if (messenger != null) {
+        SchedulerBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          messenger.showSnackBar(
+            SnackBar(
+              content: Text('Capture sync failed: $e'),
+              duration: const Duration(seconds: 4),
+              action: SnackBarAction(
+                label: 'Retry',
+                onPressed: () => _syncCaptures(),
+              ),
+            ),
+          );
+        });
+      }
     }
   }
 
@@ -604,6 +621,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
                   onPushDeltas: _pushDeltas,
                   crdtSyncService: _crdtSyncService,
                   displaySettings: _displaySettings,
+                  captureSyncService: _captureSyncService,
                 ),
         );
       },
@@ -629,6 +647,7 @@ class _HomeShell extends StatefulWidget {
   final Future<void> Function(List<Map<String, dynamic>>)? onPushDeltas;
   final CrdtSyncService? crdtSyncService;
   final DisplaySettingsService? displaySettings;
+  final CaptureSyncService? captureSyncService;
 
   const _HomeShell({
     required this.dashboardProvider,
@@ -642,6 +661,7 @@ class _HomeShell extends StatefulWidget {
     this.onPushDeltas,
     this.crdtSyncService,
     this.displaySettings,
+    this.captureSyncService,
   });
 
   @override
@@ -650,23 +670,45 @@ class _HomeShell extends StatefulWidget {
 
 class _HomeShellState extends State<_HomeShell> {
   int _currentIndex = 0;
+  int _unsyncedCount = 0;
+  Timer? _badgeRefreshTimer;
 
   @override
   void initState() {
     super.initState();
     widget.reviewProvider.addListener(_onUpdate);
     widget.boardProvider.addListener(_onUpdate);
+    _refreshUnsyncedCount();
+    // Periodically refresh badge count every 10 seconds
+    _badgeRefreshTimer = Timer.periodic(
+      const Duration(seconds: 10),
+      (_) => _refreshUnsyncedCount(),
+    );
   }
 
   @override
   void dispose() {
     widget.reviewProvider.removeListener(_onUpdate);
     widget.boardProvider.removeListener(_onUpdate);
+    _badgeRefreshTimer?.cancel();
     super.dispose();
   }
 
   void _onUpdate() {
     if (mounted) setState(() {});
+  }
+
+  Future<void> _refreshUnsyncedCount() async {
+    final sync = widget.captureSyncService;
+    if (sync == null) return;
+    try {
+      final count = await sync.unsyncedCount();
+      if (mounted) {
+        setState(() => _unsyncedCount = count);
+      }
+    } catch (e) {
+      debugPrint('[HomeShell] Failed to get unsynced count: $e');
+    }
   }
 
   @override
@@ -821,9 +863,19 @@ class _HomeShellState extends State<_HomeShell> {
                 : const Icon(Icons.view_kanban),
             label: 'Kanban',
           ),
-          const NavigationDestination(
-            icon: Icon(Icons.dashboard_outlined),
-            selectedIcon: Icon(Icons.dashboard),
+          NavigationDestination(
+            icon: _unsyncedCount > 0
+                ? Badge(
+                    label: Text('$_unsyncedCount'),
+                    child: const Icon(Icons.dashboard_outlined),
+                  )
+                : const Icon(Icons.dashboard_outlined),
+            selectedIcon: _unsyncedCount > 0
+                ? Badge(
+                    label: Text('$_unsyncedCount'),
+                    child: const Icon(Icons.dashboard),
+                  )
+                : const Icon(Icons.dashboard),
             label: 'Dashboard',
           ),
           NavigationDestination(

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -16,6 +16,7 @@ import 'screens/team_browser_screen.dart';
 import 'screens/timers_screen.dart';
 import 'services/agent_api_client.dart';
 import 'services/board_provider.dart';
+import 'services/capture_sync_service.dart';
 import 'services/crdt_sync_service.dart';
 import 'services/crypto_sync_service.dart';
 import 'services/deployment_provider.dart';
@@ -25,6 +26,7 @@ import 'services/local_dashboard_provider.dart';
 import 'services/local_write_service.dart';
 import 'services/review_provider.dart';
 import 'services/team_browser_provider.dart';
+import 'storage/phone_database.dart';
 import 'settings/settings_screen.dart';
 import 'storage/database.dart';
 import 'widgets/connection_indicator.dart';
@@ -43,6 +45,7 @@ class AvodahViewerApp extends StatefulWidget {
 class _AvodahViewerAppState extends State<AvodahViewerApp>
     with WidgetsBindingObserver {
   AppDatabase? _db;
+  PhoneDatabase? _phoneDb;
   LocalDashboardProvider? _dashboardProvider;
   LocalWriteService? _writeService;
   CrdtSyncService? _crdtSyncService;
@@ -54,6 +57,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
   BoardProvider? _boardProvider;
   FocusProvider? _focusProvider;
   DisplaySettingsService? _displaySettings;
+  CaptureSyncService? _captureSyncService;
   Timer? _syncTimer;
   bool _pairingInProgress = false;
   final _navigatorKey = GlobalKey<NavigatorState>();
@@ -91,6 +95,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
   Future<void> _initAppInner() async {
     // Open local database
     final db = await openPhoneDatabase();
+    final phoneDb = await openPhoneLocalDatabase();
 
     // Node ID + HLC clock
     final nodeId = await CrdtSyncService.getOrCreateNodeId();
@@ -136,6 +141,10 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     final apiClient = AgentApiClient(baseUrl: httpBaseUrl)
       ..pairingToken = cryptoSyncService?.pairingToken
       ..nodeId = nodeId;
+    final captureSyncService = CaptureSyncService(
+      db: phoneDb,
+      apiClient: apiClient,
+    );
     final reviewProvider = ReviewProvider(apiClient);
     reviewProvider.startAutoRefresh();
 
@@ -159,11 +168,13 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
 
     setState(() {
       _db = db;
+      _phoneDb = phoneDb;
       _dashboardProvider = dashboardProvider;
       _writeService = writeService;
       _crdtSyncService = crdtSyncService;
       _cryptoSyncService = cryptoSyncService;
       _apiClient = apiClient;
+      _captureSyncService = captureSyncService;
       _reviewProvider = reviewProvider;
       _deploymentProvider = deploymentProvider;
       _teamBrowserProvider = teamBrowserProvider;
@@ -174,6 +185,8 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
 
     // Initial pull + dashboard render
     await _syncAndRefresh();
+    // Sync pending captures to PA (offline queue — P2)
+    await _syncCaptures();
 
     // Listen for share intents while app is running
     _shareIntentSubscription = ReceiveSharingIntent.instance
@@ -188,7 +201,10 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     // Periodic sync + refresh every 5 seconds while app is running
     _syncTimer = Timer.periodic(
       const Duration(seconds: 5),
-      (_) => _syncAndRefresh(),
+      (_) {
+        _syncAndRefresh();
+        _syncCaptures();
+      },
     );
   }
 
@@ -225,14 +241,14 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
 
     // Navigate to QuickCaptureScreen
     final nav = _navigatorKey.currentState;
-    final apiClient = _apiClient;
-    if (nav != null && apiClient != null) {
+    final captureSync = _captureSyncService;
+    if (nav != null && captureSync != null) {
       nav.push(
         MaterialPageRoute(
           builder: (_) => QuickCaptureScreen(
             sharedText: sharedText,
             sharedUrl: isUrl ? sharedText : null,
-            apiClient: apiClient,
+            captureSyncService: captureSync,
           ),
         ),
       );
@@ -302,6 +318,25 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     // Override the indicator to reflect actual sync status, not just local DB read
     if (!syncOk) {
       dashboard.connectionState.value = SyncConnectionState.disconnected;
+    }
+  }
+
+  /// Syncs pending captures from local Drift storage to PA via API.
+  Future<void> _syncCaptures() async {
+    final sync = _captureSyncService;
+    if (sync == null) return;
+
+    // Only sync if connected (avoids hammering API when offline)
+    final dashboard = _dashboardProvider;
+    if (dashboard != null &&
+        dashboard.connectionState.value == SyncConnectionState.disconnected) {
+      return;
+    }
+
+    try {
+      await sync.syncPendingCaptures();
+    } catch (e) {
+      debugPrint('[CaptureSync] Sync failed: $e');
     }
   }
 
@@ -490,6 +525,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     _dashboardProvider?.dispose();
     _displaySettings?.dispose();
     _db?.close();
+    _phoneDb?.close();
     super.dispose();
   }
 

--- a/phone/lib/models/pending_capture.dart
+++ b/phone/lib/models/pending_capture.dart
@@ -1,0 +1,52 @@
+import 'package:drift/drift.dart' hide Column;
+
+import '../storage/phone_database.dart';
+
+/// Model for a pending capture from Android share intent.
+///
+/// Mirror of [PendingCaptures] drift table for use in UI.
+class PendingCaptureModel {
+  final int? id;
+  final String title;
+  final String? url;
+  final String? notes;
+  final String category;
+  final String? sharedText;
+  final DateTime createdAt;
+  final bool synced;
+
+  const PendingCaptureModel({
+    this.id,
+    required this.title,
+    this.url,
+    this.notes,
+    this.category = 'learning',
+    this.sharedText,
+    required this.createdAt,
+    this.synced = false,
+  });
+
+  /// Create from Drift row.
+  factory PendingCaptureModel.fromDrift(PendingCapture row) =>
+      PendingCaptureModel(
+        id: row.id,
+        title: row.title,
+        url: row.url,
+        notes: row.notes,
+        category: row.category,
+        sharedText: row.sharedText,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(row.createdAt),
+        synced: row.synced,
+      );
+
+  /// Convert to Drift companion for insert.
+  PendingCapturesCompanion toCompanion() => PendingCapturesCompanion.insert(
+        title: title,
+        url: Value(url),
+        notes: Value(notes),
+        category: Value(category),
+        sharedText: Value(sharedText),
+        createdAt: createdAt.millisecondsSinceEpoch,
+        synced: Value(synced),
+      );
+}

--- a/phone/lib/screens/quick_capture_screen.dart
+++ b/phone/lib/screens/quick_capture_screen.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+
+import '../models/create_idea_payload.dart';
+import '../services/agent_api_client.dart';
+
+/// Minimal capture form shown when Android share intent is received.
+///
+/// Pre-filled with shared text/URL. Fields: title, URL, notes, category.
+/// On submit: calls createIdea() and stores locally in pending_captures.
+/// Navigation: pops with true on success.
+class QuickCaptureScreen extends StatefulWidget {
+  final String sharedText;
+  final String? sharedUrl;
+  final AgentApiClient apiClient;
+
+  const QuickCaptureScreen({
+    super.key,
+    required this.sharedText,
+    this.sharedUrl,
+    required this.apiClient,
+  });
+
+  @override
+  State<QuickCaptureScreen> createState() => _QuickCaptureScreenState();
+}
+
+class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
+  static const _categories = ['learning', 'personal', 'work', 'video', 'article'];
+
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _titleController;
+  late final TextEditingController _urlController;
+  late final TextEditingController _notesController;
+
+  String _category = 'learning';
+  bool _submitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Pre-fill URL if shared text is a URL, otherwise use as title
+    final isUrl = _looksLikeUrl(widget.sharedText);
+    _titleController = TextEditingController(
+      text: isUrl ? '' : widget.sharedText,
+    );
+    _urlController = TextEditingController(
+      text: widget.sharedUrl ?? (isUrl ? widget.sharedText : ''),
+    );
+    _notesController = TextEditingController(
+      text: isUrl ? widget.sharedText : '',
+    );
+  }
+
+  bool _looksLikeUrl(String text) {
+    final trimmed = text.trim();
+    return trimmed.startsWith('http://') || trimmed.startsWith('https://');
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _urlController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    final title = _titleController.text.trim();
+    final url = _urlController.text.trim();
+    final notes = _notesController.text.trim();
+
+    setState(() => _submitting = true);
+
+    try {
+      final payload = CreateIdeaPayload(
+        title: title.isEmpty ? (url.isEmpty ? 'Quick capture' : url) : title,
+        category: _category,
+        notes: notes.isEmpty ? null : notes,
+        tags: url.isNotEmpty ? ['shared-link'] : [],
+      );
+
+      // Include URL in notes if separate URL field has content
+      await widget.apiClient.createIdea(payload);
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Capture saved')),
+        );
+        Navigator.pop(context, true);
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _submitting = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to save: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Quick Capture'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+        ],
+      ),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            // Title
+            TextFormField(
+              controller: _titleController,
+              decoration: const InputDecoration(
+                labelText: 'Title',
+                hintText: 'Auto-filled from shared content',
+                border: OutlineInputBorder(),
+              ),
+              autofocus: _titleController.text.isEmpty,
+              textInputAction: TextInputAction.next,
+            ),
+            const SizedBox(height: 16),
+
+            // URL
+            TextFormField(
+              controller: _urlController,
+              decoration: const InputDecoration(
+                labelText: 'URL',
+                hintText: 'https://...',
+                border: OutlineInputBorder(),
+              ),
+              keyboardType: TextInputType.url,
+              textInputAction: TextInputAction.next,
+            ),
+            const SizedBox(height: 16),
+
+            // Category
+            DropdownButtonFormField<String>(
+              value: _category,
+              decoration: const InputDecoration(
+                labelText: 'Category',
+                border: OutlineInputBorder(),
+              ),
+              items: _categories
+                  .map((c) => DropdownMenuItem(value: c, child: Text(c)))
+                  .toList(),
+              onChanged: (v) => setState(() => _category = v!),
+            ),
+            const SizedBox(height: 16),
+
+            // Notes
+            TextField(
+              controller: _notesController,
+              decoration: const InputDecoration(
+                labelText: 'Notes',
+                hintText: 'Optional notes...',
+                border: OutlineInputBorder(),
+                alignLabelWithHint: true,
+              ),
+              maxLines: 4,
+              textInputAction: TextInputAction.done,
+            ),
+            const SizedBox(height: 24),
+
+            // Submit
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _submitting ? null : _submit,
+                child: _submitting
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Save Capture'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/phone/lib/screens/quick_capture_screen.dart
+++ b/phone/lib/screens/quick_capture_screen.dart
@@ -1,23 +1,22 @@
 import 'package:flutter/material.dart';
 
-import '../models/create_idea_payload.dart';
-import '../services/agent_api_client.dart';
+import '../services/capture_sync_service.dart';
 
 /// Minimal capture form shown when Android share intent is received.
 ///
 /// Pre-filled with shared text/URL. Fields: title, URL, notes, category.
-/// On submit: calls createIdea() and stores locally in pending_captures.
+/// On submit: saves to local Drift table (offline-first), then syncs to PA.
 /// Navigation: pops with true on success.
 class QuickCaptureScreen extends StatefulWidget {
   final String sharedText;
   final String? sharedUrl;
-  final AgentApiClient apiClient;
+  final CaptureSyncService captureSyncService;
 
   const QuickCaptureScreen({
     super.key,
     required this.sharedText,
     this.sharedUrl,
-    required this.apiClient,
+    required this.captureSyncService,
   });
 
   @override
@@ -74,15 +73,19 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
     setState(() => _submitting = true);
 
     try {
-      final payload = CreateIdeaPayload(
+      // Save to local Drift table (offline-first)
+      await widget.captureSyncService.saveCapture(
         title: title.isEmpty ? (url.isEmpty ? 'Quick capture' : url) : title,
+        url: url.isNotEmpty ? url : null,
+        notes: notes.isNotEmpty ? notes : null,
         category: _category,
-        notes: notes.isEmpty ? null : notes,
-        tags: url.isNotEmpty ? ['shared-link'] : [],
+        sharedText: widget.sharedText,
       );
 
-      // Include URL in notes if separate URL field has content
-      await widget.apiClient.createIdea(payload);
+      // Trigger immediate sync to PA (best-effort — doesn't block UI)
+      widget.captureSyncService.syncPendingCaptures().catchError((e) {
+        debugPrint('[QuickCapture] Sync error: $e');
+      });
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/phone/lib/screens/quick_capture_screen.dart
+++ b/phone/lib/screens/quick_capture_screen.dart
@@ -29,7 +29,7 @@ class QuickCaptureScreen extends StatefulWidget {
 }
 
 class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
-  static const _categories = ['learning', 'personal', 'work', 'video', 'article'];
+  static const _categories = ['learning', 'personal', 'work', 'video', 'article', 'code'];
 
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _titleController;
@@ -214,7 +214,8 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
 
             // Category
             DropdownButtonFormField<String>(
-              value: _category,
+              key: ValueKey(_category),
+              initialValue: _category,
               decoration: const InputDecoration(
                 labelText: 'Category',
                 border: OutlineInputBorder(),

--- a/phone/lib/screens/quick_capture_screen.dart
+++ b/phone/lib/screens/quick_capture_screen.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../models/ticket.dart';
+import '../services/agent_api_client.dart';
 import '../services/capture_sync_service.dart';
 import '../services/title_extraction_service.dart';
 import '../utils/category_detection.dart';
@@ -16,12 +18,14 @@ class QuickCaptureScreen extends StatefulWidget {
   final String sharedText;
   final String? sharedUrl;
   final CaptureSyncService captureSyncService;
+  final AgentApiClient apiClient;
 
   const QuickCaptureScreen({
     super.key,
     required this.sharedText,
     this.sharedUrl,
     required this.captureSyncService,
+    required this.apiClient,
   });
 
   @override
@@ -37,6 +41,9 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
   late final TextEditingController _notesController;
 
   String _category = 'learning';
+  String _project = 'learning-management';
+  List<TicketProject> _projects = [];
+  bool _loadingProjects = false;
   bool _submitting = false;
   bool _fetchingTitle = false;
   Timer? _debounceTimer;
@@ -47,6 +54,7 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
   void initState() {
     super.initState();
     _titleService = TitleExtractionService();
+    _loadProjects();
 
     // Pre-fill URL if shared text is a URL, otherwise use as title.
     // extractUrl handles both scheme URLs and scheme-less (e.g., news.google.com/...)
@@ -70,6 +78,27 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
       final detected = detectCategoryFromUrl(prefillUrl);
       if (detected != 'learning') {
         _category = detected;
+      }
+    }
+  }
+
+  Future<void> _loadProjects() async {
+    setState(() => _loadingProjects = true);
+    try {
+      final projects = await widget.apiClient.getProjects();
+      if (mounted) {
+        setState(() {
+          _projects = projects;
+          _loadingProjects = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          // Keep default LM only on error
+          _projects = [];
+          _loadingProjects = false;
+        });
       }
     }
   }
@@ -136,6 +165,7 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
         notes: notes.isNotEmpty ? notes : null,
         category: _category,
         sharedText: widget.sharedText,
+        project: _project,
       );
 
       // Trigger immediate sync to PA (best-effort — doesn't block UI)
@@ -197,6 +227,24 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
               autofocus: _titleController.text.isEmpty,
               textInputAction: TextInputAction.next,
             ),
+            const SizedBox(height: 16),
+
+            // Project
+            if (_loadingProjects)
+              const LinearProgressIndicator()
+            else
+              DropdownButtonFormField<String>(
+                key: ValueKey(_project),
+                value: _project,
+                decoration: const InputDecoration(
+                  labelText: 'Project',
+                  border: OutlineInputBorder(),
+                ),
+                items: _projects.isEmpty
+                    ? [const DropdownMenuItem(value: 'learning-management', child: Text('learning-management'))]
+                    : _projects.map((p) => DropdownMenuItem(value: p.key, child: Text(p.key))).toList(),
+                onChanged: (v) => setState(() => _project = v ?? 'learning-management'),
+              ),
             const SizedBox(height: 16),
 
             // URL

--- a/phone/lib/screens/quick_capture_screen.dart
+++ b/phone/lib/screens/quick_capture_screen.dart
@@ -48,24 +48,25 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
     super.initState();
     _titleService = TitleExtractionService();
 
-    // Pre-fill URL if shared text is a URL, otherwise use as title
-    final sharedUrl = extractUrl(widget.sharedText);
-    final isUrl = sharedUrl != null;
+    // Pre-fill URL if shared text is a URL, otherwise use as title.
+    // extractUrl handles both scheme URLs and scheme-less (e.g., news.google.com/...)
+    final extractedUrl = extractUrl(widget.sharedText);
+    final hasUrl = extractedUrl != null;
     _titleController = TextEditingController(
-      text: isUrl ? '' : widget.sharedText,
+      text: hasUrl ? '' : widget.sharedText,
     );
     _urlController = TextEditingController(
-      text: widget.sharedUrl ?? (isUrl ? widget.sharedText : ''),
+      text: widget.sharedUrl ?? extractedUrl ?? '',
     );
     _notesController = TextEditingController(
-      text: isUrl ? widget.sharedText : '',
+      text: hasUrl ? widget.sharedText : '',
     );
 
     // Trigger title extraction if URL is pre-filled
-    if (isUrl) {
-      _fetchTitleForUrl(widget.sharedUrl ?? widget.sharedText);
+    if (hasUrl) {
+      final prefillUrl = widget.sharedUrl ?? extractedUrl;
+      _fetchTitleForUrl(prefillUrl);
       // Auto-detect category from domain
-      final prefillUrl = widget.sharedUrl ?? widget.sharedText;
       final detected = detectCategoryFromUrl(prefillUrl);
       if (detected != 'learning') {
         _category = detected;

--- a/phone/lib/screens/quick_capture_screen.dart
+++ b/phone/lib/screens/quick_capture_screen.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../services/capture_sync_service.dart';
+import '../services/title_extraction_service.dart';
+import '../utils/url_utils.dart';
 
 /// Minimal capture form shown when Android share intent is received.
 ///
@@ -33,12 +37,19 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
 
   String _category = 'learning';
   bool _submitting = false;
+  bool _fetchingTitle = false;
+  Timer? _debounceTimer;
+
+  late final TitleExtractionService _titleService;
 
   @override
   void initState() {
     super.initState();
+    _titleService = TitleExtractionService();
+
     // Pre-fill URL if shared text is a URL, otherwise use as title
-    final isUrl = _looksLikeUrl(widget.sharedText);
+    final sharedUrl = extractUrl(widget.sharedText);
+    final isUrl = sharedUrl != null;
     _titleController = TextEditingController(
       text: isUrl ? '' : widget.sharedText,
     );
@@ -48,15 +59,45 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
     _notesController = TextEditingController(
       text: isUrl ? widget.sharedText : '',
     );
+
+    // Trigger title extraction if URL is pre-filled
+    if (isUrl) {
+      _fetchTitleForUrl(widget.sharedUrl ?? widget.sharedText);
+    }
   }
 
-  bool _looksLikeUrl(String text) {
-    final trimmed = text.trim();
-    return trimmed.startsWith('http://') || trimmed.startsWith('https://');
+  Future<void> _fetchTitleForUrl(String url) async {
+    if (url.isEmpty) return;
+
+    setState(() => _fetchingTitle = true);
+
+    final title = await _titleService.fetchTitle(url);
+
+    if (mounted && title != null) {
+      // Only pre-fill if title field is still empty (user hasn't edited it)
+      if (_titleController.text.isEmpty) {
+        _titleController.text = title;
+      }
+    }
+
+    if (mounted) {
+      setState(() => _fetchingTitle = false);
+    }
+  }
+
+  void _onUrlChanged(String value) {
+    // Debounce URL changes to avoid excessive fetches
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(const Duration(milliseconds: 500), () {
+      if (isUrl(value)) {
+        _fetchTitleForUrl(value);
+      }
+    });
   }
 
   @override
   void dispose() {
+    _debounceTimer?.cancel();
     _titleController.dispose();
     _urlController.dispose();
     _notesController.dispose();
@@ -123,10 +164,20 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
             // Title
             TextFormField(
               controller: _titleController,
-              decoration: const InputDecoration(
+              decoration: InputDecoration(
                 labelText: 'Title',
                 hintText: 'Auto-filled from shared content',
-                border: OutlineInputBorder(),
+                border: const OutlineInputBorder(),
+                suffixIcon: _fetchingTitle
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: Padding(
+                          padding: EdgeInsets.all(12),
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                      )
+                    : null,
               ),
               autofocus: _titleController.text.isEmpty,
               textInputAction: TextInputAction.next,
@@ -143,6 +194,7 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
               ),
               keyboardType: TextInputType.url,
               textInputAction: TextInputAction.next,
+              onChanged: _onUrlChanged,
             ),
             const SizedBox(height: 16),
 

--- a/phone/lib/screens/quick_capture_screen.dart
+++ b/phone/lib/screens/quick_capture_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../services/capture_sync_service.dart';
 import '../services/title_extraction_service.dart';
+import '../utils/category_detection.dart';
 import '../utils/url_utils.dart';
 
 /// Minimal capture form shown when Android share intent is received.
@@ -63,6 +64,12 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
     // Trigger title extraction if URL is pre-filled
     if (isUrl) {
       _fetchTitleForUrl(widget.sharedUrl ?? widget.sharedText);
+      // Auto-detect category from domain
+      final prefillUrl = widget.sharedUrl ?? widget.sharedText;
+      final detected = detectCategoryFromUrl(prefillUrl);
+      if (detected != 'learning') {
+        _category = detected;
+      }
     }
   }
 
@@ -91,6 +98,13 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
     _debounceTimer = Timer(const Duration(milliseconds: 500), () {
       if (isUrl(value)) {
         _fetchTitleForUrl(value);
+        // Auto-detect category from domain (only override default 'learning')
+        if (_category == 'learning') {
+          final detected = detectCategoryFromUrl(value);
+          if (detected != 'learning') {
+            setState(() => _category = detected);
+          }
+        }
       }
     });
   }

--- a/phone/lib/screens/quick_capture_screen.dart
+++ b/phone/lib/screens/quick_capture_screen.dart
@@ -59,7 +59,7 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
       text: widget.sharedUrl ?? extractedUrl ?? '',
     );
     _notesController = TextEditingController(
-      text: hasUrl ? widget.sharedText : '',
+      text: widget.sharedText,
     );
 
     // Trigger title extraction if URL is pre-filled

--- a/phone/lib/services/capture_sync_service.dart
+++ b/phone/lib/services/capture_sync_service.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:drift/drift.dart';
 import 'package:flutter/foundation.dart';
 
-import '../models/create_idea_payload.dart';
 import '../storage/phone_database.dart';
 import 'agent_api_client.dart';
 
@@ -47,16 +46,25 @@ class CaptureSyncService {
 
   /// Syncs a single capture to the PA system and marks it as synced.
   Future<void> _syncCapture(PendingCapture capture) async {
-    final payload = CreateIdeaPayload(
-      title: capture.title,
-      category: capture.category,
-      notes: _buildNotes(capture),
-      tags: capture.url != null && capture.url!.isNotEmpty
-          ? ['shared-link']
-          : [],
-    );
+    final data = <String, dynamic>{
+      'project': capture.project,
+      'title': capture.title,
+      'type': 'idea',
+      'status': 'idea',
+      'priority': 'normal',
+      'estimate': 'XS',
+      'summary': _buildSummary(capture),
+      'doc_refs': [
+        if (capture.url != null && capture.url!.isNotEmpty)
+          {'type': 'url', 'path': capture.url},
+      ],
+      'tags': [
+        capture.category,
+        if (capture.url != null && capture.url!.isNotEmpty) 'shared-link',
+      ],
+    };
 
-    await apiClient.createIdea(payload);
+    await apiClient.createTicket(data);
 
     // Mark as synced
     await (db.update(db.pendingCaptures)
@@ -66,10 +74,10 @@ class CaptureSyncService {
     debugPrint('[CaptureSync] Synced capture ${capture.id}: "${capture.title}"');
   }
 
-  /// Builds notes field from URL + notes content.
+  /// Builds summary field from URL + notes content.
   ///
-  /// If URL is present and distinct from notes, prepends it.
-  String? _buildNotes(PendingCapture capture) {
+  /// If URL is present, prepended to notes.
+  String? _buildSummary(PendingCapture capture) {
     final parts = <String>[];
 
     if (capture.url != null &&
@@ -96,6 +104,7 @@ class CaptureSyncService {
     String? notes,
     String category = 'learning',
     String? sharedText,
+    String project = 'learning-management',
   }) async {
     final id = await db.into(db.pendingCaptures).insert(
           PendingCapturesCompanion.insert(
@@ -104,6 +113,7 @@ class CaptureSyncService {
             notes: Value(notes),
             category: Value(category),
             sharedText: Value(sharedText),
+            project: Value(project),
             createdAt: DateTime.now().millisecondsSinceEpoch,
             synced: const Value(false),
           ),

--- a/phone/lib/services/capture_sync_service.dart
+++ b/phone/lib/services/capture_sync_service.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+
+import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
+
+import '../models/create_idea_payload.dart';
+import '../storage/phone_database.dart';
+import 'agent_api_client.dart';
+
+/// Syncs pending captures from local Drift storage to the PA system via API.
+///
+/// Runs on:
+/// - App start (after initial sync)
+/// - When a new capture is saved (immediate trigger)
+/// - Periodic background sync (via caller-supplied timer)
+///
+/// Uses insertOnConflictUpdate for the synced flag — safe to call repeatedly.
+class CaptureSyncService {
+  final PhoneDatabase db;
+  final AgentApiClient apiClient;
+
+  CaptureSyncService({required this.db, required this.apiClient});
+
+  /// Attempts to sync all unsynced captures to the PA system.
+  ///
+  /// Skipped if already syncing ( concurrent call protection).
+  /// Errors are logged but not thrown — sync failures should not crash the app.
+  Future<void> syncPendingCaptures() async {
+    // Fetch unsynced captures
+    final captures = await (db.select(db.pendingCaptures)
+          ..where((t) => t.synced.equals(false)))
+        .get();
+
+    if (captures.isEmpty) return;
+
+    debugPrint('[CaptureSync] Syncing ${captures.length} capture(s)');
+
+    for (final capture in captures) {
+      try {
+        await _syncCapture(capture);
+      } catch (e) {
+        // Log but don't throw — we don't want to lose other captures
+        debugPrint('[CaptureSync] Failed to sync capture ${capture.id}: $e');
+      }
+    }
+  }
+
+  /// Syncs a single capture to the PA system and marks it as synced.
+  Future<void> _syncCapture(PendingCapture capture) async {
+    final payload = CreateIdeaPayload(
+      title: capture.title,
+      category: capture.category,
+      notes: _buildNotes(capture),
+      tags: capture.url != null && capture.url!.isNotEmpty
+          ? ['shared-link']
+          : [],
+    );
+
+    await apiClient.createIdea(payload);
+
+    // Mark as synced
+    await (db.update(db.pendingCaptures)
+          ..where((t) => t.id.equals(capture.id)))
+        .write(PendingCapturesCompanion(synced: Value(true)));
+
+    debugPrint('[CaptureSync] Synced capture ${capture.id}: "${capture.title}"');
+  }
+
+  /// Builds notes field from URL + notes content.
+  ///
+  /// If URL is present and distinct from notes, prepends it.
+  String? _buildNotes(PendingCapture capture) {
+    final parts = <String>[];
+
+    if (capture.url != null &&
+        capture.url!.isNotEmpty &&
+        capture.url != capture.notes) {
+      parts.add(capture.url!);
+    }
+
+    if (capture.notes != null && capture.notes!.isNotEmpty) {
+      parts.add(capture.notes!);
+    }
+
+    if (parts.isEmpty) return null;
+    return parts.join('\n');
+  }
+
+  /// Saves a capture to the local Drift table.
+  ///
+  /// Called by QuickCaptureScreen on submit.
+  /// After saving, caller should trigger sync (via [syncPendingCaptures]).
+  Future<int> saveCapture({
+    required String title,
+    String? url,
+    String? notes,
+    String category = 'learning',
+    String? sharedText,
+  }) async {
+    final id = await db.into(db.pendingCaptures).insert(
+          PendingCapturesCompanion.insert(
+            title: title,
+            url: Value(url),
+            notes: Value(notes),
+            category: Value(category),
+            sharedText: Value(sharedText),
+            createdAt: DateTime.now().millisecondsSinceEpoch,
+            synced: const Value(false),
+          ),
+        );
+
+    debugPrint('[CaptureSync] Saved capture $id: "$title"');
+    return id;
+  }
+
+  /// Returns the count of unsynced captures.
+  Future<int> unsyncedCount() async {
+    final count = await (db.selectOnly(db.pendingCaptures)
+          ..where(db.pendingCaptures.synced.equals(false))
+          ..addColumns([db.pendingCaptures.id.count()]))
+        .map((row) => row.read(db.pendingCaptures.id.count()))
+        .getSingle();
+    return count ?? 0;
+  }
+}

--- a/phone/lib/services/title_extraction_service.dart
+++ b/phone/lib/services/title_extraction_service.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+import 'package:flutter/foundation.dart';
+
+/// Best-effort HTTP title extraction service.
+///
+/// Fetches the <title> tag from a URL. Falls back to null on timeout
+/// or error — callers should use the raw URL as the title fallback.
+class TitleExtractionService {
+  final http.Client _client;
+  final Duration _timeout;
+
+  TitleExtractionService({
+    http.Client? client,
+    Duration timeout = const Duration(seconds: 3),
+  })  : _client = client ?? http.Client(),
+        _timeout = timeout;
+
+  /// Fetches the <title> from [url].
+  ///
+  /// Returns the title text on success, null on timeout or error.
+  /// Errors are logged but not thrown — this is best-effort.
+  Future<String?> fetchTitle(String url) async {
+    try {
+      final response = await _client
+          .get(Uri.parse(url))
+          .timeout(_timeout, onTimeout: () {
+        throw TimeoutException('Title fetch timed out');
+      });
+
+      if (response.statusCode != 200) {
+        debugPrint('[TitleExtraction] Non-200 status: ${response.statusCode} for $url');
+        return null;
+      }
+
+      return _parseTitle(response.body);
+    } catch (e) {
+      debugPrint('[TitleExtraction] Failed to fetch title for $url: $e');
+      return null;
+    }
+  }
+
+  /// Parses the <title> tag from [html] content.
+  ///
+  /// Handles common variations: <title>, <TITLE>, whitespace, attributes.
+  /// Returns null if no title found.
+  String? _parseTitle(String html) {
+    // Try lowercase first (most common)
+    var match = RegExp(r'<title[^>]*>([^<]+)</title>', caseSensitive: false)
+        .firstMatch(html);
+    if (match != null) {
+      return _cleanTitle(match.group(1)!);
+    }
+    return null;
+  }
+
+  /// Cleans extracted title text.
+  ///
+  /// Trims whitespace and decodes common HTML entities.
+  String _cleanTitle(String raw) {
+    return raw
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .replaceAll('&amp;', '&')
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&#39;', "'")
+        .trim();
+  }
+}

--- a/phone/lib/services/title_extraction_service.dart
+++ b/phone/lib/services/title_extraction_service.dart
@@ -22,9 +22,15 @@ class TitleExtractionService {
   /// Returns the title text on success, null on timeout or error.
   /// Errors are logged but not thrown — this is best-effort.
   Future<String?> fetchTitle(String url) async {
+    // Only fetch http/https URLs — reject file://, ftp://, etc.
+    final uri = Uri.tryParse(url);
+    if (uri == null || (uri.scheme != 'http' && uri.scheme != 'https')) {
+      return null;
+    }
+
     try {
       final response = await _client
-          .get(Uri.parse(url))
+          .get(uri)
           .timeout(_timeout, onTimeout: () {
         throw TimeoutException('Title fetch timed out');
       });
@@ -59,13 +65,27 @@ class TitleExtractionService {
   ///
   /// Trims whitespace and decodes common HTML entities.
   String _cleanTitle(String raw) {
-    return raw
+    var result = raw
         .replaceAll(RegExp(r'\s+'), ' ')
         .replaceAll('&amp;', '&')
         .replaceAll('&lt;', '<')
         .replaceAll('&gt;', '>')
         .replaceAll('&quot;', '"')
         .replaceAll('&#39;', "'")
-        .trim();
+        .replaceAll('&apos;', "'");
+
+    // Decode decimal numeric entities: &#NNN;
+    result = result.replaceAllMapped(
+      RegExp(r'&#(\d+);'),
+      (m) => String.fromCharCode(int.parse(m.group(1)!)),
+    );
+
+    // Decode hex numeric entities: &#xHHH;
+    result = result.replaceAllMapped(
+      RegExp(r'&#x([0-9a-fA-F]+);'),
+      (m) => String.fromCharCode(int.parse(m.group(1)!, radix: 16)),
+    );
+
+    return result.trim();
   }
 }

--- a/phone/lib/storage/database_native.dart
+++ b/phone/lib/storage/database_native.dart
@@ -5,6 +5,8 @@ import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:avodah_core/avodah_core.dart';
 
+import 'phone_database.dart';
+
 /// Opens the Avodah database on native platforms (mobile/desktop).
 ///
 /// Uses [sqlite3_flutter_libs] for Android SQLite bindings.
@@ -27,4 +29,27 @@ Future<AppDatabase> openPhoneDatabase() async {
   final file = File(p.join(dbFolder.path, 'avodah_phone.db'));
   final executor = NativeDatabase.createInBackground(file);
   return AppDatabase(executor);
+}
+
+/// Opens the phone-local database on native platforms.
+///
+/// Phone-local tables (not synced via CRDT): pending_captures.
+/// Database file: `<app_documents>/avodah_phone_local.db`
+///
+/// On Linux desktop (debug), falls back to `~/.local/share/avodah/`
+/// when path_provider cannot resolve XDG directories.
+Future<PhoneDatabase> openPhoneLocalDatabase() async {
+  Directory dbFolder;
+  try {
+    dbFolder = await getApplicationDocumentsDirectory();
+  } on MissingPlatformDirectoryException {
+    final home = Platform.environment['HOME'] ?? '/tmp';
+    dbFolder = Directory(p.join(home, '.local', 'share', 'avodah'));
+    if (!dbFolder.existsSync()) {
+      dbFolder.createSync(recursive: true);
+    }
+  }
+  final file = File(p.join(dbFolder.path, 'avodah_phone_local.db'));
+  final executor = NativeDatabase.createInBackground(file);
+  return PhoneDatabase(executor);
 }

--- a/phone/lib/storage/database_stub.dart
+++ b/phone/lib/storage/database_stub.dart
@@ -1,5 +1,7 @@
 import 'package:avodah_core/avodah_core.dart';
 
+import 'phone_database.dart';
+
 /// Stub for platform-specific database opening.
 ///
 /// This file is used as a fallback when neither native nor web
@@ -10,5 +12,13 @@ Future<AppDatabase> openPhoneDatabase() async {
     'Cannot open database: no platform implementation available. '
     'Use database_native.dart for mobile/desktop or '
     'database_web.dart for web.',
+  );
+}
+
+/// Stub for phone-local database opening.
+Future<PhoneDatabase> openPhoneLocalDatabase() async {
+  throw UnsupportedError(
+    'Cannot open phone-local database: no platform implementation available. '
+    'Use database_native.dart for mobile/desktop.',
   );
 }

--- a/phone/lib/storage/database_web.dart
+++ b/phone/lib/storage/database_web.dart
@@ -1,6 +1,8 @@
 import 'package:drift/wasm.dart';
 import 'package:avodah_core/avodah_core.dart';
 
+import 'phone_database.dart';
+
 /// Opens the Avodah database on web platforms using WasmDatabase.
 ///
 /// Uses IndexedDB via OPFS (Origin Private File System) for storage.
@@ -20,4 +22,12 @@ Future<AppDatabase> openPhoneDatabase() async {
 
   final executor = result.resolvedExecutor;
   return AppDatabase(executor);
+}
+
+/// Phone-local database not supported on web.
+/// Web doesn't support Android share intents, so this is never needed.
+Future<PhoneDatabase> openPhoneLocalDatabase() async {
+  throw UnsupportedError(
+    'Phone-local database is not supported on web.',
+  );
 }

--- a/phone/lib/storage/pending_captures.dart
+++ b/phone/lib/storage/pending_captures.dart
@@ -12,6 +12,8 @@ class PendingCaptures extends Table {
   TextColumn get category =>
       text().withDefault(const Constant('learning'))();
   TextColumn get sharedText => text().nullable()();
+  TextColumn get project =>
+      text().withDefault(const Constant('learning-management'))();
   IntColumn get createdAt => integer()();
   BoolColumn get synced => boolean().withDefault(const Constant(false))();
 }

--- a/phone/lib/storage/pending_captures.dart
+++ b/phone/lib/storage/pending_captures.dart
@@ -1,0 +1,17 @@
+import 'package:drift/drift.dart';
+
+/// Pending captures table — stores shared content from Android share intents.
+///
+/// Phone-local only (not synced via CRDT). Used by the quick capture flow
+/// to hold captures until they can be synced to the PA system (P2 sync service).
+class PendingCaptures extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get title => text()();
+  TextColumn get url => text().nullable()();
+  TextColumn get notes => text().nullable()();
+  TextColumn get category =>
+      text().withDefault(const Constant('learning'))();
+  TextColumn get sharedText => text().nullable()();
+  IntColumn get createdAt => integer()();
+  BoolColumn get synced => boolean().withDefault(const Constant(false))();
+}

--- a/phone/lib/storage/phone_database.dart
+++ b/phone/lib/storage/phone_database.dart
@@ -13,5 +13,18 @@ class PhoneDatabase extends _$PhoneDatabase {
   PhoneDatabase(super.e);
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
+
+  @override
+  MigrationStrategy get migration {
+    return MigrationStrategy(
+      onUpgrade: (m, from, to) async {
+        if (from < 2) {
+          try {
+            await m.addColumn(pendingCaptures, pendingCaptures.project);
+          } on Exception catch (_) {}
+        }
+      },
+    );
+  }
 }

--- a/phone/lib/storage/phone_database.dart
+++ b/phone/lib/storage/phone_database.dart
@@ -1,0 +1,17 @@
+import 'package:drift/drift.dart';
+
+import 'pending_captures.dart';
+
+part 'phone_database.g.dart';
+
+/// Phone-local database for tables not synced via CRDT.
+///
+/// These tables are specific to the Flutter viewer app and are not
+/// part of the shared avodah_core schema.
+@DriftDatabase(tables: [PendingCaptures])
+class PhoneDatabase extends _$PhoneDatabase {
+  PhoneDatabase(super.e);
+
+  @override
+  int get schemaVersion => 1;
+}

--- a/phone/lib/storage/phone_database.g.dart
+++ b/phone/lib/storage/phone_database.g.dart
@@ -1,0 +1,780 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'phone_database.dart';
+
+// ignore_for_file: type=lint
+class $PendingCapturesTable extends PendingCaptures
+    with TableInfo<$PendingCapturesTable, PendingCapture> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PendingCapturesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _urlMeta = const VerificationMeta('url');
+  @override
+  late final GeneratedColumn<String> url = GeneratedColumn<String>(
+    'url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _notesMeta = const VerificationMeta('notes');
+  @override
+  late final GeneratedColumn<String> notes = GeneratedColumn<String>(
+    'notes',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _categoryMeta = const VerificationMeta(
+    'category',
+  );
+  @override
+  late final GeneratedColumn<String> category = GeneratedColumn<String>(
+    'category',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('learning'),
+  );
+  static const VerificationMeta _sharedTextMeta = const VerificationMeta(
+    'sharedText',
+  );
+  @override
+  late final GeneratedColumn<String> sharedText = GeneratedColumn<String>(
+    'shared_text',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<int> createdAt = GeneratedColumn<int>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _syncedMeta = const VerificationMeta('synced');
+  @override
+  late final GeneratedColumn<bool> synced = GeneratedColumn<bool>(
+    'synced',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("synced" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    title,
+    url,
+    notes,
+    category,
+    sharedText,
+    createdAt,
+    synced,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'pending_captures';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PendingCapture> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('url')) {
+      context.handle(
+        _urlMeta,
+        url.isAcceptableOrUnknown(data['url']!, _urlMeta),
+      );
+    }
+    if (data.containsKey('notes')) {
+      context.handle(
+        _notesMeta,
+        notes.isAcceptableOrUnknown(data['notes']!, _notesMeta),
+      );
+    }
+    if (data.containsKey('category')) {
+      context.handle(
+        _categoryMeta,
+        category.isAcceptableOrUnknown(data['category']!, _categoryMeta),
+      );
+    }
+    if (data.containsKey('shared_text')) {
+      context.handle(
+        _sharedTextMeta,
+        sharedText.isAcceptableOrUnknown(data['shared_text']!, _sharedTextMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('synced')) {
+      context.handle(
+        _syncedMeta,
+        synced.isAcceptableOrUnknown(data['synced']!, _syncedMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  PendingCapture map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PendingCapture(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      title: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}title'],
+      )!,
+      url: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}url'],
+      ),
+      notes: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}notes'],
+      ),
+      category: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}category'],
+      )!,
+      sharedText: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}shared_text'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}created_at'],
+      )!,
+      synced: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}synced'],
+      )!,
+    );
+  }
+
+  @override
+  $PendingCapturesTable createAlias(String alias) {
+    return $PendingCapturesTable(attachedDatabase, alias);
+  }
+}
+
+class PendingCapture extends DataClass implements Insertable<PendingCapture> {
+  final int id;
+  final String title;
+  final String? url;
+  final String? notes;
+  final String category;
+  final String? sharedText;
+  final int createdAt;
+  final bool synced;
+  const PendingCapture({
+    required this.id,
+    required this.title,
+    this.url,
+    this.notes,
+    required this.category,
+    this.sharedText,
+    required this.createdAt,
+    required this.synced,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['title'] = Variable<String>(title);
+    if (!nullToAbsent || url != null) {
+      map['url'] = Variable<String>(url);
+    }
+    if (!nullToAbsent || notes != null) {
+      map['notes'] = Variable<String>(notes);
+    }
+    map['category'] = Variable<String>(category);
+    if (!nullToAbsent || sharedText != null) {
+      map['shared_text'] = Variable<String>(sharedText);
+    }
+    map['created_at'] = Variable<int>(createdAt);
+    map['synced'] = Variable<bool>(synced);
+    return map;
+  }
+
+  PendingCapturesCompanion toCompanion(bool nullToAbsent) {
+    return PendingCapturesCompanion(
+      id: Value(id),
+      title: Value(title),
+      url: url == null && nullToAbsent ? const Value.absent() : Value(url),
+      notes: notes == null && nullToAbsent
+          ? const Value.absent()
+          : Value(notes),
+      category: Value(category),
+      sharedText: sharedText == null && nullToAbsent
+          ? const Value.absent()
+          : Value(sharedText),
+      createdAt: Value(createdAt),
+      synced: Value(synced),
+    );
+  }
+
+  factory PendingCapture.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PendingCapture(
+      id: serializer.fromJson<int>(json['id']),
+      title: serializer.fromJson<String>(json['title']),
+      url: serializer.fromJson<String?>(json['url']),
+      notes: serializer.fromJson<String?>(json['notes']),
+      category: serializer.fromJson<String>(json['category']),
+      sharedText: serializer.fromJson<String?>(json['sharedText']),
+      createdAt: serializer.fromJson<int>(json['createdAt']),
+      synced: serializer.fromJson<bool>(json['synced']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'title': serializer.toJson<String>(title),
+      'url': serializer.toJson<String?>(url),
+      'notes': serializer.toJson<String?>(notes),
+      'category': serializer.toJson<String>(category),
+      'sharedText': serializer.toJson<String?>(sharedText),
+      'createdAt': serializer.toJson<int>(createdAt),
+      'synced': serializer.toJson<bool>(synced),
+    };
+  }
+
+  PendingCapture copyWith({
+    int? id,
+    String? title,
+    Value<String?> url = const Value.absent(),
+    Value<String?> notes = const Value.absent(),
+    String? category,
+    Value<String?> sharedText = const Value.absent(),
+    int? createdAt,
+    bool? synced,
+  }) => PendingCapture(
+    id: id ?? this.id,
+    title: title ?? this.title,
+    url: url.present ? url.value : this.url,
+    notes: notes.present ? notes.value : this.notes,
+    category: category ?? this.category,
+    sharedText: sharedText.present ? sharedText.value : this.sharedText,
+    createdAt: createdAt ?? this.createdAt,
+    synced: synced ?? this.synced,
+  );
+  PendingCapture copyWithCompanion(PendingCapturesCompanion data) {
+    return PendingCapture(
+      id: data.id.present ? data.id.value : this.id,
+      title: data.title.present ? data.title.value : this.title,
+      url: data.url.present ? data.url.value : this.url,
+      notes: data.notes.present ? data.notes.value : this.notes,
+      category: data.category.present ? data.category.value : this.category,
+      sharedText: data.sharedText.present
+          ? data.sharedText.value
+          : this.sharedText,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      synced: data.synced.present ? data.synced.value : this.synced,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PendingCapture(')
+          ..write('id: $id, ')
+          ..write('title: $title, ')
+          ..write('url: $url, ')
+          ..write('notes: $notes, ')
+          ..write('category: $category, ')
+          ..write('sharedText: $sharedText, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('synced: $synced')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    title,
+    url,
+    notes,
+    category,
+    sharedText,
+    createdAt,
+    synced,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PendingCapture &&
+          other.id == this.id &&
+          other.title == this.title &&
+          other.url == this.url &&
+          other.notes == this.notes &&
+          other.category == this.category &&
+          other.sharedText == this.sharedText &&
+          other.createdAt == this.createdAt &&
+          other.synced == this.synced);
+}
+
+class PendingCapturesCompanion extends UpdateCompanion<PendingCapture> {
+  final Value<int> id;
+  final Value<String> title;
+  final Value<String?> url;
+  final Value<String?> notes;
+  final Value<String> category;
+  final Value<String?> sharedText;
+  final Value<int> createdAt;
+  final Value<bool> synced;
+  const PendingCapturesCompanion({
+    this.id = const Value.absent(),
+    this.title = const Value.absent(),
+    this.url = const Value.absent(),
+    this.notes = const Value.absent(),
+    this.category = const Value.absent(),
+    this.sharedText = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.synced = const Value.absent(),
+  });
+  PendingCapturesCompanion.insert({
+    this.id = const Value.absent(),
+    required String title,
+    this.url = const Value.absent(),
+    this.notes = const Value.absent(),
+    this.category = const Value.absent(),
+    this.sharedText = const Value.absent(),
+    required int createdAt,
+    this.synced = const Value.absent(),
+  }) : title = Value(title),
+       createdAt = Value(createdAt);
+  static Insertable<PendingCapture> custom({
+    Expression<int>? id,
+    Expression<String>? title,
+    Expression<String>? url,
+    Expression<String>? notes,
+    Expression<String>? category,
+    Expression<String>? sharedText,
+    Expression<int>? createdAt,
+    Expression<bool>? synced,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (title != null) 'title': title,
+      if (url != null) 'url': url,
+      if (notes != null) 'notes': notes,
+      if (category != null) 'category': category,
+      if (sharedText != null) 'shared_text': sharedText,
+      if (createdAt != null) 'created_at': createdAt,
+      if (synced != null) 'synced': synced,
+    });
+  }
+
+  PendingCapturesCompanion copyWith({
+    Value<int>? id,
+    Value<String>? title,
+    Value<String?>? url,
+    Value<String?>? notes,
+    Value<String>? category,
+    Value<String?>? sharedText,
+    Value<int>? createdAt,
+    Value<bool>? synced,
+  }) {
+    return PendingCapturesCompanion(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      url: url ?? this.url,
+      notes: notes ?? this.notes,
+      category: category ?? this.category,
+      sharedText: sharedText ?? this.sharedText,
+      createdAt: createdAt ?? this.createdAt,
+      synced: synced ?? this.synced,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (url.present) {
+      map['url'] = Variable<String>(url.value);
+    }
+    if (notes.present) {
+      map['notes'] = Variable<String>(notes.value);
+    }
+    if (category.present) {
+      map['category'] = Variable<String>(category.value);
+    }
+    if (sharedText.present) {
+      map['shared_text'] = Variable<String>(sharedText.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<int>(createdAt.value);
+    }
+    if (synced.present) {
+      map['synced'] = Variable<bool>(synced.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PendingCapturesCompanion(')
+          ..write('id: $id, ')
+          ..write('title: $title, ')
+          ..write('url: $url, ')
+          ..write('notes: $notes, ')
+          ..write('category: $category, ')
+          ..write('sharedText: $sharedText, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('synced: $synced')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$PhoneDatabase extends GeneratedDatabase {
+  _$PhoneDatabase(QueryExecutor e) : super(e);
+  $PhoneDatabaseManager get managers => $PhoneDatabaseManager(this);
+  late final $PendingCapturesTable pendingCaptures = $PendingCapturesTable(
+    this,
+  );
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [pendingCaptures];
+}
+
+typedef $$PendingCapturesTableCreateCompanionBuilder =
+    PendingCapturesCompanion Function({
+      Value<int> id,
+      required String title,
+      Value<String?> url,
+      Value<String?> notes,
+      Value<String> category,
+      Value<String?> sharedText,
+      required int createdAt,
+      Value<bool> synced,
+    });
+typedef $$PendingCapturesTableUpdateCompanionBuilder =
+    PendingCapturesCompanion Function({
+      Value<int> id,
+      Value<String> title,
+      Value<String?> url,
+      Value<String?> notes,
+      Value<String> category,
+      Value<String?> sharedText,
+      Value<int> createdAt,
+      Value<bool> synced,
+    });
+
+class $$PendingCapturesTableFilterComposer
+    extends Composer<_$PhoneDatabase, $PendingCapturesTable> {
+  $$PendingCapturesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get notes => $composableBuilder(
+    column: $table.notes,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get sharedText => $composableBuilder(
+    column: $table.sharedText,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get synced => $composableBuilder(
+    column: $table.synced,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$PendingCapturesTableOrderingComposer
+    extends Composer<_$PhoneDatabase, $PendingCapturesTable> {
+  $$PendingCapturesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get notes => $composableBuilder(
+    column: $table.notes,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get sharedText => $composableBuilder(
+    column: $table.sharedText,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get synced => $composableBuilder(
+    column: $table.synced,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$PendingCapturesTableAnnotationComposer
+    extends Composer<_$PhoneDatabase, $PendingCapturesTable> {
+  $$PendingCapturesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<String> get url =>
+      $composableBuilder(column: $table.url, builder: (column) => column);
+
+  GeneratedColumn<String> get notes =>
+      $composableBuilder(column: $table.notes, builder: (column) => column);
+
+  GeneratedColumn<String> get category =>
+      $composableBuilder(column: $table.category, builder: (column) => column);
+
+  GeneratedColumn<String> get sharedText => $composableBuilder(
+    column: $table.sharedText,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<bool> get synced =>
+      $composableBuilder(column: $table.synced, builder: (column) => column);
+}
+
+class $$PendingCapturesTableTableManager
+    extends
+        RootTableManager<
+          _$PhoneDatabase,
+          $PendingCapturesTable,
+          PendingCapture,
+          $$PendingCapturesTableFilterComposer,
+          $$PendingCapturesTableOrderingComposer,
+          $$PendingCapturesTableAnnotationComposer,
+          $$PendingCapturesTableCreateCompanionBuilder,
+          $$PendingCapturesTableUpdateCompanionBuilder,
+          (
+            PendingCapture,
+            BaseReferences<
+              _$PhoneDatabase,
+              $PendingCapturesTable,
+              PendingCapture
+            >,
+          ),
+          PendingCapture,
+          PrefetchHooks Function()
+        > {
+  $$PendingCapturesTableTableManager(
+    _$PhoneDatabase db,
+    $PendingCapturesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PendingCapturesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PendingCapturesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PendingCapturesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> title = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+                Value<String?> notes = const Value.absent(),
+                Value<String> category = const Value.absent(),
+                Value<String?> sharedText = const Value.absent(),
+                Value<int> createdAt = const Value.absent(),
+                Value<bool> synced = const Value.absent(),
+              }) => PendingCapturesCompanion(
+                id: id,
+                title: title,
+                url: url,
+                notes: notes,
+                category: category,
+                sharedText: sharedText,
+                createdAt: createdAt,
+                synced: synced,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String title,
+                Value<String?> url = const Value.absent(),
+                Value<String?> notes = const Value.absent(),
+                Value<String> category = const Value.absent(),
+                Value<String?> sharedText = const Value.absent(),
+                required int createdAt,
+                Value<bool> synced = const Value.absent(),
+              }) => PendingCapturesCompanion.insert(
+                id: id,
+                title: title,
+                url: url,
+                notes: notes,
+                category: category,
+                sharedText: sharedText,
+                createdAt: createdAt,
+                synced: synced,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$PendingCapturesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$PhoneDatabase,
+      $PendingCapturesTable,
+      PendingCapture,
+      $$PendingCapturesTableFilterComposer,
+      $$PendingCapturesTableOrderingComposer,
+      $$PendingCapturesTableAnnotationComposer,
+      $$PendingCapturesTableCreateCompanionBuilder,
+      $$PendingCapturesTableUpdateCompanionBuilder,
+      (
+        PendingCapture,
+        BaseReferences<_$PhoneDatabase, $PendingCapturesTable, PendingCapture>,
+      ),
+      PendingCapture,
+      PrefetchHooks Function()
+    >;
+
+class $PhoneDatabaseManager {
+  final _$PhoneDatabase _db;
+  $PhoneDatabaseManager(this._db);
+  $$PendingCapturesTableTableManager get pendingCaptures =>
+      $$PendingCapturesTableTableManager(_db, _db.pendingCaptures);
+}

--- a/phone/lib/storage/phone_database.g.dart
+++ b/phone/lib/storage/phone_database.g.dart
@@ -72,6 +72,18 @@ class $PendingCapturesTable extends PendingCaptures
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _projectMeta = const VerificationMeta(
+    'project',
+  );
+  @override
+  late final GeneratedColumn<String> project = GeneratedColumn<String>(
+    'project',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('learning-management'),
+  );
   static const VerificationMeta _createdAtMeta = const VerificationMeta(
     'createdAt',
   );
@@ -104,6 +116,7 @@ class $PendingCapturesTable extends PendingCaptures
     notes,
     category,
     sharedText,
+    project,
     createdAt,
     synced,
   ];
@@ -154,6 +167,12 @@ class $PendingCapturesTable extends PendingCaptures
         sharedText.isAcceptableOrUnknown(data['shared_text']!, _sharedTextMeta),
       );
     }
+    if (data.containsKey('project')) {
+      context.handle(
+        _projectMeta,
+        project.isAcceptableOrUnknown(data['project']!, _projectMeta),
+      );
+    }
     if (data.containsKey('created_at')) {
       context.handle(
         _createdAtMeta,
@@ -201,6 +220,10 @@ class $PendingCapturesTable extends PendingCaptures
         DriftSqlType.string,
         data['${effectivePrefix}shared_text'],
       ),
+      project: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}project'],
+      )!,
       createdAt: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}created_at'],
@@ -225,6 +248,7 @@ class PendingCapture extends DataClass implements Insertable<PendingCapture> {
   final String? notes;
   final String category;
   final String? sharedText;
+  final String project;
   final int createdAt;
   final bool synced;
   const PendingCapture({
@@ -234,6 +258,7 @@ class PendingCapture extends DataClass implements Insertable<PendingCapture> {
     this.notes,
     required this.category,
     this.sharedText,
+    required this.project,
     required this.createdAt,
     required this.synced,
   });
@@ -252,6 +277,7 @@ class PendingCapture extends DataClass implements Insertable<PendingCapture> {
     if (!nullToAbsent || sharedText != null) {
       map['shared_text'] = Variable<String>(sharedText);
     }
+    map['project'] = Variable<String>(project);
     map['created_at'] = Variable<int>(createdAt);
     map['synced'] = Variable<bool>(synced);
     return map;
@@ -269,6 +295,7 @@ class PendingCapture extends DataClass implements Insertable<PendingCapture> {
       sharedText: sharedText == null && nullToAbsent
           ? const Value.absent()
           : Value(sharedText),
+      project: Value(project),
       createdAt: Value(createdAt),
       synced: Value(synced),
     );
@@ -286,6 +313,7 @@ class PendingCapture extends DataClass implements Insertable<PendingCapture> {
       notes: serializer.fromJson<String?>(json['notes']),
       category: serializer.fromJson<String>(json['category']),
       sharedText: serializer.fromJson<String?>(json['sharedText']),
+      project: serializer.fromJson<String>(json['project']),
       createdAt: serializer.fromJson<int>(json['createdAt']),
       synced: serializer.fromJson<bool>(json['synced']),
     );
@@ -300,6 +328,7 @@ class PendingCapture extends DataClass implements Insertable<PendingCapture> {
       'notes': serializer.toJson<String?>(notes),
       'category': serializer.toJson<String>(category),
       'sharedText': serializer.toJson<String?>(sharedText),
+      'project': serializer.toJson<String>(project),
       'createdAt': serializer.toJson<int>(createdAt),
       'synced': serializer.toJson<bool>(synced),
     };
@@ -312,6 +341,7 @@ class PendingCapture extends DataClass implements Insertable<PendingCapture> {
     Value<String?> notes = const Value.absent(),
     String? category,
     Value<String?> sharedText = const Value.absent(),
+    String? project,
     int? createdAt,
     bool? synced,
   }) => PendingCapture(
@@ -321,6 +351,7 @@ class PendingCapture extends DataClass implements Insertable<PendingCapture> {
     notes: notes.present ? notes.value : this.notes,
     category: category ?? this.category,
     sharedText: sharedText.present ? sharedText.value : this.sharedText,
+    project: project ?? this.project,
     createdAt: createdAt ?? this.createdAt,
     synced: synced ?? this.synced,
   );
@@ -334,6 +365,7 @@ class PendingCapture extends DataClass implements Insertable<PendingCapture> {
       sharedText: data.sharedText.present
           ? data.sharedText.value
           : this.sharedText,
+      project: data.project.present ? data.project.value : this.project,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       synced: data.synced.present ? data.synced.value : this.synced,
     );
@@ -348,6 +380,7 @@ class PendingCapture extends DataClass implements Insertable<PendingCapture> {
           ..write('notes: $notes, ')
           ..write('category: $category, ')
           ..write('sharedText: $sharedText, ')
+          ..write('project: $project, ')
           ..write('createdAt: $createdAt, ')
           ..write('synced: $synced')
           ..write(')'))
@@ -362,6 +395,7 @@ class PendingCapture extends DataClass implements Insertable<PendingCapture> {
     notes,
     category,
     sharedText,
+    project,
     createdAt,
     synced,
   );
@@ -375,6 +409,7 @@ class PendingCapture extends DataClass implements Insertable<PendingCapture> {
           other.notes == this.notes &&
           other.category == this.category &&
           other.sharedText == this.sharedText &&
+          other.project == this.project &&
           other.createdAt == this.createdAt &&
           other.synced == this.synced);
 }
@@ -386,6 +421,7 @@ class PendingCapturesCompanion extends UpdateCompanion<PendingCapture> {
   final Value<String?> notes;
   final Value<String> category;
   final Value<String?> sharedText;
+  final Value<String> project;
   final Value<int> createdAt;
   final Value<bool> synced;
   const PendingCapturesCompanion({
@@ -395,6 +431,7 @@ class PendingCapturesCompanion extends UpdateCompanion<PendingCapture> {
     this.notes = const Value.absent(),
     this.category = const Value.absent(),
     this.sharedText = const Value.absent(),
+    this.project = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.synced = const Value.absent(),
   });
@@ -405,6 +442,7 @@ class PendingCapturesCompanion extends UpdateCompanion<PendingCapture> {
     this.notes = const Value.absent(),
     this.category = const Value.absent(),
     this.sharedText = const Value.absent(),
+    this.project = const Value.absent(),
     required int createdAt,
     this.synced = const Value.absent(),
   }) : title = Value(title),
@@ -416,6 +454,7 @@ class PendingCapturesCompanion extends UpdateCompanion<PendingCapture> {
     Expression<String>? notes,
     Expression<String>? category,
     Expression<String>? sharedText,
+    Expression<String>? project,
     Expression<int>? createdAt,
     Expression<bool>? synced,
   }) {
@@ -426,6 +465,7 @@ class PendingCapturesCompanion extends UpdateCompanion<PendingCapture> {
       if (notes != null) 'notes': notes,
       if (category != null) 'category': category,
       if (sharedText != null) 'shared_text': sharedText,
+      if (project != null) 'project': project,
       if (createdAt != null) 'created_at': createdAt,
       if (synced != null) 'synced': synced,
     });
@@ -438,6 +478,7 @@ class PendingCapturesCompanion extends UpdateCompanion<PendingCapture> {
     Value<String?>? notes,
     Value<String>? category,
     Value<String?>? sharedText,
+    Value<String>? project,
     Value<int>? createdAt,
     Value<bool>? synced,
   }) {
@@ -448,6 +489,7 @@ class PendingCapturesCompanion extends UpdateCompanion<PendingCapture> {
       notes: notes ?? this.notes,
       category: category ?? this.category,
       sharedText: sharedText ?? this.sharedText,
+      project: project ?? this.project,
       createdAt: createdAt ?? this.createdAt,
       synced: synced ?? this.synced,
     );
@@ -474,6 +516,9 @@ class PendingCapturesCompanion extends UpdateCompanion<PendingCapture> {
     if (sharedText.present) {
       map['shared_text'] = Variable<String>(sharedText.value);
     }
+    if (project.present) {
+      map['project'] = Variable<String>(project.value);
+    }
     if (createdAt.present) {
       map['created_at'] = Variable<int>(createdAt.value);
     }
@@ -492,6 +537,7 @@ class PendingCapturesCompanion extends UpdateCompanion<PendingCapture> {
           ..write('notes: $notes, ')
           ..write('category: $category, ')
           ..write('sharedText: $sharedText, ')
+          ..write('project: $project, ')
           ..write('createdAt: $createdAt, ')
           ..write('synced: $synced')
           ..write(')'))
@@ -520,6 +566,7 @@ typedef $$PendingCapturesTableCreateCompanionBuilder =
       Value<String?> notes,
       Value<String> category,
       Value<String?> sharedText,
+      Value<String> project,
       required int createdAt,
       Value<bool> synced,
     });
@@ -531,6 +578,7 @@ typedef $$PendingCapturesTableUpdateCompanionBuilder =
       Value<String?> notes,
       Value<String> category,
       Value<String?> sharedText,
+      Value<String> project,
       Value<int> createdAt,
       Value<bool> synced,
     });
@@ -571,6 +619,11 @@ class $$PendingCapturesTableFilterComposer
 
   ColumnFilters<String> get sharedText => $composableBuilder(
     column: $table.sharedText,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get project => $composableBuilder(
+    column: $table.project,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -624,6 +677,11 @@ class $$PendingCapturesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get project => $composableBuilder(
+    column: $table.project,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get createdAt => $composableBuilder(
     column: $table.createdAt,
     builder: (column) => ColumnOrderings(column),
@@ -663,6 +721,9 @@ class $$PendingCapturesTableAnnotationComposer
     column: $table.sharedText,
     builder: (column) => column,
   );
+
+  GeneratedColumn<String> get project =>
+      $composableBuilder(column: $table.project, builder: (column) => column);
 
   GeneratedColumn<int> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
@@ -714,6 +775,7 @@ class $$PendingCapturesTableTableManager
                 Value<String?> notes = const Value.absent(),
                 Value<String> category = const Value.absent(),
                 Value<String?> sharedText = const Value.absent(),
+                Value<String> project = const Value.absent(),
                 Value<int> createdAt = const Value.absent(),
                 Value<bool> synced = const Value.absent(),
               }) => PendingCapturesCompanion(
@@ -723,6 +785,7 @@ class $$PendingCapturesTableTableManager
                 notes: notes,
                 category: category,
                 sharedText: sharedText,
+                project: project,
                 createdAt: createdAt,
                 synced: synced,
               ),
@@ -734,6 +797,7 @@ class $$PendingCapturesTableTableManager
                 Value<String?> notes = const Value.absent(),
                 Value<String> category = const Value.absent(),
                 Value<String?> sharedText = const Value.absent(),
+                Value<String> project = const Value.absent(),
                 required int createdAt,
                 Value<bool> synced = const Value.absent(),
               }) => PendingCapturesCompanion.insert(
@@ -743,6 +807,7 @@ class $$PendingCapturesTableTableManager
                 notes: notes,
                 category: category,
                 sharedText: sharedText,
+                project: project,
                 createdAt: createdAt,
                 synced: synced,
               ),

--- a/phone/lib/utils/category_detection.dart
+++ b/phone/lib/utils/category_detection.dart
@@ -1,0 +1,91 @@
+library;
+
+/// Map of domain patterns to their content categories.
+///
+/// Keys are domain substrings (e.g., 'youtube.com', 'github.com').
+/// Values are category strings matching the QuickCaptureScreen dropdown.
+const Map<String, String> _domainCategoryMap = {
+  // Video
+  'youtube.com': 'video',
+  'youtu.be': 'video',
+  'vimeo.com': 'video',
+  'twitch.tv': 'video',
+  'dailymotion.com': 'video',
+
+  // Articles / Reading
+  'medium.com': 'article',
+  'substack.com': 'article',
+  'dev.to': 'article',
+  'hashnode.com': 'article',
+
+  // Code / Technical
+  'github.com': 'code',
+  'gitlab.com': 'code',
+  'bitbucket.org': 'code',
+  'stackoverflow.com': 'code',
+  'stackblitz.com': 'code',
+  'codesandbox.io': 'code',
+  'replit.com': 'code',
+
+  // News / Information
+  'news.ycombinator.com': 'article',
+  'hn.': 'article',
+  'reddit.com': 'article',
+  'lobsters.org': 'article',
+
+  // Documentation / Reference
+  'docs.google.com': 'article',
+  'notion.so': 'article',
+  'canva.com': 'article',
+  'figma.com': 'article',
+
+  // Social
+  'twitter.com': 'article',
+  'x.com': 'article',
+  'linkedin.com': 'article',
+  'threads.net': 'article',
+};
+
+/// Returns the category for a given URL based on its domain.
+///
+/// Returns 'learning' as the default when no domain matches.
+///
+/// The matching is done via substring containment — any domain containing
+/// a mapped key will receive that category. For example:
+/// - 'https://www.youtube.com/watch?v=...' → 'video'
+/// - 'https://github.com/user/repo' → 'code'
+/// - 'https://example.com/unknown' → 'learning'
+String detectCategoryFromUrl(String? url) {
+  if (url == null || url.isEmpty) {
+    return 'learning';
+  }
+
+  final lowerUrl = url.toLowerCase();
+
+  for (final entry in _domainCategoryMap.entries) {
+    if (lowerUrl.contains(entry.key)) {
+      return entry.value;
+    }
+  }
+
+  return 'learning';
+}
+
+/// Returns a human-readable label for a category.
+String categoryLabel(String category) {
+  switch (category) {
+    case 'video':
+      return 'Video';
+    case 'article':
+      return 'Article';
+    case 'code':
+      return 'Code';
+    case 'personal':
+      return 'Personal';
+    case 'work':
+      return 'Work';
+    case 'learning':
+    default:
+      return 'Learning';
+  }
+}

--- a/phone/lib/utils/url_utils.dart
+++ b/phone/lib/utils/url_utils.dart
@@ -1,0 +1,17 @@
+/// URL detection utilities for quick capture content type detection.
+library;
+
+/// Returns true if [text] looks like a URL (starts with http:// or https://).
+bool isUrl(String text) {
+  final trimmed = text.trim();
+  return trimmed.startsWith('http://') || trimmed.startsWith('https://');
+}
+
+/// Extracts the URL from [text] if it is a URL, otherwise returns null.
+String? extractUrl(String text) {
+  final trimmed = text.trim();
+  if (isUrl(trimmed)) {
+    return trimmed;
+  }
+  return null;
+}

--- a/phone/lib/utils/url_utils.dart
+++ b/phone/lib/utils/url_utils.dart
@@ -1,17 +1,37 @@
 /// URL detection utilities for quick capture content type detection.
 library;
 
-/// Returns true if [text] looks like a URL (starts with http:// or https://).
+/// Detects scheme-less URLs:
+/// - www.example.com (with or without path)
+/// - domain.tld/path (must have path to avoid false positives like "file.txt")
+final _schemelessUrlPattern = RegExp(
+  r'^www\.[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}(/\S*)?$'
+  r'|'
+  r'^[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}/\S+$',
+);
+
+/// Returns true if [text] looks like a URL.
+///
+/// Matches http/https URLs and scheme-less patterns like
+/// `news.google.com/articles/...` or `www.example.com`.
 bool isUrl(String text) {
   final trimmed = text.trim();
-  return trimmed.startsWith('http://') || trimmed.startsWith('https://');
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return true;
+  }
+  return _schemelessUrlPattern.hasMatch(trimmed);
 }
 
 /// Extracts the URL from [text] if it is a URL, otherwise returns null.
+///
+/// For scheme-less URLs, prepends `https://`.
 String? extractUrl(String text) {
   final trimmed = text.trim();
-  if (isUrl(trimmed)) {
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
     return trimmed;
+  }
+  if (_schemelessUrlPattern.hasMatch(trimmed)) {
+    return 'https://$trimmed';
   }
   return null;
 }

--- a/phone/pubspec.yaml
+++ b/phone/pubspec.yaml
@@ -32,6 +32,9 @@ dependencies:
   cryptography: ^2.7.0
   flutter_secure_storage: ^9.2.2
 
+  # Share intent receiver (for Android share-to-capture, P1)
+  receive_sharing_intent: ^1.1.2
+
 dependency_overrides:
   # 2.3.0 pulls in jni/jni_flutter which requires NDK 28 (not available in Nix env)
   path_provider_android: 2.2.23

--- a/phone/test/category_detection_test.dart
+++ b/phone/test/category_detection_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:avodah_viewer/utils/category_detection.dart';
+
+void main() {
+  group('detectCategoryFromUrl', () {
+    test('returns learning for null URL', () {
+      expect(detectCategoryFromUrl(null), 'learning');
+    });
+
+    test('returns learning for empty URL', () {
+      expect(detectCategoryFromUrl(''), 'learning');
+    });
+
+    test('returns learning for unknown domain', () {
+      expect(detectCategoryFromUrl('https://example.com/page'), 'learning');
+    });
+
+    group('video domains', () {
+      test('youtube.com', () {
+        expect(
+          detectCategoryFromUrl('https://www.youtube.com/watch?v=abc'),
+          'video',
+        );
+      });
+
+      test('youtu.be', () {
+        expect(detectCategoryFromUrl('https://youtu.be/abc'), 'video');
+      });
+
+      test('vimeo.com', () {
+        expect(detectCategoryFromUrl('https://vimeo.com/12345'), 'video');
+      });
+
+      test('twitch.tv', () {
+        expect(detectCategoryFromUrl('https://twitch.tv/channel'), 'video');
+      });
+
+      test('dailymotion.com', () {
+        expect(
+          detectCategoryFromUrl('https://www.dailymotion.com/video'),
+          'video',
+        );
+      });
+    });
+
+    group('article domains', () {
+      test('medium.com', () {
+        expect(
+          detectCategoryFromUrl('https://medium.com/@user/post'),
+          'article',
+        );
+      });
+
+      test('substack.com', () {
+        expect(
+          detectCategoryFromUrl('https://newsletter.substack.com/p/issue'),
+          'article',
+        );
+      });
+
+      test('dev.to', () {
+        expect(detectCategoryFromUrl('https://dev.to/user/post'), 'article');
+      });
+
+      test('reddit.com', () {
+        expect(
+          detectCategoryFromUrl('https://www.reddit.com/r/flutter/post'),
+          'article',
+        );
+      });
+
+      test('news.ycombinator.com', () {
+        expect(
+          detectCategoryFromUrl('https://news.ycombinator.com/item?id=123'),
+          'article',
+        );
+      });
+
+      test('twitter.com', () {
+        expect(
+          detectCategoryFromUrl('https://twitter.com/user/status/123'),
+          'article',
+        );
+      });
+
+      test('x.com', () {
+        expect(
+          detectCategoryFromUrl('https://x.com/user/status/123'),
+          'article',
+        );
+      });
+    });
+
+    group('code domains', () {
+      test('github.com', () {
+        expect(
+          detectCategoryFromUrl('https://github.com/user/repo'),
+          'code',
+        );
+      });
+
+      test('gitlab.com', () {
+        expect(
+          detectCategoryFromUrl('https://gitlab.com/user/repo'),
+          'code',
+        );
+      });
+
+      test('bitbucket.org', () {
+        expect(
+          detectCategoryFromUrl('https://bitbucket.org/user/repo'),
+          'code',
+        );
+      });
+
+      test('stackoverflow.com', () {
+        expect(
+          detectCategoryFromUrl(
+            'https://stackoverflow.com/questions/123/title',
+          ),
+          'code',
+        );
+      });
+
+      test('codesandbox.io', () {
+        expect(
+          detectCategoryFromUrl('https://codesandbox.io/s/example'),
+          'code',
+        );
+      });
+
+      test('replit.com', () {
+        expect(
+          detectCategoryFromUrl('https://replit.com/@user/project'),
+          'code',
+        );
+      });
+    });
+
+    test('case insensitive matching', () {
+      expect(
+        detectCategoryFromUrl('https://GITHUB.COM/user/repo'),
+        'code',
+      );
+      expect(
+        detectCategoryFromUrl('https://YouTube.COM/watch?v=abc'),
+        'video',
+      );
+    });
+  });
+
+  group('categoryLabel', () {
+    test('returns correct labels for known categories', () {
+      expect(categoryLabel('video'), 'Video');
+      expect(categoryLabel('article'), 'Article');
+      expect(categoryLabel('code'), 'Code');
+      expect(categoryLabel('personal'), 'Personal');
+      expect(categoryLabel('work'), 'Work');
+      expect(categoryLabel('learning'), 'Learning');
+    });
+
+    test('returns Learning for unknown category', () {
+      expect(categoryLabel('unknown'), 'Learning');
+    });
+  });
+}

--- a/phone/test/title_extraction_service_test.dart
+++ b/phone/test/title_extraction_service_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:avodah_viewer/services/title_extraction_service.dart';
+
+void main() {
+  group('TitleExtractionService', () {
+    test('extracts title from valid HTML', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          '<html><head><title>Example Page</title></head></html>',
+          200,
+        );
+      });
+      final service = TitleExtractionService(client: client);
+
+      final title = await service.fetchTitle('https://example.com');
+      expect(title, 'Example Page');
+    });
+
+    test('handles uppercase TITLE tag', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          '<html><head><TITLE>Uppercase Title</TITLE></head></html>',
+          200,
+        );
+      });
+      final service = TitleExtractionService(client: client);
+
+      final title = await service.fetchTitle('https://example.com');
+      expect(title, 'Uppercase Title');
+    });
+
+    test('decodes common HTML entities', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          '<html><head><title>Tom &amp; Jerry &lt;3&gt;</title></head></html>',
+          200,
+        );
+      });
+      final service = TitleExtractionService(client: client);
+
+      final title = await service.fetchTitle('https://example.com');
+      expect(title, 'Tom & Jerry <3>');
+    });
+
+    test('decodes &quot; and &#39; entities', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          '<html><head><title>&quot;Hello&quot; &#39;World&#39;</title></head></html>',
+          200,
+        );
+      });
+      final service = TitleExtractionService(client: client);
+
+      final title = await service.fetchTitle('https://example.com');
+      expect(title, '"Hello" \'World\'');
+    });
+
+    test('decodes &apos; entity', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          "<html><head><title>It&apos;s working</title></head></html>",
+          200,
+        );
+      });
+      final service = TitleExtractionService(client: client);
+
+      final title = await service.fetchTitle('https://example.com');
+      expect(title, "It's working");
+    });
+
+    test('decodes decimal numeric entities', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          '<html><head><title>Copyright &#169; 2026</title></head></html>',
+          200,
+        );
+      });
+      final service = TitleExtractionService(client: client);
+
+      final title = await service.fetchTitle('https://example.com');
+      // &#169; = ©
+      expect(title, 'Copyright \u00A9 2026');
+    });
+
+    test('decodes hex numeric entities', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          '<html><head><title>Smart &#x2019;quotes&#x2019;</title></head></html>',
+          200,
+        );
+      });
+      final service = TitleExtractionService(client: client);
+
+      final title = await service.fetchTitle('https://example.com');
+      // &#x2019; = right single quotation mark
+      expect(title, 'Smart \u2019quotes\u2019');
+    });
+
+    test('collapses whitespace in title', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          '<html><head><title>  Lots   of    spaces  </title></head></html>',
+          200,
+        );
+      });
+      final service = TitleExtractionService(client: client);
+
+      final title = await service.fetchTitle('https://example.com');
+      expect(title, 'Lots of spaces');
+    });
+
+    test('returns null when no title found', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          '<html><head></head><body>No title here</body></html>',
+          200,
+        );
+      });
+      final service = TitleExtractionService(client: client);
+
+      final title = await service.fetchTitle('https://example.com');
+      expect(title, isNull);
+    });
+
+    test('returns null for non-200 status', () async {
+      final client = MockClient((request) async {
+        return http.Response('Not Found', 404);
+      });
+      final service = TitleExtractionService(client: client);
+
+      final title = await service.fetchTitle('https://example.com');
+      expect(title, isNull);
+    });
+
+    test('returns null for network error', () async {
+      final client = MockClient((request) async {
+        throw Exception('Connection refused');
+      });
+      final service = TitleExtractionService(client: client);
+
+      final title = await service.fetchTitle('https://example.com');
+      expect(title, isNull);
+    });
+
+    test('rejects non-http/https URLs', () async {
+      var requestCount = 0;
+      final client = MockClient((request) async {
+        requestCount++;
+        return http.Response('', 200);
+      });
+      final service = TitleExtractionService(client: client);
+
+      expect(await service.fetchTitle('file:///etc/passwd'), isNull);
+      expect(await service.fetchTitle('ftp://files.example.com'), isNull);
+      expect(await service.fetchTitle('javascript:alert(1)'), isNull);
+      expect(requestCount, 0, reason: 'No HTTP requests should be made');
+    });
+
+    test('handles title with attributes', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          '<html><head><title lang="en">Attributed Title</title></head></html>',
+          200,
+        );
+      });
+      final service = TitleExtractionService(client: client);
+
+      final title = await service.fetchTitle('https://example.com');
+      expect(title, 'Attributed Title');
+    });
+  });
+}

--- a/phone/test/url_utils_test.dart
+++ b/phone/test/url_utils_test.dart
@@ -23,8 +23,24 @@ void main() {
       expect(isUrl(''), isFalse);
     });
 
-    test('returns false for www without scheme', () {
-      expect(isUrl('www.example.com'), isFalse);
+    test('returns true for www without scheme', () {
+      expect(isUrl('www.example.com'), isTrue);
+    });
+
+    test('returns true for scheme-less URL with path', () {
+      expect(isUrl('news.google.com/articles/123'), isTrue);
+    });
+
+    test('returns true for scheme-less domain with path', () {
+      expect(isUrl('github.com/user/repo'), isTrue);
+    });
+
+    test('returns false for bare domain without path', () {
+      expect(isUrl('example.com'), isFalse);
+    });
+
+    test('returns false for filename-like text', () {
+      expect(isUrl('file.txt'), isFalse);
     });
 
     test('returns false for ftp scheme', () {
@@ -33,6 +49,10 @@ void main() {
 
     test('returns false for file scheme', () {
       expect(isUrl('file:///tmp/test.txt'), isFalse);
+    });
+
+    test('returns false for text with spaces', () {
+      expect(isUrl('not a url.com/path'), isFalse);
     });
   });
 
@@ -51,6 +71,35 @@ void main() {
 
     test('returns null for empty string', () {
       expect(extractUrl(''), isNull);
+    });
+
+    test('prepends https for scheme-less URL with path', () {
+      expect(
+        extractUrl('news.google.com/articles/CBMi123'),
+        'https://news.google.com/articles/CBMi123',
+      );
+    });
+
+    test('prepends https for www domain', () {
+      expect(extractUrl('www.example.com'), 'https://www.example.com');
+    });
+
+    test('prepends https for github-like URL', () {
+      expect(
+        extractUrl('github.com/user/repo'),
+        'https://github.com/user/repo',
+      );
+    });
+
+    test('returns null for bare domain without path', () {
+      expect(extractUrl('example.com'), isNull);
+    });
+
+    test('trims whitespace before detecting scheme-less URL', () {
+      expect(
+        extractUrl('  news.google.com/path  '),
+        'https://news.google.com/path',
+      );
     });
   });
 }

--- a/phone/test/url_utils_test.dart
+++ b/phone/test/url_utils_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:avodah_viewer/utils/url_utils.dart';
+
+void main() {
+  group('isUrl', () {
+    test('returns true for http URLs', () {
+      expect(isUrl('http://example.com'), isTrue);
+    });
+
+    test('returns true for https URLs', () {
+      expect(isUrl('https://example.com'), isTrue);
+    });
+
+    test('returns true with leading/trailing whitespace', () {
+      expect(isUrl('  https://example.com  '), isTrue);
+    });
+
+    test('returns false for plain text', () {
+      expect(isUrl('just some text'), isFalse);
+    });
+
+    test('returns false for empty string', () {
+      expect(isUrl(''), isFalse);
+    });
+
+    test('returns false for www without scheme', () {
+      expect(isUrl('www.example.com'), isFalse);
+    });
+
+    test('returns false for ftp scheme', () {
+      expect(isUrl('ftp://files.example.com'), isFalse);
+    });
+
+    test('returns false for file scheme', () {
+      expect(isUrl('file:///tmp/test.txt'), isFalse);
+    });
+  });
+
+  group('extractUrl', () {
+    test('returns URL for https URL', () {
+      expect(extractUrl('https://example.com/path'), 'https://example.com/path');
+    });
+
+    test('returns trimmed URL with whitespace', () {
+      expect(extractUrl('  https://example.com  '), 'https://example.com');
+    });
+
+    test('returns null for plain text', () {
+      expect(extractUrl('not a url'), isNull);
+    });
+
+    test('returns null for empty string', () {
+      expect(extractUrl(''), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Android share target registration (ACTION_SEND intents for text/URL)
- Quick capture form (minimal: title + URL + notes + auto-category)
- Best-effort URL metadata extraction (fetch page title when online)
- Offline queue via Drift table (pending_captures)
- Auto-sync to PA via `/api/ideas` when online
- Auto-categorize by domain (youtube→video, medium→article, etc.)
- Unsynced badge count + error snackbars

## Test Scenarios (UAT)
- [x] TS-1: Share URL from Chrome → quick capture → saved in <2s
- [x] TS-2: Share YouTube link → title extraction → stored with URL and title
- [x] TS-3: Offline capture → sync when back online
- [x] TS-4: Captured items in LM kanban board
- [x] TS-5: Share from any Android app

## Regression Checks
- [ ] Existing Avodah features (dashboard, timers, CRDT sync)
- [ ] CreateIdeaScreen still works
- [ ] CreateTicketScreen still works
- [ ] CRDT sync between phone and desktop
- [ ] Build passes (`flutter build apk --debug`)
- [ ] Tests pass (`flutter test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)