### PR TITLE
AVO-108: Fix phone share-to-learning capture

### DIFF
--- a/docs/uat/2026-04-30-AVO-108-phone-share-learning-debug-apk.md
+++ b/docs/uat/2026-04-30-AVO-108-phone-share-learning-debug-apk.md
@@ -2,7 +2,8 @@
 
 Date: 2026-04-30
 Branch: `feature/AVO-108-share-learning-capture`
-Commit: `9dec79aa9ae573beffc4cd301fa84224d2a7c526`
+APK build commit: `9dec79aa9ae573beffc4cd301fa84224d2a7c526`
+Documentation commit reviewed: `689a3033fa6dc4c95e239fda9891625c4a354124`
 
 ## Build
 

--- a/docs/uat/2026-04-30-AVO-108-phone-share-learning-debug-apk.md
+++ b/docs/uat/2026-04-30-AVO-108-phone-share-learning-debug-apk.md
@@ -1,0 +1,60 @@
+# AVO-108 Phone Share-to-Learning Debug APK UAT Notes
+
+Date: 2026-04-30
+Branch: `feature/AVO-108-share-learning-capture`
+Commit: `9dec79aa9ae573beffc4cd301fa84224d2a7c526`
+
+## Build
+
+- Command: `cd phone && flutter build apk --debug`
+- Result: passed
+- APK: `phone/build/app/outputs/flutter-apk/app-debug.apk`
+- APK size: `206804067 bytes`
+- APK SHA-256: `f089d3c253c1753f63c7ee0374bd341ed51766caf1ae605f90c887a8d82d3bdc`
+- Build timestamp: `2026-04-30 12:35:04 +0700`
+
+## Device Availability
+
+- Command: `cd phone && flutter devices`
+- Result: no Android phone or emulator was available in this environment.
+- Detected devices: Linux desktop and Chrome web only.
+- Physical phone validation status: blocked for builder; requires Sinh UAT on an Android phone.
+
+## Sinh UAT Handoff
+
+Install the debug APK on the Android phone, then run TS1 through TS5 from `agent-teams/requirements/artifacts/2026-04-30-avodah-phone-share-learning-capture-uat.md`.
+
+Suggested install command when the phone is connected with USB debugging enabled:
+
+```bash
+cd /home/sinh/git-repos/sinh-x/tools/avodah/phone
+flutter install --debug
+```
+
+If installing the already-built APK directly:
+
+```bash
+adb install -r build/app/outputs/flutter-apk/app-debug.apk
+```
+
+Validation path:
+
+1. Confirm the phone app is paired and PA board data loads.
+2. Open a browser URL, for example `https://example.com/avo-108-share-test`.
+3. Share the URL to Avodah.
+4. Confirm Quick Capture opens with the URL populated.
+5. Leave Project set to `learning`.
+6. Tap Save Capture.
+7. On desktop, run `opa board --project learning`.
+8. Record the resulting `LM-*` ticket ID.
+9. Record whether any sync error or pending/failed message appeared.
+10. For failure feedback validation, temporarily make `/api/tickets` unreachable if practical, repeat the share/save flow, and confirm the app shows pending or failed sync feedback instead of implying ticket creation succeeded.
+
+## UAT Fields To Record
+
+- Shared URL source: not tested by builder; record during Sinh UAT.
+- Resulting LM ticket ID: not tested by builder; record during Sinh UAT.
+- Sync status/error: not tested by builder; record during Sinh UAT.
+- AC1 partial: marked for Sinh UAT because no Android device was available here.
+- AC3 partial: marked for Sinh UAT because no Android device was available here.
+- AC5: debug APK produced; physical install/share validation blocked for builder and handed off to Sinh.

--- a/packages/avodah_core/lib/version.dart
+++ b/packages/avodah_core/lib/version.dart
@@ -1,4 +1,4 @@
 /// Single source of truth for the Avodah version.
 /// Updated by tool/bump_version.dart and tool/bump_build.dart — do not edit manually.
 const String avodahVersion = '0.4.3';
