### PR TITLE
Fix phone P2P sync retry diagnostics

### DIFF
--- a/mcp/lib/cli/sync_commands.dart
+++ b/mcp/lib/cli/sync_commands.dart
@@ -20,11 +20,10 @@ class SyncCommand extends Command<void> {
   String get name => 'sync';
 
   @override
-  String get description =>
-      'CRDT sync status and diagnostics (status)';
+  String get description => 'CRDT sync status and diagnostics (status)';
 }
 
-/// Shows current sync state, watermarks, and per-document delta counts.
+/// Shows current sync state, watermarks, and local document counts.
 class SyncStatusCommand extends Command<void> {
   final AppDatabase db;
   final HybridLogicalClock clock;
@@ -35,7 +34,7 @@ class SyncStatusCommand extends Command<void> {
   String get name => 'status';
 
   @override
-  String get description => 'Show sync state, watermarks, and delta counts';
+  String get description => 'Show sync state, watermarks, and document counts';
 
   @override
   String get invocation => 'avo sync status';
@@ -54,7 +53,8 @@ class SyncStatusCommand extends Command<void> {
 
     // Last sync from phone (received)
     final phoneWatermark = diagnostics['phoneWatermark'] as String? ?? '0';
-    final lastPhoneSync = _formatTimestamp(diagnostics['lastPhoneSync'] as int?);
+    final lastPhoneSync =
+        _formatTimestamp(diagnostics['lastPhoneSync'] as int?);
     print(kvRow('Phone watermark:', phoneWatermark));
     print(kvRow('Last phone sync:', lastPhoneSync));
 
@@ -63,7 +63,7 @@ class SyncStatusCommand extends Command<void> {
     print(kvRow('Desktop HLC:', clock.now().pack()));
 
     print('');
-    print('  Per-document delta counts:');
+    print('  Local document counts (not pending sync):');
     final counts = diagnostics['deltaCounts'] as Map<String, int>;
     print(kvRow('  dailyPlan:', '${counts['dailyPlan'] ?? 0}'));
     print(kvRow('  dayPlanTask:', '${counts['dayPlanTask'] ?? 0}'));

--- a/mcp/lib/services/sync_api_service.dart
+++ b/mcp/lib/services/sync_api_service.dart
@@ -194,7 +194,8 @@ class SyncApiService {
       return;
     }
 
-    final result = await mergePushBatch(remoteNode: remoteNode, deltas: deltasJson);
+    final result =
+        await mergePushBatch(remoteNode: remoteNode, deltas: deltasJson);
 
     _jsonResponse(request, HttpStatus.ok, {
       'merged': result.merged,
@@ -247,7 +248,9 @@ class SyncApiService {
     }
 
     // Fall back to config.categoryChips when DB is empty
-    if (chipModels.isEmpty && config != null && config!.categoryChips.isNotEmpty) {
+    if (chipModels.isEmpty &&
+        config != null &&
+        config!.categoryChips.isNotEmpty) {
       final configChips = config!.categoryChips;
       if (category != null) {
         final chips = configChips[category] ?? [];
@@ -263,9 +266,10 @@ class SyncApiService {
 
     if (category != null) {
       // Return chips for specific category
-      final categoryChipList =
-          chipModels.where((c) => c.category == category).toList()
-            ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+      final categoryChipList = chipModels
+          .where((c) => c.category == category)
+          .toList()
+        ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
       _jsonResponse(request, HttpStatus.ok, {
         'category': category,
         'chips': categoryChipList.map((c) => c.label).toList(),
@@ -279,9 +283,7 @@ class SyncApiService {
       }
       // Sort each category's chips by sortOrder
       for (final key in chipsMap.keys) {
-        final sorted = chipModels
-            .where((c) => c.category == key)
-            .toList()
+        final sorted = chipModels.where((c) => c.category == key).toList()
           ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
         chipsMap[key] = sorted.map((c) => c.label!).toList();
       }
@@ -303,8 +305,8 @@ class SyncApiService {
 
     final body = await utf8.decoder.bind(request).join();
     if (body.isEmpty) {
-      _jsonResponse(request, HttpStatus.badRequest,
-          {'error': 'Request body is empty'});
+      _jsonResponse(
+          request, HttpStatus.badRequest, {'error': 'Request body is empty'});
       return;
     }
     final json = jsonDecode(body) as Map<String, dynamic>;
@@ -456,10 +458,10 @@ class SyncApiService {
       onDeltasMerged?.call(merged);
       // Trigger Jira push for any newly merged worklogs (fire-and-forget).
       jiraService?.push().then(
-        (_) {},
-        onError: (Object e) =>
-            stderr.writeln('Jira push after phone sync failed: $e'),
-      );
+            (_) {},
+            onError: (Object e) =>
+                stderr.writeln('Jira push after phone sync failed: $e'),
+          );
     }
 
     return (merged: merged, errors: errors, watermark: watermark);
@@ -573,11 +575,9 @@ class SyncApiService {
     }
   }
 
-  Future<void> _mergeTask(
-      String id, Map<String, CrdtFieldState> state) async {
-    final rows = await (db.select(db.tasks)
-          ..where((t) => t.id.equals(id)))
-        .get();
+  Future<void> _mergeTask(String id, Map<String, CrdtFieldState> state) async {
+    final rows =
+        await (db.select(db.tasks)..where((t) => t.id.equals(id))).get();
 
     final TaskDocument doc;
     if (rows.isNotEmpty) {
@@ -609,11 +609,9 @@ class SyncApiService {
         .insertOnConflictUpdate(doc.toDriftCompanion());
   }
 
-  Future<void> _mergeTimer(
-      String id, Map<String, CrdtFieldState> state) async {
-    final rows = await (db.select(db.timerEntries)
-          ..where((t) => t.id.equals(id)))
-        .get();
+  Future<void> _mergeTimer(String id, Map<String, CrdtFieldState> state) async {
+    final rows =
+        await (db.select(db.timerEntries)..where((t) => t.id.equals(id))).get();
 
     final TimerDocument doc;
     if (rows.isNotEmpty) {
@@ -630,9 +628,8 @@ class SyncApiService {
 
   Future<void> _mergeProject(
       String id, Map<String, CrdtFieldState> state) async {
-    final rows = await (db.select(db.projects)
-          ..where((t) => t.id.equals(id)))
-        .get();
+    final rows =
+        await (db.select(db.projects)..where((t) => t.id.equals(id))).get();
 
     final ProjectDocument doc;
     if (rows.isNotEmpty) {
@@ -666,9 +663,8 @@ class SyncApiService {
 
   Future<void> _mergeDayPlanTask(
       String id, Map<String, CrdtFieldState> state) async {
-    final rows = await (db.select(db.dayPlanTasks)
-          ..where((t) => t.id.equals(id)))
-        .get();
+    final rows =
+        await (db.select(db.dayPlanTasks)..where((t) => t.id.equals(id))).get();
 
     final DayPlanTaskDocument doc;
     if (rows.isNotEmpty) {
@@ -697,7 +693,9 @@ class SyncApiService {
     }
 
     _applyState(doc, state);
-    await db.into(db.categoryChips).insertOnConflictUpdate(doc.toDriftCompanion());
+    await db
+        .into(db.categoryChips)
+        .insertOnConflictUpdate(doc.toDriftCompanion());
   }
 
   // ============================================================
@@ -705,8 +703,7 @@ class SyncApiService {
   // ============================================================
 
   /// Applies CRDT field state to a document using per-field merge.
-  void _applyState(
-      CrdtDocument doc, Map<String, CrdtFieldState> state) {
+  void _applyState(CrdtDocument doc, Map<String, CrdtFieldState> state) {
     for (final entry in state.entries) {
       doc.mergeField(
         entry.key,
@@ -794,27 +791,28 @@ class SyncApiService {
   /// Returns comprehensive sync diagnostics for CLI status display.
   ///
   /// Returns:
-  /// - phoneWatermark: the last HLC watermark received from the phone
+  /// - phoneWatermark: the last HLC watermark received from any phone node
   /// - lastPhoneSync: epoch millis of last phone sync
-  /// - deltaCounts: per-document-type count of documents with deltas since watermark
+  /// - deltaCounts: per-document-type local document counts, not pending deltas
   Future<Map<String, dynamic>> syncDiagnostics() async {
-    // Get phone watermark (received from phone)
-    final phoneWatermark = await getWatermark('phone', direction: 'received');
-
-    // Get all watermarks to find last phone sync time
     final allWatermarks = await getAllWatermarks();
     int? lastPhoneSync;
+    String phoneWatermark = '0';
     for (final w in allWatermarks) {
-      if (w['nodeId'] == 'phone' && w['direction'] == 'received') {
+      final nodeId = w['nodeId'] as String? ?? '';
+      if (nodeId.startsWith('phone') && w['direction'] == 'received') {
         final ts = w['updatedAt'] as int?;
         if (ts != null && (lastPhoneSync == null || ts > lastPhoneSync)) {
           lastPhoneSync = ts;
+          phoneWatermark = (w['lastHlc'] as String?) ?? '0';
         }
       }
     }
 
-    // Count deltas per document type (docs modified since zero watermark = all docs)
-    final zeroWatermark = HybridTimestamp(physicalTime: 0, counter: 0, nodeId: '');
+    // Count local documents per type. This is a diagnostic inventory, not a
+    // pending-sync count; phone pull watermarks are stored on the phone.
+    final zeroWatermark =
+        HybridTimestamp(physicalTime: 0, counter: 0, nodeId: '');
     final counts = <String, int>{
       'dailyPlan': 0,
       'dayPlanTask': 0,
@@ -826,27 +824,39 @@ class SyncApiService {
 
     // Tasks
     final tasks = await db.select(db.tasks).get();
-    counts['task'] = tasks.where((r) => _isAfterWatermark(r.crdtClock, zeroWatermark)).length;
+    counts['task'] = tasks
+        .where((r) => _isAfterWatermark(r.crdtClock, zeroWatermark))
+        .length;
 
     // Worklogs
     final worklogs = await db.select(db.worklogEntries).get();
-    counts['worklog'] = worklogs.where((r) => _isAfterWatermark(r.crdtClock, zeroWatermark)).length;
+    counts['worklog'] = worklogs
+        .where((r) => _isAfterWatermark(r.crdtClock, zeroWatermark))
+        .length;
 
     // Timers
     final timers = await db.select(db.timerEntries).get();
-    counts['timer'] = timers.where((r) => _isAfterWatermark(r.crdtClock, zeroWatermark)).length;
+    counts['timer'] = timers
+        .where((r) => _isAfterWatermark(r.crdtClock, zeroWatermark))
+        .length;
 
     // Projects
     final projects = await db.select(db.projects).get();
-    counts['project'] = projects.where((r) => _isAfterWatermark(r.crdtClock, zeroWatermark)).length;
+    counts['project'] = projects
+        .where((r) => _isAfterWatermark(r.crdtClock, zeroWatermark))
+        .length;
 
     // Daily plans
     final dailyPlans = await db.select(db.dailyPlanEntries).get();
-    counts['dailyPlan'] = dailyPlans.where((r) => _isAfterWatermark(r.crdtClock, zeroWatermark)).length;
+    counts['dailyPlan'] = dailyPlans
+        .where((r) => _isAfterWatermark(r.crdtClock, zeroWatermark))
+        .length;
 
     // Day plan tasks
     final dayPlanTasks = await db.select(db.dayPlanTasks).get();
-    counts['dayPlanTask'] = dayPlanTasks.where((r) => _isAfterWatermark(r.crdtClock, zeroWatermark)).length;
+    counts['dayPlanTask'] = dayPlanTasks
+        .where((r) => _isAfterWatermark(r.crdtClock, zeroWatermark))
+        .length;
 
     return {
       'phoneWatermark': phoneWatermark,
@@ -891,7 +901,8 @@ class SyncApiService {
         if (device != null && device.origin != null) {
           // If origin matches the stored origin (or is a sub-origin of it), allow it
           if (origin == device.origin ||
-              origin.startsWith(device.origin!.replaceFirst(RegExp(r'^https?://'), ''))) {
+              origin.startsWith(
+                  device.origin!.replaceFirst(RegExp(r'^https?://'), ''))) {
             allowedOrigin = origin;
           }
         }
@@ -902,8 +913,8 @@ class SyncApiService {
     // (After pairing, the phone sends the same origin it used during pairing)
     allowedOrigin ??= origin ?? '*';
 
-    request.response.headers.add(
-        'Access-Control-Allow-Origin', allowedOrigin == '*' ? '*' : allowedOrigin);
+    request.response.headers.add('Access-Control-Allow-Origin',
+        allowedOrigin == '*' ? '*' : allowedOrigin);
     request.response.headers
         .add('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
     request.response.headers.add('Access-Control-Allow-Headers',
@@ -914,8 +925,7 @@ class SyncApiService {
 
   /// Updates the lastSeen timestamp for a paired device.
   Future<void> _updateLastSeen(String nodeId) async {
-    await (db.update(db.pairedDevices)
-          ..where((d) => d.id.equals(nodeId)))
+    await (db.update(db.pairedDevices)..where((d) => d.id.equals(nodeId)))
         .write(PairedDevicesCompanion(
       lastSeen: Value(DateTime.now().millisecondsSinceEpoch),
     ));

--- a/mcp/test/services/sync_api_service_test.dart
+++ b/mcp/test/services/sync_api_service_test.dart
@@ -269,9 +269,7 @@ void main() {
         category: 'Working',
         label: 'local-label',
       );
-      await db
-          .into(db.categoryChips)
-          .insert(localChip.toDriftCompanion());
+      await db.into(db.categoryChips).insert(localChip.toDriftCompanion());
 
       // Remote update with a later timestamp
       final remoteTs = HybridTimestamp(
@@ -302,9 +300,7 @@ void main() {
         category: 'Working',
         label: 'Local label',
       );
-      await db
-          .into(db.categoryChips)
-          .insert(localChip.toDriftCompanion());
+      await db.into(db.categoryChips).insert(localChip.toDriftCompanion());
 
       // Remote update with an OLD timestamp
       final remoteTs = HybridTimestamp(
@@ -389,11 +385,9 @@ void main() {
       await syncApi.setWatermark(nodeId, receivedHlc, direction: 'received');
       await syncApi.setWatermark(nodeId, sentHlc, direction: 'sent');
 
-      expect(
-          await syncApi.getWatermark(nodeId, direction: 'received'),
+      expect(await syncApi.getWatermark(nodeId, direction: 'received'),
           equals(receivedHlc));
-      expect(
-          await syncApi.getWatermark(nodeId, direction: 'sent'),
+      expect(await syncApi.getWatermark(nodeId, direction: 'sent'),
           equals(sentHlc));
     });
 
@@ -409,6 +403,20 @@ void main() {
       expect(all, hasLength(3));
       final nodeIds = all.map((e) => e['nodeId']).toSet();
       expect(nodeIds, containsAll(['phone-1', 'phone-2']));
+    });
+
+    test('syncDiagnostics uses most recent phone-* received watermark',
+        () async {
+      await syncApi.setWatermark('phone-older', '1000-0-phone-older',
+          direction: 'received');
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+      await syncApi.setWatermark('phone-newer', '2000-0-phone-newer',
+          direction: 'received');
+
+      final diagnostics = await syncApi.syncDiagnostics();
+
+      expect(diagnostics['phoneWatermark'], equals('2000-0-phone-newer'));
+      expect(diagnostics['lastPhoneSync'], isA<int>());
     });
   });
 
@@ -440,7 +448,10 @@ void main() {
             'fields': {
               'title': {'v': 'Phone task', 't': remoteTs.pack()},
               'isDone': {'v': false, 't': remoteTs.pack()},
-              'created': {'v': DateTime.now().millisecondsSinceEpoch, 't': remoteTs.pack()},
+              'created': {
+                'v': DateTime.now().millisecondsSinceEpoch,
+                't': remoteTs.pack()
+              },
               'timeSpent': {'v': 0, 't': remoteTs.pack()},
               'timeEstimate': {'v': 0, 't': remoteTs.pack()},
             },
@@ -492,7 +503,10 @@ void main() {
             'fields': {
               'taskTitle': {'v': 'Phone timer', 't': remoteTs.pack()},
               'isRunning': {'v': true, 't': remoteTs.pack()},
-              'startedAt': {'v': DateTime.now().millisecondsSinceEpoch, 't': remoteTs.pack()},
+              'startedAt': {
+                'v': DateTime.now().millisecondsSinceEpoch,
+                't': remoteTs.pack()
+              },
               'accumulatedMs': {'v': 0, 't': remoteTs.pack()},
             },
           },
@@ -531,7 +545,10 @@ void main() {
             'fields': {
               'taskTitle': {'v': 'Phone work', 't': remoteTs.pack()},
               'isRunning': {'v': true, 't': remoteTs.pack()},
-              'startedAt': {'v': DateTime.now().millisecondsSinceEpoch, 't': remoteTs.pack()},
+              'startedAt': {
+                'v': DateTime.now().millisecondsSinceEpoch,
+                't': remoteTs.pack()
+              },
               'accumulatedMs': {'v': 0, 't': remoteTs.pack()},
             },
           },
@@ -562,8 +579,7 @@ void main() {
       // Create a "remote" database and merge
       final remoteDb = openMemoryDatabase();
       final remoteClock = HybridLogicalClock(nodeId: 'phone-1');
-      final remoteSyncApi =
-          SyncApiService(db: remoteDb, clock: remoteClock);
+      final remoteSyncApi = SyncApiService(db: remoteDb, clock: remoteClock);
 
       for (final delta in deltas) {
         await remoteSyncApi.mergeDelta(delta);

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -59,10 +59,11 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
   DisplaySettingsService? _displaySettings;
   CaptureSyncService? _captureSyncService;
   Timer? _syncTimer;
+  bool _syncInProgress = false;
   bool _pairingInProgress = false;
   final _navigatorKey = GlobalKey<NavigatorState>();
   final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
-  final List<Map<String, dynamic>> _pendingTimerDeltas = [];
+  final List<Map<String, dynamic>> _pendingSyncDeltas = [];
 
   // Share intent handling
   StreamSubscription<List<SharedMediaFile>>? _shareIntentSubscription;
@@ -144,10 +145,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
       ..nodeId = nodeId;
     final captureSyncService = phoneDb == null
         ? null
-        : CaptureSyncService(
-            db: phoneDb,
-            apiClient: apiClient,
-          );
+        : CaptureSyncService(db: phoneDb, apiClient: apiClient);
     final reviewProvider = ReviewProvider(apiClient);
     reviewProvider.startAutoRefresh();
 
@@ -204,20 +202,17 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     }
 
     // Periodic sync + refresh every 5 seconds while app is running
-    _syncTimer = Timer.periodic(
-      const Duration(seconds: 5),
-      (_) {
-        _syncAndRefresh();
-        _syncCaptures();
-      },
-    );
+    _syncTimer = Timer.periodic(const Duration(seconds: 5), (_) {
+      _syncAndRefresh();
+      _syncCaptures();
+    });
   }
 
   /// Check for share intent that started the app (cold start).
   Future<void> _checkInitialShareIntent() async {
     try {
-      final initialMedia =
-          await ReceiveSharingIntent.instance.getInitialMedia();
+      final initialMedia = await ReceiveSharingIntent.instance
+          .getInitialMedia();
       if (initialMedia.isNotEmpty && !_shareIntentHandled) {
         _handleShareIntent(initialMedia);
       }
@@ -249,19 +244,21 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     final captureSync = _captureSyncService;
     final apiClient = _apiClient;
     if (nav != null && captureSync != null && apiClient != null) {
-      nav.push<bool>(
-        MaterialPageRoute(
-          builder: (_) => QuickCaptureScreen(
-            sharedText: sharedText,
-            sharedUrl: isUrl ? sharedText : null,
-            captureSyncService: captureSync,
-            apiClient: apiClient,
-          ),
-        ),
-      ).then((_) {
-        // Reset so subsequent shares in the same session are handled
-        _shareIntentHandled = false;
-      });
+      nav
+          .push<bool>(
+            MaterialPageRoute(
+              builder: (_) => QuickCaptureScreen(
+                sharedText: sharedText,
+                sharedUrl: isUrl ? sharedText : null,
+                captureSyncService: captureSync,
+                apiClient: apiClient,
+              ),
+            ),
+          )
+          .then((_) {
+            // Reset so subsequent shares in the same session are handled
+            _shareIntentHandled = false;
+          });
     } else {
       // Navigation not ready — defer until init completes
       debugPrint('[ShareIntent] Navigation not ready, deferring share intent');
@@ -269,63 +266,59 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
   }
 
   /// Pull CRDT deltas from desktop, then refresh the dashboard from local DB.
-  /// pullFromDesktop() is called on EVERY cycle regardless of prior failure state.
-  /// When already disconnected, skip the pull to avoid 10s blocking timeout
-  /// and just refresh the local dashboard.
+  /// pullFromDesktop() is called on every non-overlapping cycle regardless of
+  /// prior failure state so the app can recover after transient disconnects.
   Future<void> _syncAndRefresh() async {
     final sync = _crdtSyncService;
     final dashboard = _dashboardProvider;
     if (sync == null || dashboard == null) return;
+    if (_syncInProgress) return;
+
+    _syncInProgress = true;
     var syncOk = false;
 
-    // If already disconnected, skip pull to avoid blocking 10s TCP timeout.
-    // Just refresh the local dashboard and retry pull on next cycle.
-    final alreadyOffline =
-        dashboard.connectionState.value == SyncConnectionState.disconnected;
-
-    if (!alreadyOffline) {
-      try {
-        await sync.pullFromDesktop();
-        syncOk = true;
-        // Flush queued timer deltas after successful pull
-        if (_pendingTimerDeltas.isNotEmpty) {
-          final queued = List<Map<String, dynamic>>.from(_pendingTimerDeltas);
-          _pendingTimerDeltas.clear();
-          try {
-            await sync.pushToDesktop(queued);
-            debugPrint('[Sync] Flushed ${queued.length} queued timer delta(s)');
-          } catch (e) {
-            debugPrint('[Sync] Queued timer push failed: $e — re-queueing');
-            _pendingTimerDeltas.addAll(queued);
-          }
-        }
-      } catch (e) {
-        debugPrint('[Sync] Pull failed: $e');
-        // Surface pull failure to user via snackbar (AC4)
-        final messenger = _scaffoldMessengerKey.currentState;
-        if (messenger != null) {
-          SchedulerBinding.instance.addPostFrameCallback((_) {
-            if (!mounted) return;
-            messenger.showSnackBar(
-              const SnackBar(
-                content: Text('Sync failed — will retry on next cycle'),
-                duration: Duration(seconds: 4),
-              ),
-            );
-          });
-        } else {
-          debugPrint('[Sync] Pull failed but ScaffoldMessenger unavailable '
-              'for snackbar notification');
+    try {
+      await sync.pullFromDesktop();
+      syncOk = true;
+      // Flush queued local deltas after successful pull.
+      if (_pendingSyncDeltas.isNotEmpty) {
+        final queued = List<Map<String, dynamic>>.from(_pendingSyncDeltas);
+        _pendingSyncDeltas.clear();
+        try {
+          await sync.pushToDesktop(queued);
+          debugPrint('[Sync] Flushed ${queued.length} queued local delta(s)');
+        } catch (e) {
+          debugPrint('[Sync] Queued local push failed: $e — re-queueing');
+          _pendingSyncDeltas.addAll(queued);
         }
       }
-    } else {
-      debugPrint('[Sync] Skipping pull — already offline');
-    }
-
-    await dashboard.refresh();
-    // Override the indicator to reflect actual sync status, not just local DB read
-    if (!syncOk) {
-      dashboard.connectionState.value = SyncConnectionState.disconnected;
+    } catch (e) {
+      debugPrint('[Sync] Pull failed: $e');
+      // Surface pull failure to user via snackbar (AC4)
+      final messenger = _scaffoldMessengerKey.currentState;
+      if (messenger != null) {
+        SchedulerBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          messenger.showSnackBar(
+            const SnackBar(
+              content: Text('Sync failed — will retry on next cycle'),
+              duration: Duration(seconds: 4),
+            ),
+          );
+        });
+      } else {
+        debugPrint(
+          '[Sync] Pull failed but ScaffoldMessenger unavailable '
+          'for snackbar notification',
+        );
+      }
+    } finally {
+      await dashboard.refresh();
+      // Override the indicator to reflect actual sync status, not just local DB read
+      if (!syncOk) {
+        dashboard.connectionState.value = SyncConnectionState.disconnected;
+      }
+      _syncInProgress = false;
     }
   }
 
@@ -366,34 +359,28 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
   }
 
   /// Push CRDT deltas from phone to desktop (non-fatal on failure).
-  /// Timer deltas that fail to push are queued and retried on the next sync cycle.
+  /// Local deltas that fail to push are queued and retried on the next sync cycle.
   Future<void> _pushDeltas(List<Map<String, dynamic>> deltas) async {
     if (deltas.isEmpty) return;
-
-    // Queue timer deltas on failure for later retry
-    final timerDeltas = deltas.where((d) => d['type'] == 'timer').toList();
 
     try {
       // Always try to push all deltas together
       await _crdtSyncService?.pushToDesktop(deltas);
-      // On success, flush any queued timer deltas too
-      if (_pendingTimerDeltas.isNotEmpty) {
-        final queued = List<Map<String, dynamic>>.from(_pendingTimerDeltas);
-        _pendingTimerDeltas.clear();
+      // On success, flush any queued deltas too
+      if (_pendingSyncDeltas.isNotEmpty) {
+        final queued = List<Map<String, dynamic>>.from(_pendingSyncDeltas);
+        _pendingSyncDeltas.clear();
         try {
           await _crdtSyncService?.pushToDesktop(queued);
         } catch (e) {
-          debugPrint('[Sync] Queued timer push failed: $e');
-          _pendingTimerDeltas.addAll(queued);
+          debugPrint('[Sync] Queued local push failed: $e');
+          _pendingSyncDeltas.addAll(queued);
         }
       }
     } catch (e) {
       debugPrint('[Sync] Push failed: $e');
-      // Queue timer deltas for retry; non-timer deltas are dropped (fire-and-forget)
-      if (timerDeltas.isNotEmpty) {
-        _pendingTimerDeltas.addAll(timerDeltas);
-        debugPrint('[Sync] Queued ${timerDeltas.length} timer delta(s) for retry');
-      }
+      _pendingSyncDeltas.addAll(deltas);
+      debugPrint('[Sync] Queued ${deltas.length} local delta(s) for retry');
       // Surface failure to user via snackbar (not spam — ScaffoldMessenger
       // only shows one snackbar at a time)
       final messenger = _scaffoldMessengerKey.currentState;
@@ -402,7 +389,9 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
           if (!mounted) return;
           messenger.showSnackBar(
             SnackBar(
-              content: Text('Sync failed${_pendingTimerDeltas.isNotEmpty ? ' — timer will retry' : ''}'),
+              content: Text(
+                'Sync failed — ${_pendingSyncDeltas.length} local change(s) will retry',
+              ),
               duration: const Duration(seconds: 4),
             ),
           );
@@ -503,10 +492,7 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
       final result = await nav.push<bool>(
         MaterialPageRoute(
           builder: (_) => PairingScreen(
-            args: PairingScreenArgs(
-              cryptoClient: crypto,
-              nodeId: nodeId,
-            ),
+            args: PairingScreenArgs(cryptoClient: crypto, nodeId: nodeId),
           ),
         ),
       );
@@ -572,18 +558,16 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
           navigatorKey: _navigatorKey,
           title: 'Avodah',
           debugShowCheckedModeBanner: false,
-          theme: display?.lightTheme().copyWith(
-                extensions: [syntaxTheme],
-              ) ??
+          theme:
+              display?.lightTheme().copyWith(extensions: [syntaxTheme]) ??
               ThemeData(
                 colorSchemeSeed: const Color(0xFF6750A4),
                 useMaterial3: true,
                 brightness: Brightness.light,
                 extensions: [syntaxTheme],
               ),
-          darkTheme: display?.darkTheme().copyWith(
-                extensions: [syntaxTheme],
-              ) ??
+          darkTheme:
+              display?.darkTheme().copyWith(extensions: [syntaxTheme]) ??
               ThemeData(
                 colorSchemeSeed: const Color(0xFF6750A4),
                 useMaterial3: true,
@@ -599,24 +583,29 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          const Icon(Icons.error_outline,
-                              size: 48, color: Colors.red),
+                          const Icon(
+                            Icons.error_outline,
+                            size: 48,
+                            color: Colors.red,
+                          ),
                           const SizedBox(height: 16),
-                          const Text('Failed to initialize',
-                              style: TextStyle(fontSize: 18)),
+                          const Text(
+                            'Failed to initialize',
+                            style: TextStyle(fontSize: 18),
+                          ),
                           const SizedBox(height: 8),
-                          Text(_initError!,
-                              textAlign: TextAlign.center,
-                              style: const TextStyle(color: Colors.grey)),
+                          Text(
+                            _initError!,
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(color: Colors.grey),
+                          ),
                         ],
                       ),
                     ),
                   ),
                 )
               : _dashboardProvider == null
-              ? const Scaffold(
-                  body: Center(child: CircularProgressIndicator()),
-                )
+              ? const Scaffold(body: Center(child: CircularProgressIndicator()))
               : _HomeShell(
                   dashboardProvider: _dashboardProvider!,
                   writeService: _writeService!,
@@ -729,14 +718,14 @@ class _HomeShellState extends State<_HomeShell> {
         index: _currentIndex,
         children: [
           KanbanBoardScreen(
-              boardProvider: widget.boardProvider,
-              dashboardProvider: widget.dashboardProvider,
-              focusProvider: widget.focusProvider,
-              deploymentProvider: widget.deploymentProvider,
-              crdtSyncService: widget.crdtSyncService,
-              apiClient: widget.apiClient,
-              displaySettings: widget.displaySettings,
-            ),
+            boardProvider: widget.boardProvider,
+            dashboardProvider: widget.dashboardProvider,
+            focusProvider: widget.focusProvider,
+            deploymentProvider: widget.deploymentProvider,
+            crdtSyncService: widget.crdtSyncService,
+            apiClient: widget.apiClient,
+            displaySettings: widget.displaySettings,
+          ),
           DashboardScreen(
             dashboardProvider: widget.dashboardProvider,
             writeService: widget.writeService,
@@ -761,10 +750,12 @@ class _HomeShellState extends State<_HomeShell> {
                   onPressed: () => Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => SettingsScreen(
+                      builder: (_) => SettingsScreen(
                         apiClient: widget.apiClient,
                         crdtSyncService: widget.crdtSyncService,
-                        displaySettings: widget.displaySettings)),
+                        displaySettings: widget.displaySettings,
+                      ),
+                    ),
                   ),
                 ),
               ],
@@ -790,10 +781,12 @@ class _HomeShellState extends State<_HomeShell> {
                   onPressed: () => Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => SettingsScreen(
+                      builder: (_) => SettingsScreen(
                         apiClient: widget.apiClient,
                         crdtSyncService: widget.crdtSyncService,
-                        displaySettings: widget.displaySettings)),
+                        displaySettings: widget.displaySettings,
+                      ),
+                    ),
                   ),
                 ),
                 IconButton(
@@ -823,10 +816,12 @@ class _HomeShellState extends State<_HomeShell> {
                   onPressed: () => Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => SettingsScreen(
+                      builder: (_) => SettingsScreen(
                         apiClient: widget.apiClient,
                         crdtSyncService: widget.crdtSyncService,
-                        displaySettings: widget.displaySettings)),
+                        displaySettings: widget.displaySettings,
+                      ),
+                    ),
                   ),
                 ),
                 IconButton(
@@ -835,8 +830,7 @@ class _HomeShellState extends State<_HomeShell> {
                   onPressed: () => Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (_) =>
-                          TimersScreen(apiClient: widget.apiClient),
+                      builder: (_) => TimersScreen(apiClient: widget.apiClient),
                     ),
                   ),
                 ),
@@ -846,15 +840,13 @@ class _HomeShellState extends State<_HomeShell> {
                 ),
               ],
             ),
-            body: TeamBrowserScreen(
-                teamProvider: widget.teamBrowserProvider),
+            body: TeamBrowserScreen(teamProvider: widget.teamBrowserProvider),
           ),
         ],
       ),
       bottomNavigationBar: NavigationBar(
         selectedIndex: _currentIndex,
-        onDestinationSelected: (index) =>
-            setState(() => _currentIndex = index),
+        onDestinationSelected: (index) => setState(() => _currentIndex = index),
         destinations: [
           NavigationDestination(
             icon: actionableCount > 0

--- a/phone/lib/services/capture_sync_service.dart
+++ b/phone/lib/services/capture_sync_service.dart
@@ -51,8 +51,9 @@ class CaptureSyncService {
       'title': capture.title,
       'type': 'idea',
       'status': 'idea',
-      'priority': 'normal',
+      'priority': 'medium',
       'estimate': 'XS',
+      'assignee': 'requirements',
       'summary': _buildSummary(capture),
       'doc_refs': [
         if (capture.url != null && capture.url!.isNotEmpty)

--- a/phone/lib/services/crdt_sync_service.dart
+++ b/phone/lib/services/crdt_sync_service.dart
@@ -51,6 +51,108 @@ class _SyncDocType {
 /// Callback type invoked when the server indicates pairing is required.
 typedef OnNeedsPairingCallback = Future<void> Function();
 
+class P2pSyncDiagnostics {
+  final String desktopWatermark;
+  final Map<String, int> localCounts;
+  final List<Map<String, Object?>> watermarks;
+  final List<P2pSyncRecentWorklog> recentWorklogs;
+  final DateTime? lastPushStartedAt;
+  final DateTime? lastPushCompletedAt;
+  final int? lastPushDeltaCount;
+  final Map<String, int> lastPushDeltaTypes;
+  final int? lastPushMergedCount;
+  final String? lastPushWatermark;
+  final String? lastPushError;
+
+  const P2pSyncDiagnostics({
+    required this.desktopWatermark,
+    required this.localCounts,
+    required this.watermarks,
+    required this.recentWorklogs,
+    required this.lastPushStartedAt,
+    required this.lastPushCompletedAt,
+    required this.lastPushDeltaCount,
+    required this.lastPushDeltaTypes,
+    required this.lastPushMergedCount,
+    required this.lastPushWatermark,
+    required this.lastPushError,
+  });
+
+  String toDebugText() {
+    final buffer = StringBuffer()
+      ..writeln('P2P Sync Diagnostics')
+      ..writeln('Generated: ${DateTime.now().toIso8601String()}')
+      ..writeln('Desktop watermark: $desktopWatermark')
+      ..writeln()
+      ..writeln('Last push:')
+      ..writeln('  started: ${lastPushStartedAt?.toIso8601String() ?? 'never'}')
+      ..writeln(
+        '  completed: ${lastPushCompletedAt?.toIso8601String() ?? 'never'}',
+      )
+      ..writeln('  delta count: ${lastPushDeltaCount ?? 'n/a'}')
+      ..writeln(
+        '  delta types: ${lastPushDeltaTypes.isEmpty ? 'n/a' : lastPushDeltaTypes}',
+      )
+      ..writeln('  desktop merged: ${lastPushMergedCount ?? 'n/a'}')
+      ..writeln('  desktop watermark: ${lastPushWatermark ?? 'n/a'}')
+      ..writeln('  error: ${lastPushError ?? 'none'}')
+      ..writeln()
+      ..writeln('Local document counts:');
+    for (final entry in localCounts.entries) {
+      buffer.writeln('  ${entry.key}: ${entry.value}');
+    }
+    buffer
+      ..writeln()
+      ..writeln('Watermarks:');
+    if (watermarks.isEmpty) {
+      buffer.writeln('  none');
+    } else {
+      for (final watermark in watermarks) {
+        buffer.writeln(
+          '  ${watermark['nodeId']} ${watermark['direction']} '
+          '${watermark['lastHlc']} updatedAt=${watermark['updatedAt']}',
+        );
+      }
+    }
+    buffer
+      ..writeln()
+      ..writeln('Recent local worklogs:');
+    if (recentWorklogs.isEmpty) {
+      buffer.writeln('  none');
+    } else {
+      for (final worklog in recentWorklogs) {
+        buffer.writeln(
+          '  ${worklog.id} date=${worklog.date} durationMs=${worklog.durationMs} '
+          'taskId=${worklog.taskId.isEmpty ? '(orphan)' : worklog.taskId} '
+          'category=${worklog.category ?? '(none)'} deleted=${worklog.isDeleted} '
+          'crdtClock=${worklog.crdtClock}',
+        );
+      }
+    }
+    return buffer.toString();
+  }
+}
+
+class P2pSyncRecentWorklog {
+  final String id;
+  final String taskId;
+  final String date;
+  final int durationMs;
+  final String? category;
+  final bool isDeleted;
+  final String crdtClock;
+
+  const P2pSyncRecentWorklog({
+    required this.id,
+    required this.taskId,
+    required this.date,
+    required this.durationMs,
+    required this.category,
+    required this.isDeleted,
+    required this.crdtClock,
+  });
+}
+
 /// Sync service that pulls CRDT deltas from the desktop via HTTP.
 ///
 /// Uses [cryptoClient] for TLS + auth transport when provided.
@@ -65,6 +167,14 @@ class CrdtSyncService {
   final HybridLogicalClock clock;
   final http.Client _plainClient;
   final CryptoSyncService? _cryptoClient;
+
+  DateTime? _lastPushStartedAt;
+  DateTime? _lastPushCompletedAt;
+  int? _lastPushDeltaCount;
+  Map<String, int> _lastPushDeltaTypes = const {};
+  int? _lastPushMergedCount;
+  String? _lastPushWatermark;
+  String? _lastPushError;
 
   /// Phone-side pairing service (initialized after pairing).
   PhonePairingService? get pairingService => _pairingService;
@@ -330,18 +440,17 @@ class CrdtSyncService {
         .insertOnConflictUpdate(doc.toDriftCompanion());
   }
 
-  Future<void> _mergeTimer(
-    String id,
-    Map<String, CrdtFieldState> state,
-  ) async {
+  Future<void> _mergeTimer(String id, Map<String, CrdtFieldState> state) async {
     // ---- Phase 1 debug logging ----
     // Log incoming timer delta fields
-    final incomingFields = state.entries.map((e) {
-      final fieldState = e.value;
-      final val = fieldState.value;
-      final ts = fieldState.timestamp;
-      return '$e.key=$val[t=$ts]';
-    }).join(', ');
+    final incomingFields = state.entries
+        .map((e) {
+          final fieldState = e.value;
+          final val = fieldState.value;
+          final ts = fieldState.timestamp;
+          return '$e.key=$val[t=$ts]';
+        })
+        .join(', ');
     debugPrint(
       '[CrdtSync] Timer delta RECEIVED: id=$id fields=[$incomingFields]',
     );
@@ -452,57 +561,143 @@ class CrdtSyncService {
   Future<int> pushToDesktop(List<Map<String, dynamic>> deltas) async {
     if (deltas.isEmpty) return 0;
 
-    final nodeId = await getOrCreateNodeId();
-    final body = jsonEncode({'node': nodeId, 'deltas': deltas});
+    _lastPushStartedAt = DateTime.now();
+    _lastPushCompletedAt = null;
+    _lastPushDeltaCount = deltas.length;
+    _lastPushDeltaTypes = _countDeltaTypes(deltas);
+    _lastPushMergedCount = null;
+    _lastPushWatermark = null;
+    _lastPushError = null;
 
     debugPrint('[Sync] Pushing ${deltas.length} deltas');
 
-    final int statusCode;
-    final String responseBody;
-    if (_cryptoClient != null) {
-      final httpResponse = await _cryptoClient.post(
-        'api/sync/deltas',
-        headers: {'Content-Type': 'application/json'},
-        body: body,
-      );
-      final bytes = await httpResponse.fold<List<int>>(
-        <int>[],
-        (prev, chunk) => prev..addAll(chunk),
-      );
-      responseBody = utf8.decode(bytes, allowMalformed: true);
-      statusCode = httpResponse.statusCode;
-    } else {
-      final uri = Uri.parse('$baseUrl/api/sync/deltas');
-      final response = await _plainClient
-          .post(uri, headers: {'Content-Type': 'application/json'}, body: body)
-          .timeout(const Duration(seconds: 10));
-      responseBody = response.body;
-      statusCode = response.statusCode;
+    try {
+      final nodeId = await getOrCreateNodeId();
+      final body = jsonEncode({'node': nodeId, 'deltas': deltas});
+
+      final int statusCode;
+      final String responseBody;
+      if (_cryptoClient != null) {
+        final httpResponse = await _cryptoClient.post(
+          'api/sync/deltas',
+          headers: {'Content-Type': 'application/json'},
+          body: body,
+        );
+        final bytes = await httpResponse.fold<List<int>>(
+          <int>[],
+          (prev, chunk) => prev..addAll(chunk),
+        );
+        responseBody = utf8.decode(bytes, allowMalformed: true);
+        statusCode = httpResponse.statusCode;
+      } else {
+        final uri = Uri.parse('$baseUrl/api/sync/deltas');
+        final response = await _plainClient
+            .post(
+              uri,
+              headers: {'Content-Type': 'application/json'},
+              body: body,
+            )
+            .timeout(const Duration(seconds: 10));
+        responseBody = response.body;
+        statusCode = response.statusCode;
+      }
+
+      if (statusCode == 403) {
+        debugPrint('[CrdtSync] HTTP 403 — triggering pairing flow');
+        await onNeedsPairing?.call();
+        throw Exception('Pairing required (HTTP 403)');
+      }
+
+      if (statusCode != 200) {
+        throw Exception('Sync push failed: HTTP $statusCode');
+      }
+
+      final json = jsonDecode(responseBody) as Map<String, dynamic>;
+      final merged = (json['merged'] as num?)?.toInt() ?? 0;
+      final watermark = json['watermark'] as String?;
+
+      // Advance our clock to the desktop's post-merge watermark
+      if (watermark != null && watermark != '0') {
+        try {
+          clock.receive(HybridTimestamp.parse(watermark));
+        } catch (_) {}
+      }
+
+      _lastPushCompletedAt = DateTime.now();
+      _lastPushMergedCount = merged;
+      _lastPushWatermark = watermark;
+      debugPrint('[Sync] Push completed, server processed $merged deltas');
+      return merged;
+    } catch (e) {
+      _lastPushCompletedAt = DateTime.now();
+      _lastPushError = e.toString();
+      rethrow;
     }
+  }
 
-    if (statusCode == 403) {
-      debugPrint('[CrdtSync] HTTP 403 — triggering pairing flow');
-      await onNeedsPairing?.call();
-      throw Exception('Pairing required (HTTP 403)');
+  Future<P2pSyncDiagnostics> debugDiagnostics() async {
+    final watermarks = await db.select(db.syncWatermarks).get();
+    final tasks = await db.select(db.tasks).get();
+    final worklogs = await db.select(db.worklogEntries).get();
+    final timers = await db.select(db.timerEntries).get();
+    final projects = await db.select(db.projects).get();
+    final dailyPlans = await db.select(db.dailyPlanEntries).get();
+    final dayPlanTasks = await db.select(db.dayPlanTasks).get();
+    final categoryChips = await db.select(db.categoryChips).get();
+
+    final recentWorklogs = worklogs.toList()
+      ..sort((a, b) => b.created.compareTo(a.created));
+
+    return P2pSyncDiagnostics(
+      desktopWatermark: await _getDesktopWatermark(),
+      localCounts: {
+        'task': tasks.length,
+        'worklog': worklogs.length,
+        'timer': timers.length,
+        'project': projects.length,
+        'dailyPlan': dailyPlans.length,
+        'dayPlanTask': dayPlanTasks.length,
+        'categoryChip': categoryChips.length,
+      },
+      watermarks: watermarks
+          .map(
+            (row) => {
+              'nodeId': row.nodeId,
+              'direction': row.direction,
+              'lastHlc': row.lastHlc,
+              'updatedAt': row.updatedAt,
+            },
+          )
+          .toList(),
+      recentWorklogs: recentWorklogs.take(8).map((row) {
+        final doc = WorklogDocument.fromDrift(worklog: row, clock: clock);
+        return P2pSyncRecentWorklog(
+          id: row.id,
+          taskId: doc.taskId,
+          date: doc.date,
+          durationMs: doc.durationMs,
+          category: doc.category,
+          isDeleted: doc.isDeleted,
+          crdtClock: row.crdtClock,
+        );
+      }).toList(),
+      lastPushStartedAt: _lastPushStartedAt,
+      lastPushCompletedAt: _lastPushCompletedAt,
+      lastPushDeltaCount: _lastPushDeltaCount,
+      lastPushDeltaTypes: _lastPushDeltaTypes,
+      lastPushMergedCount: _lastPushMergedCount,
+      lastPushWatermark: _lastPushWatermark,
+      lastPushError: _lastPushError,
+    );
+  }
+
+  Map<String, int> _countDeltaTypes(List<Map<String, dynamic>> deltas) {
+    final counts = <String, int>{};
+    for (final delta in deltas) {
+      final type = delta['type'] as String? ?? 'unknown';
+      counts[type] = (counts[type] ?? 0) + 1;
     }
-
-    if (statusCode != 200) {
-      throw Exception('Sync push failed: HTTP $statusCode');
-    }
-
-    final json = jsonDecode(responseBody) as Map<String, dynamic>;
-    final merged = (json['merged'] as num?)?.toInt() ?? 0;
-    final watermark = json['watermark'] as String?;
-
-    // Advance our clock to the desktop's post-merge watermark
-    if (watermark != null && watermark != '0') {
-      try {
-        clock.receive(HybridTimestamp.parse(watermark));
-      } catch (_) {}
-    }
-
-    debugPrint('[Sync] Push completed, server processed $merged deltas');
-    return merged;
+    return counts;
   }
 
   // ============================================================

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -26,7 +26,12 @@ class SettingsScreen extends StatefulWidget {
   /// _DisplaySettingsSection creates its own (dual-instance bug fix).
   final DisplaySettingsService? displaySettings;
 
-  const SettingsScreen({super.key, this.apiClient, this.crdtSyncService, this.displaySettings});
+  const SettingsScreen({
+    super.key,
+    this.apiClient,
+    this.crdtSyncService,
+    this.displaySettings,
+  });
 
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
@@ -120,9 +125,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, true),
-            style: FilledButton.styleFrom(
-              backgroundColor: Colors.red,
-            ),
+            style: FilledButton.styleFrom(backgroundColor: Colors.red),
             child: const Text('Forget Server'),
           ),
         ],
@@ -137,14 +140,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
       await widget.crdtSyncService?.revokePairing();
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Server forgotten. Please restart the app.')),
+          const SnackBar(
+            content: Text('Server forgotten. Please restart the app.'),
+          ),
         );
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to forget server: $e')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to forget server: $e')));
       }
     } finally {
       if (mounted) setState(() => _forgetting = false);
@@ -157,17 +162,58 @@ class _SettingsScreenState extends State<SettingsScreen> {
       final pushed = await widget.crdtSyncService?.forceFullSync() ?? 0;
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Full sync complete. Pushed $pushed deltas. Pull will refresh shortly.')),
+          SnackBar(
+            content: Text(
+              'Full sync complete. Pushed $pushed deltas. Pull will refresh shortly.',
+            ),
+          ),
         );
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Full sync failed: $e')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Full sync failed: $e')));
       }
     } finally {
       if (mounted) setState(() => _fullSyncing = false);
+    }
+  }
+
+  Future<void> _showP2pDiagnostics() async {
+    final sync = widget.crdtSyncService;
+    if (sync == null) return;
+
+    try {
+      final diagnostics = await sync.debugDiagnostics();
+      if (!mounted) return;
+      await showDialog<void>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('P2P Sync Diagnostics'),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: SingleChildScrollView(
+              child: SelectableText(
+                diagnostics.toDebugText(),
+                style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Close'),
+            ),
+          ],
+        ),
+      );
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Diagnostics failed: $e')));
+      }
     }
   }
 
@@ -193,7 +239,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
       final categories = await client.getCategories();
       setState(() {
         _categoryChips = chips;
-        _categories = categories.isNotEmpty ? categories : _getDefaultCategories();
+        _categories = categories.isNotEmpty
+            ? categories
+            : _getDefaultCategories();
         _loadingChips = false;
       });
     } catch (e) {
@@ -206,7 +254,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   List<String> _getDefaultCategories() {
-    return ['Learning', 'Working', 'Side-project', 'Administrative', 'Meetings'];
+    return [
+      'Learning',
+      'Working',
+      'Side-project',
+      'Administrative',
+      'Meetings',
+    ];
   }
 
   Future<void> _addChip() async {
@@ -223,15 +277,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _chipController.clear();
       await _loadChips();
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Added "$chip" to $category')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Added "$chip" to $category')));
       }
     } else {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to add chip')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Failed to add chip')));
       }
     }
   }
@@ -251,9 +305,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
       }
     } else {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to remove chip')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Failed to remove chip')));
       }
     }
   }
@@ -279,13 +333,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
       final url = _controller.text.trim();
       // Use root health endpoint (no auth required)
       final uri = Uri.parse('$url/');
-      final response =
-          await http.get(uri).timeout(const Duration(seconds: 5));
+      final response = await http.get(uri).timeout(const Duration(seconds: 5));
       if (response.statusCode == 200) {
         setState(() => _testResult = 'Connected successfully!');
       } else {
         setState(
-            () => _testResult = 'Connection failed: HTTP ${response.statusCode}');
+          () => _testResult = 'Connection failed: HTTP ${response.statusCode}',
+        );
       }
     } catch (e) {
       setState(() => _testResult = 'Connection failed: $e');
@@ -328,7 +382,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void _startStatusPolling(String url) {
     _statusPollTimer?.cancel();
     final client = widget.apiClient ?? AgentApiClient(baseUrl: url);
-    _statusPollTimer = Timer.periodic(const Duration(seconds: 5), (timer) async {
+    _statusPollTimer = Timer.periodic(const Duration(seconds: 5), (
+      timer,
+    ) async {
       final status = await client.getSelfUpdateStatus();
 
       if (status == null) return;
@@ -354,9 +410,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
           final snackMsg = status.isSuccess
               ? 'Update complete!'
               : 'Build failed. Check logs for details.';
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(snackMsg)),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(snackMsg)));
         }
       }
     });
@@ -411,8 +467,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text('Comment Chip Presets',
-                      style: Theme.of(context).textTheme.titleMedium),
+                  Text(
+                    'Comment Chip Presets',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
                   TextButton.icon(
                     onPressed: () async {
                       _selectedCategory = null;
@@ -468,16 +526,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     decoration: const InputDecoration(
                       hintText: 'New chip text',
                       border: OutlineInputBorder(),
-                      contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                      contentPadding: EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 8,
+                      ),
                     ),
                     onSubmitted: (_) => _addChip(),
                   ),
                 ),
                 const SizedBox(width: 8),
-                FilledButton(
-                  onPressed: _addChip,
-                  child: const Text('Add'),
-                ),
+                FilledButton(onPressed: _addChip, child: const Text('Add')),
               ],
             ),
           ),
@@ -504,8 +562,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text('Sync Server URL',
-                  style: Theme.of(context).textTheme.titleMedium),
+              Text(
+                'Sync Server URL',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
               const SizedBox(height: 8),
               TextField(
                 controller: _controller,
@@ -526,14 +586,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         ? const SizedBox(
                             width: 16,
                             height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2))
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
                         : const Text('Test Connection'),
                   ),
                   const SizedBox(width: 12),
-                  FilledButton(
-                    onPressed: _save,
-                    child: const Text('Save'),
-                  ),
+                  FilledButton(onPressed: _save, child: const Text('Save')),
                 ],
               ),
               if (_testResult != null) ...[
@@ -558,8 +616,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text('Server Connection',
-                    style: Theme.of(context).textTheme.titleMedium),
+                Text(
+                  'Server Connection',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
                 const SizedBox(height: 8),
                 const Text(
                   'Remove pairing with the current sync server.',
@@ -575,10 +635,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
                             width: 16,
                             height: 16,
                             child: CircularProgressIndicator(
-                                strokeWidth: 2, color: Colors.white))
+                              strokeWidth: 2,
+                              color: Colors.white,
+                            ),
+                          )
                         : const Icon(Icons.sync),
                     label: Text(
-                        _fullSyncing ? 'Syncing...' : 'Force Full Sync'),
+                      _fullSyncing ? 'Syncing...' : 'Force Full Sync',
+                    ),
                   ),
                 ),
                 const SizedBox(height: 8),
