### PR TITLE
fix(phone): validate sync test connection URL

### DIFF
--- a/phone/lib/settings/settings_screen.dart
+++ b/phone/lib/settings/settings_screen.dart
@@ -71,6 +71,25 @@ class SettingsScreen extends StatefulWidget {
     await prefs.setString(kServerUrlKey, url);
     return url;
   }
+
+  static Uri syncStatusUriForServerUrl(String rawUrl) {
+    final trimmed = rawUrl.trim();
+    if (trimmed.isEmpty) {
+      throw const FormatException('Enter a server URL first');
+    }
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null || !uri.hasScheme || uri.host.isEmpty) {
+      throw FormatException('Invalid server URL: $trimmed');
+    }
+
+    final basePath = uri.path.replaceFirst(RegExp(r'/+$'), '');
+    return uri.replace(
+      path: '$basePath/api/sync/status',
+      query: null,
+      fragment: null,
+    );
+  }
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
@@ -330,9 +349,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
     });
 
     try {
-      final url = _controller.text.trim();
-      // Use root health endpoint (no auth required)
-      final uri = Uri.parse('$url/');
+      var url = _controller.text.trim();
+      if (url.isEmpty) {
+        url = await SettingsScreen.loadServerUrl();
+        _controller.text = url;
+      }
+      final uri = SettingsScreen.syncStatusUriForServerUrl(url);
       final response = await http.get(uri).timeout(const Duration(seconds: 5));
       if (response.statusCode == 200) {
         setState(() => _testResult = 'Connected successfully!');

--- a/phone/test/settings_load_server_url_test.dart
+++ b/phone/test/settings_load_server_url_test.dart
@@ -64,4 +64,35 @@ void main() {
       expect(prefs.getString(kServerUrlKey), 'http://100.64.0.1:9847');
     });
   });
+
+  group('SettingsScreen.syncStatusUriForServerUrl', () {
+    test('appends sync status path to mounted server URL', () {
+      final uri = SettingsScreen.syncStatusUriForServerUrl(
+        'https://drgnfly.tail10c2c6.ts.net/avodah',
+      );
+
+      expect(
+        uri.toString(),
+        'https://drgnfly.tail10c2c6.ts.net/avodah/api/sync/status',
+      );
+    });
+
+    test('handles trailing slash on mounted server URL', () {
+      final uri = SettingsScreen.syncStatusUriForServerUrl(
+        'https://drgnfly.tail10c2c6.ts.net/avodah/',
+      );
+
+      expect(
+        uri.toString(),
+        'https://drgnfly.tail10c2c6.ts.net/avodah/api/sync/status',
+      );
+    });
+
+    test('rejects empty server URL before building request URI', () {
+      expect(
+        () => SettingsScreen.syncStatusUriForServerUrl(''),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Validate the Settings sync server URL before building a test request URI.
- Fall back to the saved/default server URL if the controller is empty during initial load.
- Test the unauthenticated `/api/sync/status` endpoint under mounted paths like `/avodah`.

## Verification
- `flutter test test/settings_load_server_url_test.dart` (10 passed)
- Installed debug APK to `sinh-oppo:5555`; user confirmed Test Connection and dashboard sync work after initial sync completed.