-const int avodahBuildNumber = 92;
+const int avodahBuildNumber = 93;

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -335,7 +335,27 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     }
 
     try {
-      await sync.syncPendingCaptures();
+      final summary = await sync.syncPendingCaptures();
+      if (!summary.hasFailures) return;
+
+      final messenger = _scaffoldMessengerKey.currentState;
+      if (messenger != null) {
+        SchedulerBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          messenger.showSnackBar(
+            SnackBar(
+              content: Text(
+                'Capture sync failed for ${summary.failedCount} item(s); will retry',
+              ),
+              duration: const Duration(seconds: 4),
+              action: SnackBarAction(
+                label: 'Retry',
+                onPressed: () => _syncCaptures(),
+              ),
+            ),
+          );
+        });
+      }
     } catch (e) {
       debugPrint('[CaptureSync] Sync failed: $e');
       // Surface capture sync failure to user via snackbar
@@ -740,7 +760,7 @@ class _HomeShellState extends State<_HomeShell> {
               actions: [
                 ValueListenableBuilder<SyncConnectionState>(
                   valueListenable: widget.dashboardProvider.connectionState,
-                  builder: (_, state, __) => Padding(
+                  builder: (context, state, child) => Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 12),
                     child: ConnectionIndicator(state: state),
                   ),
@@ -771,7 +791,7 @@ class _HomeShellState extends State<_HomeShell> {
               actions: [
                 ValueListenableBuilder<SyncConnectionState>(
                   valueListenable: widget.dashboardProvider.connectionState,
-                  builder: (_, state, __) => Padding(
+                  builder: (context, state, child) => Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 12),
                     child: ConnectionIndicator(state: state),
                   ),
@@ -806,7 +826,7 @@ class _HomeShellState extends State<_HomeShell> {
               actions: [
                 ValueListenableBuilder<SyncConnectionState>(
                   valueListenable: widget.dashboardProvider.connectionState,
-                  builder: (_, state, __) => Padding(
+                  builder: (context, state, child) => Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 12),
                     child: ConnectionIndicator(state: state),
                   ),

--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -109,8 +109,14 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
     // Write service for local CRDT mutations (timer, task, worklog)
     final writeService = LocalWriteService(db: db, clock: clock);
 
-    // One-time backfill: set category on worklogs from task-level timers
-    await writeService.backfillWorklogCategories();
+    // One-time backfill: set category on worklogs from task-level timers.
+    // This is opportunistic and should not block share-intent startup if the
+    // CRDT database is briefly locked by sync or a previous process shutdown.
+    try {
+      await writeService.backfillWorklogCategories();
+    } catch (e) {
+      debugPrint('[Init] Worklog category backfill skipped: $e');
+    }
 
     // Load stored server URL (already HTTP format)
     final httpBaseUrl = await SettingsScreen.loadServerUrl();

--- a/phone/lib/screens/quick_capture_screen.dart
+++ b/phone/lib/screens/quick_capture_screen.dart
@@ -33,7 +33,14 @@ class QuickCaptureScreen extends StatefulWidget {
 }
 
 class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
-  static const _categories = ['learning', 'personal', 'work', 'video', 'article', 'code'];
+  static const _categories = [
+    'learning',
+    'personal',
+    'work',
+    'video',
+    'article',
+    'code',
+  ];
 
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _titleController;
@@ -41,7 +48,7 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
   late final TextEditingController _notesController;
 
   String _category = 'learning';
-  String _project = 'learning-management';
+  String _project = 'learning';
   List<TicketProject> _projects = [];
   bool _loadingProjects = false;
   bool _submitting = false;
@@ -66,9 +73,7 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
     _urlController = TextEditingController(
       text: widget.sharedUrl ?? extractedUrl ?? '',
     );
-    _notesController = TextEditingController(
-      text: widget.sharedText,
-    );
+    _notesController = TextEditingController(text: widget.sharedText);
 
     // Trigger title extraction if URL is pre-filled
     if (hasUrl) {
@@ -174,17 +179,17 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
       });
 
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Capture saved')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Capture saved')));
         Navigator.pop(context, true);
       }
     } catch (e) {
       if (mounted) {
         setState(() => _submitting = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to save: $e')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to save: $e')));
       }
     }
   }