@@ -590,15 +654,31 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 SizedBox(
                   width: double.infinity,
                   child: OutlinedButton.icon(
+                    onPressed: _showP2pDiagnostics,
+                    icon: const Icon(Icons.bug_report_outlined),
+                    label: const Text('P2P Sync Diagnostics'),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  'Shows local worklog counts, watermarks, and last push result.',
+                  style: TextStyle(color: Colors.grey, fontSize: 12),
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton.icon(
                     onPressed: _forgetting ? null : _forgetServer,
                     icon: _forgetting
                         ? const SizedBox(
                             width: 16,
                             height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2))
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
                         : const Icon(Icons.link_off, color: Colors.red),
                     label: Text(
-                        _forgetting ? 'Forgetting...' : 'Forget This Server'),
+                      _forgetting ? 'Forgetting...' : 'Forget This Server',
+                    ),
                     style: OutlinedButton.styleFrom(
                       foregroundColor: Colors.red,
                     ),
@@ -615,8 +695,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text('App Updates',
-                  style: Theme.of(context).textTheme.titleMedium),
+              Text(
+                'App Updates',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
               const SizedBox(height: 8),
               const Text(
                 'Build and install the latest version on your device.',
@@ -631,15 +713,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     color: _updateStatus == 'Update complete!'
                         ? Colors.green.shade50
                         : _updateStatus == 'Build failed'
-                            ? Colors.red.shade50
-                            : Colors.blue.shade50,
+                        ? Colors.red.shade50
+                        : Colors.blue.shade50,
                     borderRadius: BorderRadius.circular(8),
                     border: Border.all(
                       color: _updateStatus == 'Update complete!'
                           ? Colors.green.shade200
                           : _updateStatus == 'Build failed'
-                              ? Colors.red.shade200
-                              : Colors.blue.shade200,
+                          ? Colors.red.shade200
+                          : Colors.blue.shade200,
                     ),
                   ),
                   child: Column(
@@ -672,8 +754,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                                 color: _updateStatus == 'Update complete!'
                                     ? Colors.green.shade700
                                     : _updateStatus == 'Build failed'
-                                        ? Colors.red.shade700
-                                        : Colors.blue.shade700,
+                                    ? Colors.red.shade700
+                                    : Colors.blue.shade700,
                               ),
                             ),
                           ),