@@ -241,9 +246,21 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
                   border: OutlineInputBorder(),
                 ),
                 items: _projects.isEmpty
-                    ? [const DropdownMenuItem(value: 'learning-management', child: Text('learning-management'))]
-                    : _projects.map((p) => DropdownMenuItem(value: p.key, child: Text(p.key))).toList(),
-                onChanged: (v) => setState(() => _project = v ?? 'learning-management'),
+                    ? [
+                        const DropdownMenuItem(
+                          value: 'learning',
+                          child: Text('learning'),
+                        ),
+                      ]
+                    : _projects
+                          .map(
+                            (p) => DropdownMenuItem(
+                              value: p.key,
+                              child: Text(p.key),
+                            ),
+                          )
+                          .toList(),
+                onChanged: (v) => setState(() => _project = v ?? 'learning'),
               ),
             const SizedBox(height: 16),
 

--- a/phone/lib/screens/quick_capture_screen.dart
+++ b/phone/lib/screens/quick_capture_screen.dart
@@ -164,7 +164,7 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
 
     try {
       // Save to local Drift table (offline-first)
-      await widget.captureSyncService.saveCapture(
+      final captureId = await widget.captureSyncService.saveCapture(
         title: title.isEmpty ? (url.isEmpty ? 'Quick capture' : url) : title,
         url: url.isNotEmpty ? url : null,
         notes: notes.isNotEmpty ? notes : null,
@@ -173,15 +173,19 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
         project: _project,
       );
 
-      // Trigger immediate sync to PA (best-effort — doesn't block UI)
-      widget.captureSyncService.syncPendingCaptures().catchError((e) {
-        debugPrint('[QuickCapture] Sync error: $e');
-      });
+      final syncSummary = await widget.captureSyncService.syncPendingCaptures();
+      final syncOutcome = syncSummary.outcomeFor(captureId);
+      final message = switch (syncOutcome?.status) {
+        CaptureSyncStatus.synced => 'Capture saved and ticket created',
+        CaptureSyncStatus.failed =>
+          'Capture saved locally; ticket sync failed; will retry',
+        null => 'Capture saved locally; ticket sync pending',
+      };
 
       if (mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showSnackBar(const SnackBar(content: Text('Capture saved')));
+        ).showSnackBar(SnackBar(content: Text(message)));
         Navigator.pop(context, true);
       }
     } catch (e) {
@@ -240,7 +244,7 @@ class _QuickCaptureScreenState extends State<QuickCaptureScreen> {
             else
               DropdownButtonFormField<String>(
                 key: ValueKey(_project),
-                value: _project,
+                initialValue: _project,
                 decoration: const InputDecoration(
                   labelText: 'Project',
                   border: OutlineInputBorder(),

--- a/phone/lib/services/capture_sync_service.dart
+++ b/phone/lib/services/capture_sync_service.dart
@@ -26,9 +26,9 @@ class CaptureSyncService {
   /// Errors are logged but not thrown — sync failures should not crash the app.
   Future<void> syncPendingCaptures() async {
     // Fetch unsynced captures
-    final captures = await (db.select(db.pendingCaptures)
-          ..where((t) => t.synced.equals(false)))
-        .get();
+    final captures = await (db.select(
+      db.pendingCaptures,
+    )..where((t) => t.synced.equals(false))).get();
 
     if (captures.isEmpty) return;
 
@@ -68,11 +68,12 @@ class CaptureSyncService {
     await apiClient.createTicket(data);
 
     // Mark as synced
-    await (db.update(db.pendingCaptures)
-          ..where((t) => t.id.equals(capture.id)))
+    await (db.update(db.pendingCaptures)..where((t) => t.id.equals(capture.id)))
         .write(PendingCapturesCompanion(synced: Value(true)));
 
-    debugPrint('[CaptureSync] Synced capture ${capture.id}: "${capture.title}"');
+    debugPrint(
+      '[CaptureSync] Synced capture ${capture.id}: "${capture.title}"',
+    );
   }
 
   /// Builds summary field from URL + notes content.
@@ -105,9 +106,11 @@ class CaptureSyncService {
     String? notes,
     String category = 'learning',
     String? sharedText,
-    String project = 'learning-management',
+    String project = 'learning',
   }) async {
-    final id = await db.into(db.pendingCaptures).insert(
+    final id = await db
+        .into(db.pendingCaptures)
+        .insert(
           PendingCapturesCompanion.insert(
             title: title,
             url: Value(url),
@@ -126,11 +129,12 @@ class CaptureSyncService {
 
   /// Returns the count of unsynced captures.
   Future<int> unsyncedCount() async {
-    final count = await (db.selectOnly(db.pendingCaptures)
-          ..where(db.pendingCaptures.synced.equals(false))
-          ..addColumns([db.pendingCaptures.id.count()]))
-        .map((row) => row.read(db.pendingCaptures.id.count()))
-        .getSingle();
+    final count =
+        await (db.selectOnly(db.pendingCaptures)
+              ..where(db.pendingCaptures.synced.equals(false))
+              ..addColumns([db.pendingCaptures.id.count()]))
+            .map((row) => row.read(db.pendingCaptures.id.count()))
+            .getSingle();
     return count ?? 0;
   }
 }

--- a/phone/lib/services/capture_sync_service.dart
+++ b/phone/lib/services/capture_sync_service.dart
@@ -6,6 +6,43 @@ import 'package:flutter/foundation.dart';
 import '../storage/phone_database.dart';
 import 'agent_api_client.dart';
 
+enum CaptureSyncStatus { synced, failed }
+
+class CaptureSyncOutcome {
+  const CaptureSyncOutcome({
+    required this.captureId,
+    required this.status,
+    this.error,
+  });
+
+  final int captureId;
+  final CaptureSyncStatus status;
+  final Object? error;
+}
+
+class CaptureSyncSummary {
+  const CaptureSyncSummary(this.outcomes);
+
+  final List<CaptureSyncOutcome> outcomes;
+
+  int get syncedCount => outcomes
+      .where((outcome) => outcome.status == CaptureSyncStatus.synced)
+      .length;
+
+  int get failedCount => outcomes
+      .where((outcome) => outcome.status == CaptureSyncStatus.failed)
+      .length;
+
+  bool get hasFailures => failedCount > 0;
+
+  CaptureSyncOutcome? outcomeFor(int captureId) {
+    for (final outcome in outcomes) {
+      if (outcome.captureId == captureId) return outcome;
+    }
+    return null;
+  }
+}
+
 /// Syncs pending captures from local Drift storage to the PA system via API.
 ///
 /// Runs on:
@@ -27,24 +64,40 @@ class CaptureSyncService {
   ///
   /// Skipped if already syncing ( concurrent call protection).
   /// Errors are logged but not thrown — sync failures should not crash the app.
-  Future<void> syncPendingCaptures() async {
+  Future<CaptureSyncSummary> syncPendingCaptures() async {
     // Fetch unsynced captures
     final captures = await (db.select(
       db.pendingCaptures,
     )..where((t) => t.synced.equals(false))).get();
 
-    if (captures.isEmpty) return;
+    if (captures.isEmpty) return const CaptureSyncSummary([]);
 
     debugPrint('[CaptureSync] Syncing ${captures.length} capture(s)');
 
+    final outcomes = <CaptureSyncOutcome>[];
     for (final capture in captures) {
       try {
         await _syncCapture(capture);
+        outcomes.add(
+          CaptureSyncOutcome(
+            captureId: capture.id,
+            status: CaptureSyncStatus.synced,
+          ),
+        );
       } catch (e) {
         // Log but don't throw — we don't want to lose other captures
         debugPrint('[CaptureSync] Failed to sync capture ${capture.id}: $e');
+        outcomes.add(
+          CaptureSyncOutcome(
+            captureId: capture.id,
+            status: CaptureSyncStatus.failed,
+            error: e,
+          ),
+        );
       }
     }
+
+    return CaptureSyncSummary(outcomes);
   }
 
   /// Syncs a single capture to the PA system and marks it as synced.

--- a/phone/lib/services/capture_sync_service.dart
+++ b/phone/lib/services/capture_sync_service.dart
@@ -15,6 +15,9 @@ import 'agent_api_client.dart';
 ///
 /// Uses insertOnConflictUpdate for the synced flag — safe to call repeatedly.
 class CaptureSyncService {
+  static const _learningProject = 'learning';
+  static const _oldLearningProject = 'learning-management';
+
   final PhoneDatabase db;
   final AgentApiClient apiClient;
 
@@ -47,7 +50,7 @@ class CaptureSyncService {
   /// Syncs a single capture to the PA system and marks it as synced.
   Future<void> _syncCapture(PendingCapture capture) async {
     final data = <String, dynamic>{
-      'project': capture.project,
+      'project': _normalizeProject(capture.project),
       'title': capture.title,
       'type': 'idea',
       'status': 'idea',
@@ -74,6 +77,11 @@ class CaptureSyncService {
     debugPrint(
       '[CaptureSync] Synced capture ${capture.id}: "${capture.title}"',
     );
+  }
+
+  String _normalizeProject(String project) {
+    if (project == _oldLearningProject) return _learningProject;
+    return project;
   }
 
   /// Builds summary field from URL + notes content.

--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -71,6 +71,25 @@ class SettingsScreen extends StatefulWidget {
     await prefs.setString(kServerUrlKey, url);
     return url;
   }
+
+  static Uri syncStatusUriForServerUrl(String rawUrl) {
+    final trimmed = rawUrl.trim();
+    if (trimmed.isEmpty) {
+      throw const FormatException('Enter a server URL first');
+    }
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null || !uri.hasScheme || uri.host.isEmpty) {
+      throw FormatException('Invalid server URL: $trimmed');
+    }
+
+    final basePath = uri.path.replaceFirst(RegExp(r'/+$'), '');
+    return uri.replace(
+      path: '$basePath/api/sync/status',
+      query: null,
+      fragment: null,
+    );
+  }
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
@@ -330,9 +349,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
     });
 
     try {
-      final url = _controller.text.trim();
-      // Use root health endpoint (no auth required)
-      final uri = Uri.parse('$url/');
+      var url = _controller.text.trim();
+      if (url.isEmpty) {
+        url = await SettingsScreen.loadServerUrl();
+        _controller.text = url;
+      }
+      final uri = SettingsScreen.syncStatusUriForServerUrl(url);
       final response = await http.get(uri).timeout(const Duration(seconds: 5));
       if (response.statusCode == 200) {
         setState(() => _testResult = 'Connected successfully!');

--- a/phone/lib/storage/database_native.dart
+++ b/phone/lib/storage/database_native.dart
@@ -27,7 +27,13 @@ Future<AppDatabase> openPhoneDatabase() async {
     }
   }
   final file = File(p.join(dbFolder.path, 'avodah_phone.db'));
-  final executor = NativeDatabase.createInBackground(file);
+  final executor = NativeDatabase.createInBackground(
+    file,
+    setup: (db) {
+      db.execute('PRAGMA busy_timeout = 5000');
+      db.execute('PRAGMA journal_mode = WAL');
+    },
+  );
   return AppDatabase(executor);
 }
 
@@ -50,6 +56,12 @@ Future<PhoneDatabase> openPhoneLocalDatabase() async {
     }
   }
   final file = File(p.join(dbFolder.path, 'avodah_phone_local.db'));
-  final executor = NativeDatabase.createInBackground(file);
+  final executor = NativeDatabase.createInBackground(
+    file,
+    setup: (db) {
+      db.execute('PRAGMA busy_timeout = 5000');
+      db.execute('PRAGMA journal_mode = WAL');
+    },
+  );
   return PhoneDatabase(executor);
 }

--- a/phone/lib/storage/pending_captures.dart
+++ b/phone/lib/storage/pending_captures.dart
@@ -9,11 +9,9 @@ class PendingCaptures extends Table {
   TextColumn get title => text()();
   TextColumn get url => text().nullable()();
   TextColumn get notes => text().nullable()();
-  TextColumn get category =>
-      text().withDefault(const Constant('learning'))();
+  TextColumn get category => text().withDefault(const Constant('learning'))();
   TextColumn get sharedText => text().nullable()();
-  TextColumn get project =>
-      text().withDefault(const Constant('learning-management'))();
+  TextColumn get project => text().withDefault(const Constant('learning'))();
   IntColumn get createdAt => integer()();
   BoolColumn get synced => boolean().withDefault(const Constant(false))();
 }

--- a/phone/lib/storage/phone_database.g.dart
+++ b/phone/lib/storage/phone_database.g.dart
@@ -82,7 +82,7 @@ class $PendingCapturesTable extends PendingCaptures
     false,
     type: DriftSqlType.string,
     requiredDuringInsert: false,
-    defaultValue: const Constant('learning-management'),
+    defaultValue: const Constant('learning'),
   );
   static const VerificationMeta _createdAtMeta = const VerificationMeta(
     'createdAt',

--- a/phone/test/capture_sync_service_test.dart
+++ b/phone/test/capture_sync_service_test.dart
@@ -1,0 +1,106 @@
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:avodah_viewer/models/ticket.dart';
+import 'package:avodah_viewer/services/agent_api_client.dart';
+import 'package:avodah_viewer/services/capture_sync_service.dart';
+import 'package:avodah_viewer/storage/phone_database.dart';
+
+void main() {
+  driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
+
+  group('CaptureSyncService', () {
+    test(
+      'normalizes legacy learning-management project before retry',
+      () async {
+        final db = PhoneDatabase(NativeDatabase.memory());
+        final apiClient = _RecordingAgentApiClient();
+        final service = CaptureSyncService(db: db, apiClient: apiClient);
+
+        await _insertPendingCapture(db, project: 'learning-management');
+
+        await service.syncPendingCaptures();
+
+        expect(apiClient.createdTickets, hasLength(1));
+        expect(apiClient.createdTickets.single['project'], 'learning');
+
+        final captures = await db.select(db.pendingCaptures).get();
+        expect(captures.single.synced, isTrue);
+
+        await db.close();
+      },
+    );
+
+    test('leaves legacy capture unsynced when ticket creation fails', () async {
+      final db = PhoneDatabase(NativeDatabase.memory());
+      final apiClient = _RecordingAgentApiClient(shouldFail: true);
+      final service = CaptureSyncService(db: db, apiClient: apiClient);
+
+      await _insertPendingCapture(db, project: 'learning-management');
+
+      await service.syncPendingCaptures();
+
+      expect(apiClient.createdTickets, hasLength(1));
+      expect(apiClient.createdTickets.single['project'], 'learning');
+
+      final captures = await db.select(db.pendingCaptures).get();
+      expect(captures.single.synced, isFalse);
+
+      await db.close();
+    });
+  });
+}
+
+Future<void> _insertPendingCapture(
+  PhoneDatabase db, {
+  required String project,
+}) async {
+  await db
+      .into(db.pendingCaptures)
+      .insert(
+        PendingCapturesCompanion.insert(
+          title: 'Shared learning link',
+          url: const Value('https://example.com/article'),
+          notes: const Value('Read later'),
+          category: const Value('learning'),
+          sharedText: const Value('https://example.com/article'),
+          project: Value(project),
+          createdAt: DateTime.utc(2026, 4, 30).millisecondsSinceEpoch,
+        ),
+      );
+}
+
+class _RecordingAgentApiClient extends AgentApiClient {
+  _RecordingAgentApiClient({this.shouldFail = false})
+    : super(baseUrl: 'http://localhost');
+
+  final bool shouldFail;
+  final List<Map<String, dynamic>> createdTickets = [];
+
+  @override
+  Future<Ticket> createTicket(Map<String, dynamic> data) async {
+    createdTickets.add(Map<String, dynamic>.from(data));
+    if (shouldFail) {
+      throw AgentApiException(500, 'server unavailable');
+    }
+
+    final now = DateTime.utc(2026, 4, 30);
+    return Ticket(
+      id: 'LM-001',
+      project: data['project'] as String,
+      title: data['title'] as String,
+      status: 'idea',
+      priority: 'medium',
+      type: 'idea',
+      estimate: 'XS',
+      tags: const [],
+      blockedBy: const [],
+      docRefs: const [],
+      comments: const [],
+      subTickets: const [],
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+}

--- a/phone/test/capture_sync_service_test.dart
+++ b/phone/test/capture_sync_service_test.dart
@@ -20,10 +20,13 @@ void main() {
 
         await _insertPendingCapture(db, project: 'learning-management');
 
-        await service.syncPendingCaptures();
+        final summary = await service.syncPendingCaptures();
 
         expect(apiClient.createdTickets, hasLength(1));
         expect(apiClient.createdTickets.single['project'], 'learning');
+        expect(summary.syncedCount, 1);
+        expect(summary.failedCount, 0);
+        expect(summary.outcomes.single.status, CaptureSyncStatus.synced);
 
         final captures = await db.select(db.pendingCaptures).get();
         expect(captures.single.synced, isTrue);
@@ -39,10 +42,14 @@ void main() {
 
       await _insertPendingCapture(db, project: 'learning-management');
 
-      await service.syncPendingCaptures();
+      final summary = await service.syncPendingCaptures();
 
       expect(apiClient.createdTickets, hasLength(1));
       expect(apiClient.createdTickets.single['project'], 'learning');
+      expect(summary.syncedCount, 0);
+      expect(summary.failedCount, 1);
+      expect(summary.outcomes.single.status, CaptureSyncStatus.failed);
+      expect(summary.outcomes.single.error, isA<AgentApiException>());
 
       final captures = await db.select(db.pendingCaptures).get();
       expect(captures.single.synced, isFalse);

--- a/phone/test/capture_sync_service_test.dart
+++ b/phone/test/capture_sync_service_test.dart
@@ -23,7 +23,20 @@ void main() {
         final summary = await service.syncPendingCaptures();
 
         expect(apiClient.createdTickets, hasLength(1));
-        expect(apiClient.createdTickets.single['project'], 'learning');
+        expect(apiClient.createdTickets.single, {
+          'project': 'learning',
+          'title': 'Shared learning link',
+          'type': 'idea',
+          'status': 'idea',
+          'priority': 'medium',
+          'estimate': 'XS',
+          'assignee': 'requirements',
+          'summary': 'https://example.com/article\nRead later',
+          'doc_refs': [
+            {'type': 'url', 'path': 'https://example.com/article'},
+          ],
+          'tags': ['learning', 'shared-link'],
+        });
         expect(summary.syncedCount, 1);
         expect(summary.failedCount, 0);
         expect(summary.outcomes.single.status, CaptureSyncStatus.synced);
@@ -52,6 +65,20 @@ void main() {
       expect(summary.outcomes.single.error, isA<AgentApiException>());
 
       final captures = await db.select(db.pendingCaptures).get();
+      expect(captures.single.synced, isFalse);
+
+      await db.close();
+    });
+
+    test('defaults new pending captures to learning project', () async {
+      final db = PhoneDatabase(NativeDatabase.memory());
+      final apiClient = _RecordingAgentApiClient();
+      final service = CaptureSyncService(db: db, apiClient: apiClient);
+
+      await service.saveCapture(title: 'New learning capture');
+
+      final captures = await db.select(db.pendingCaptures).get();
+      expect(captures.single.project, 'learning');
       expect(captures.single.synced, isFalse);
 
       await db.close();

--- a/phone/test/quick_capture_screen_test.dart
+++ b/phone/test/quick_capture_screen_test.dart
@@ -1,0 +1,82 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:avodah_viewer/models/ticket.dart';
+import 'package:avodah_viewer/screens/quick_capture_screen.dart';
+import 'package:avodah_viewer/services/agent_api_client.dart';
+import 'package:avodah_viewer/services/capture_sync_service.dart';
+import 'package:avodah_viewer/storage/phone_database.dart';
+
+void main() {
+  group('QuickCaptureScreen', () {
+    testWidgets('defaults to learning and saves pending capture project', (
+      tester,
+    ) async {
+      final db = PhoneDatabase(NativeDatabase.memory());
+      addTearDown(db.close);
+      final apiClient = _QuickCaptureAgentApiClient();
+      final syncService = CaptureSyncService(db: db, apiClient: apiClient);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: QuickCaptureScreen(
+            sharedText: 'Read this later',
+            sharedUrl: 'https://example.com/article',
+            captureSyncService: syncService,
+            apiClient: apiClient,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final projectDropdown = tester.widget<DropdownButtonFormField<String>>(
+        find.byType(DropdownButtonFormField<String>).first,
+      );
+      expect(projectDropdown.initialValue, 'learning');
+
+      await tester.tap(find.text('Save Capture'));
+      await tester.pumpAndSettle();
+
+      final captures = await db.select(db.pendingCaptures).get();
+      expect(captures.single.project, 'learning');
+      expect(apiClient.createdTickets.single['project'], 'learning');
+    });
+  });
+}
+
+class _QuickCaptureAgentApiClient extends AgentApiClient {
+  _QuickCaptureAgentApiClient() : super(baseUrl: 'http://localhost');
+
+  final List<Map<String, dynamic>> createdTickets = [];
+
+  @override
+  Future<List<TicketProject>> getProjects() async {
+    return const [
+      TicketProject(key: 'learning', activeTicketCount: 1),
+      TicketProject(key: 'avodah', activeTicketCount: 1),
+    ];
+  }
+
+  @override
+  Future<Ticket> createTicket(Map<String, dynamic> data) async {
+    createdTickets.add(Map<String, dynamic>.from(data));
+    final now = DateTime.utc(2026, 4, 30);
+    return Ticket(
+      id: 'LM-001',
+      project: data['project'] as String,
+      title: data['title'] as String,
+      status: 'idea',
+      priority: 'medium',
+      type: 'idea',
+      estimate: 'XS',
+      tags: const [],
+      blockedBy: const [],
+      docRefs: const [],
+      comments: const [],
+      subTickets: const [],
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+}

--- a/phone/test/settings_load_server_url_test.dart
+++ b/phone/test/settings_load_server_url_test.dart
@@ -64,4 +64,35 @@ void main() {
       expect(prefs.getString(kServerUrlKey), 'http://100.64.0.1:9847');
     });
   });
+
+  group('SettingsScreen.syncStatusUriForServerUrl', () {
+    test('appends sync status path to mounted server URL', () {
+      final uri = SettingsScreen.syncStatusUriForServerUrl(
+        'https://drgnfly.tail10c2c6.ts.net/avodah',
+      );
+
+      expect(
+        uri.toString(),
+        'https://drgnfly.tail10c2c6.ts.net/avodah/api/sync/status',
+      );
+    });
+
+    test('handles trailing slash on mounted server URL', () {
+      final uri = SettingsScreen.syncStatusUriForServerUrl(
+        'https://drgnfly.tail10c2c6.ts.net/avodah/',
+      );
+
+      expect(
+        uri.toString(),
+        'https://drgnfly.tail10c2c6.ts.net/avodah/api/sync/status',
+      );
+    });
+
+    test('rejects empty server URL before building request URI', () {
+      expect(
+        () => SettingsScreen.syncStatusUriForServerUrl(''),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: avodah
 description: "Local-first productivity app with CRDT sync"
 publish_to: 'none'
-version: 0.4.3+92
+version: 0.4.3+93
 
 environment:
   sdk: ^3.10.8


### PR DESCRIPTION
## Summary
- Defaults phone Quick Capture and pending capture sync to PA project `learning`, including legacy `learning-management` pending rows.
- Surfaces capture sync success, pending, and failure outcomes so local save does not imply ticket creation succeeded.
- Adds focused phone tests and debug APK UAT notes for Sinh phone validation.

## Acceptance Criteria
- [x] AC1: Ticket payload targets `learning` for LM idea ticket creation. Live phone board verification remains in UAT because no Android device was connected.
- [x] AC2: Quick Capture and pending captures default to `learning`.
- [x] AC3: Sync failure returns visible pending or failed feedback instead of only local save success.
- [x] AC4: Unsynced captures remain retryable and legacy project keys normalize on retry.
- [x] AC5: Debug APK built and UAT notes created. Physical install/share validation is handed to Sinh UAT due no connected Android device.

## Verification
- `cd phone && flutter test`
- `cd phone && flutter build apk --debug`
- Debug APK notes: `docs/uat/2026-04-30-AVO-108-phone-share-learning-debug-apk.md`