@@ -763,7 +845,8 @@ class _DisplaySettingsSection extends StatefulWidget {
   const _DisplaySettingsSection({required this.service});
 
   @override
-  State<_DisplaySettingsSection> createState() => _DisplaySettingsSectionState();
+  State<_DisplaySettingsSection> createState() =>
+      _DisplaySettingsSectionState();
 }
 
 class _DisplaySettingsSectionState extends State<_DisplaySettingsSection> {
@@ -802,8 +885,7 @@ class _DisplaySettingsSectionState extends State<_DisplaySettingsSection> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text('Display',
-                  style: Theme.of(context).textTheme.titleMedium),
+              Text('Display', style: Theme.of(context).textTheme.titleMedium),
               const SizedBox(height: 8),
               const Text(
                 'Customize brightness, accent color, and contrast.',
@@ -812,23 +894,25 @@ class _DisplaySettingsSectionState extends State<_DisplaySettingsSection> {
               const SizedBox(height: 16),
 
               // Brightness
-              Text('Brightness',
-                  style: Theme.of(context).textTheme.bodyMedium),
+              Text('Brightness', style: Theme.of(context).textTheme.bodyMedium),
               const SizedBox(height: 8),
               SegmentedButton<DisplayBrightness>(
                 segments: const [
                   ButtonSegment(
-                      value: DisplayBrightness.light,
-                      label: Text('Light'),
-                      icon: Icon(Icons.light_mode)),
+                    value: DisplayBrightness.light,
+                    label: Text('Light'),
+                    icon: Icon(Icons.light_mode),
+                  ),
                   ButtonSegment(
-                      value: DisplayBrightness.dark,
-                      label: Text('Dark'),
-                      icon: Icon(Icons.dark_mode)),
+                    value: DisplayBrightness.dark,
+                    label: Text('Dark'),
+                    icon: Icon(Icons.dark_mode),
+                  ),
                   ButtonSegment(
-                      value: DisplayBrightness.system,
-                      label: Text('System'),
-                      icon: Icon(Icons.brightness_auto)),
+                    value: DisplayBrightness.system,
+                    label: Text('System'),
+                    icon: Icon(Icons.brightness_auto),
+                  ),
                 ],
                 selected: {_service.brightness},
                 onSelectionChanged: (selected) {
@@ -838,14 +922,17 @@ class _DisplaySettingsSectionState extends State<_DisplaySettingsSection> {
               const SizedBox(height: 20),
 
               // Accent color
-              Text('Accent Color',
-                  style: Theme.of(context).textTheme.bodyMedium),
+              Text(
+                'Accent Color',
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
               const SizedBox(height: 8),
               Wrap(
                 spacing: 8,
                 runSpacing: 8,
                 children: kAccentColors.map((color) {
-                  final isSelected = _service.accentColor.toARGB32() == color.toARGB32();
+                  final isSelected =
+                      _service.accentColor.toARGB32() == color.toARGB32();
                   return GestureDetector(
                     onTap: () => _service.setAccentColor(color),
                     child: Container(
@@ -863,12 +950,16 @@ class _DisplaySettingsSectionState extends State<_DisplaySettingsSection> {
                                   color: color.withAlpha(128),
                                   blurRadius: 8,
                                   spreadRadius: 2,
-                                )
+                                ),
                               ]
                             : null,
                       ),
                       child: isSelected
-                          ? const Icon(Icons.check, color: Colors.white, size: 20)
+                          ? const Icon(
+                              Icons.check,
+                              color: Colors.white,
+                              size: 20,
+                            )
                           : null,
                     ),
                   );
@@ -877,19 +968,20 @@ class _DisplaySettingsSectionState extends State<_DisplaySettingsSection> {
               const SizedBox(height: 20),
 
               // Contrast
-              Text('Contrast',
-                  style: Theme.of(context).textTheme.bodyMedium),
+              Text('Contrast', style: Theme.of(context).textTheme.bodyMedium),
               const SizedBox(height: 8),
               SegmentedButton<DisplayContrast>(
                 segments: const [
                   ButtonSegment(
-                      value: DisplayContrast.normal,
-                      label: Text('Normal'),
-                      icon: Icon(Icons.text_fields)),
+                    value: DisplayContrast.normal,
+                    label: Text('Normal'),
+                    icon: Icon(Icons.text_fields),
+                  ),
                   ButtonSegment(
-                      value: DisplayContrast.high,
-                      label: Text('High'),
-                      icon: Icon(Icons.contrast)),
+                    value: DisplayContrast.high,
+                    label: Text('High'),
+                    icon: Icon(Icons.contrast),
+                  ),
                 ],
                 selected: {_service.contrast},
                 onSelectionChanged: (selected) {


### PR DESCRIPTION
## Summary
- Fix phone P2P retry behavior so failed local deltas, including worklogs, are retried instead of dropping non-timer deltas.
- Add phone-side P2P sync diagnostics in Settings and clarify desktop sync status as local document counts.
- Fix AVO-106 quick-capture ticket payload by sending a valid priority and required assignee so queued captures can drain.

## Verification
- flutter analyze (existing warnings/infos only)
- dart analyze (existing warnings only)
- flutter test test/integration/sync_roundtrip_test.dart
- dart test test/services/sync_api_service_test.dart
- flutter build apk --debug
- adb install/launch on phone; verified P2P badge cleared after sync and quick-capture payload fix installed