### PR TITLE
AVO-112: Phone sync-only UX (remove Jira pending badge)

### DIFF
--- a/phone/lib/main.dart
+++ b/phone/lib/main.dart
@@ -25,6 +25,7 @@ import 'services/focus_provider.dart';
 import 'services/local_dashboard_provider.dart';
 import 'services/local_write_service.dart';
 import 'services/review_provider.dart';
+import 'services/sync_error_classifier.dart';
 import 'services/team_browser_provider.dart';
 import 'storage/phone_database.dart';
 import 'settings/settings_screen.dart';
@@ -299,16 +300,17 @@ class _AvodahViewerAppState extends State<AvodahViewerApp>
         }
       }
     } catch (e) {
-      debugPrint('[Sync] Pull failed: $e');
+      final category = classifySyncError(e);
+      debugPrint('[Sync] Pull failed: $e [category=${category.name}]');
       // Surface pull failure to user via snackbar (AC4)
       final messenger = _scaffoldMessengerKey.currentState;
       if (messenger != null) {
         SchedulerBinding.instance.addPostFrameCallback((_) {
           if (!mounted) return;
           messenger.showSnackBar(
-            const SnackBar(
-              content: Text('Sync failed — will retry on next cycle'),
-              duration: Duration(seconds: 4),
+            SnackBar(
+              content: Text(errorMessage(category)),
+              duration: const Duration(seconds: 4),
             ),
           );
         });

--- a/phone/lib/models/snapshot.dart
+++ b/phone/lib/models/snapshot.dart
@@ -9,7 +9,6 @@ class DaySnapshot {
   final PlanSnapshot plan;
   final List<PlannedTaskSnapshot> plannedTasks;
   final WorklogSummarySnapshot worklogSummary;
-  final int unsyncedJiraCount;
 
   const DaySnapshot({
     required this.version,
@@ -19,7 +18,6 @@ class DaySnapshot {
     required this.plan,
     required this.plannedTasks,
     required this.worklogSummary,
-    this.unsyncedJiraCount = 0,
   });
 
   factory DaySnapshot.fromJson(Map<String, dynamic> json) {
@@ -37,7 +35,6 @@ class DaySnapshot {
           .toList(),
       worklogSummary: WorklogSummarySnapshot.fromJson(
           json['worklogSummary'] as Map<String, dynamic>),
-      unsyncedJiraCount: json['unsyncedJiraCount'] as int? ?? 0,
     );
   }
 }

--- a/phone/lib/screens/dashboard_screen.dart
+++ b/phone/lib/screens/dashboard_screen.dart
@@ -331,17 +331,6 @@ class _DashboardScreenState extends State<DashboardScreen> {
               );
             },
           ),
-          if (snapshot != null && snapshot.unsyncedJiraCount > 0)
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Tooltip(
-                message: '${snapshot.unsyncedJiraCount} unsynced Jira worklog${snapshot.unsyncedJiraCount > 1 ? 's' : ''}',
-                child: Badge(
-                  label: Text('${snapshot.unsyncedJiraCount}'),
-                  child: const Icon(Icons.cloud_upload),
-                ),
-              ),
-            ),
           IconButton(
             icon: const Icon(Icons.settings),
             onPressed: () async {

--- a/phone/lib/services/crdt_sync_service.dart
+++ b/phone/lib/services/crdt_sync_service.dart
@@ -28,6 +28,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'crypto_sync_service.dart';
 import 'pairing_service.dart';
+import 'sync_error_classifier.dart';
 
 const _kDesktopNodeId = 'desktop';
 const _kPhoneNodeIdKey = 'crdt_node_id';
@@ -234,7 +235,10 @@ class CrdtSyncService {
     if (_cryptoClient != null && !isPaired) {
       final status = await _pairingService?.checkPairingStatus();
       if (status != null && status.needsPairing) {
-        debugPrint('[CrdtSync] Server needs pairing — triggering pairing flow');
+        debugPrint(
+          '[CrdtSync] Server needs pairing — triggering pairing flow '
+          '[category=${SyncErrorCategory.authPairing.name}]',
+        );
         await onNeedsPairing?.call();
         throw Exception('Pairing required');
       }
@@ -273,7 +277,10 @@ class CrdtSyncService {
     }
 
     if (statusCode == 403) {
-      debugPrint('[CrdtSync] HTTP 403 — triggering pairing flow');
+      debugPrint(
+        '[CrdtSync] HTTP 403 — triggering pairing flow '
+        '[category=${SyncErrorCategory.authPairing.name}]',
+      );
       await onNeedsPairing?.call();
       throw Exception('Pairing required (HTTP 403)');
     }
@@ -293,8 +300,10 @@ class CrdtSyncService {
         await _mergeDelta(delta);
         merged++;
       } catch (e) {
+        final category = classifySyncError(e);
         debugPrint(
-          '[CrdtSync] Failed to merge delta ${delta['type']}/${delta['id']}: $e',
+          '[CrdtSync] Failed to merge delta ${delta['type']}/${delta['id']}: '
+          '$e [category=${category.name}]',
         );
       }
     }
@@ -472,7 +481,11 @@ class CrdtSyncService {
         'taskId=${doc.taskId} taskTitle=${doc.taskTitle}',
       );
     } catch (e) {
-      debugPrint('[CrdtSync] Timer MERGE FAILURE: id=$id error=$e');
+      final category = classifySyncError(e);
+      debugPrint(
+        '[CrdtSync] Timer MERGE FAILURE: id=$id error=$e '
+        '[category=${category.name}]',
+      );
       rethrow;
     }
     await db
@@ -603,7 +616,10 @@ class CrdtSyncService {
       }
 
       if (statusCode == 403) {
-        debugPrint('[CrdtSync] HTTP 403 — triggering pairing flow');
+        debugPrint(
+          '[CrdtSync] HTTP 403 — triggering pairing flow '
+          '[category=${SyncErrorCategory.authPairing.name}]',
+        );
         await onNeedsPairing?.call();
         throw Exception('Pairing required (HTTP 403)');
       }
@@ -631,6 +647,8 @@ class CrdtSyncService {
     } catch (e) {
       _lastPushCompletedAt = DateTime.now();
       _lastPushError = e.toString();
+      final category = classifySyncError(e);
+      debugPrint('[Sync] Push failed: $e [category=${category.name}]');
       rethrow;
     }
   }

--- a/phone/lib/services/local_dashboard_provider.dart
+++ b/phone/lib/services/local_dashboard_provider.dart
@@ -83,14 +83,12 @@ class LocalDashboardProvider extends ChangeNotifier {
       _queryDayPlanTasks(today), // 1
       _queryWorklogs(today), // 2
       _queryPlanEntries(today), // 3
-      _queryUnsyncedJiraCount(), // 4
     ]);
 
     final timerEntry = results[0] as TimerEntry?;
     final dayPlanDocs = results[1] as List<DayPlanTaskDocument>;
     final worklogDocs = results[2] as List<WorklogDocument>;
     final planDocs = results[3] as List<DailyPlanDocument>;
-    final unsyncedJiraCount = results[4] as int;
 
     // Worklog totals by task ID
     final loggedByTask = <String, int>{};
@@ -151,7 +149,6 @@ class LocalDashboardProvider extends ChangeNotifier {
       plan: plan,
       plannedTasks: plannedTasks,
       worklogSummary: worklogSummary,
-      unsyncedJiraCount: unsyncedJiraCount,
     );
   }
 
@@ -202,23 +199,6 @@ class LocalDashboardProvider extends ChangeNotifier {
           ..where((t) => t.id.isIn(ids.toList())))
         .get();
     return {for (final t in rows) t.id: t};
-  }
-
-  /// Counts worklogs that haven't been synced to Jira (jiraWorklogId is null)
-  /// but belong to a Jira-linked task (task has issueId).
-  Future<int> _queryUnsyncedJiraCount() async {
-    final worklogs = await db.select(db.worklogEntries).get();
-    final tasks = await db.select(db.tasks).get();
-    final taskIssueIds = {for (final t in tasks) t.id: t.issueId};
-
-    int count = 0;
-    for (final wl in worklogs) {
-      final issueId = taskIssueIds[wl.taskId];
-      if (wl.jiraWorklogId == null && issueId != null) {
-        count++;
-      }
-    }
-    return count;
   }
 
   // ============================================================

--- a/phone/lib/services/sync_error_classifier.dart
+++ b/phone/lib/services/sync_error_classifier.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+enum SyncErrorCategory {
+  dnsNetwork,
+  timeout,
+  authPairing,
+  tlsCert,
+  httpStatus,
+  unknown,
+}
+
+SyncErrorCategory classifySyncError(Object error) {
+  if (error is TimeoutException) {
+    return SyncErrorCategory.timeout;
+  }
+
+  final text = error.toString().toLowerCase();
+
+  if (_containsAny(text, const [
+    'failed host lookup',
+    'socketexception',
+    'connection refused',
+    'network is unreachable',
+    'connection reset by peer',
+    'os error',
+  ])) {
+    return SyncErrorCategory.dnsNetwork;
+  }
+
+  if (_containsAny(text, const ['timed out', 'timeout'])) {
+    return SyncErrorCategory.timeout;
+  }
+
+  if (_containsAny(text, const [
+    'pairing required',
+    'http 401',
+    'http 403',
+    'unauthorized',
+    'forbidden',
+    'invalid token',
+  ])) {
+    return SyncErrorCategory.authPairing;
+  }
+
+  if (_containsAny(text, const [
+    'handshakeexception',
+    'certificate',
+    'cert ',
+    'x509',
+    'tls',
+  ])) {
+    return SyncErrorCategory.tlsCert;
+  }
+
+  if (RegExp(r'http\s*\d{3}').hasMatch(text) || text.contains('status code')) {
+    return SyncErrorCategory.httpStatus;
+  }
+
+  return SyncErrorCategory.unknown;
+}
+
+String errorMessage(SyncErrorCategory category) {
+  switch (category) {
+    case SyncErrorCategory.dnsNetwork:
+      return 'Cannot reach desktop server. Check Wi-Fi/LAN and server address.';
+    case SyncErrorCategory.timeout:
+      return 'Sync timed out. Keep app open; it will retry on the next cycle.';
+    case SyncErrorCategory.authPairing:
+      return 'Pairing/auth issue. Re-pair phone with desktop in Settings.';
+    case SyncErrorCategory.tlsCert:
+      return 'TLS certificate not trusted. Approve/update the server certificate.';
+    case SyncErrorCategory.httpStatus:
+      return 'Server rejected sync request. Verify desktop server health and logs.';
+    case SyncErrorCategory.unknown:
+      return 'Sync failed unexpectedly. It will retry on the next cycle.';
+  }
+}
+
+bool _containsAny(String value, List<String> needles) {
+  for (final needle in needles) {
+    if (value.contains(needle)) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- Removes Jira pending cloud badge from phone dashboard app bar
- Removes `unsyncedJiraCount` from snapshot model and provider
- Adds `sync_error_classifier.dart` with typed error categories (dnsNetwork, timeout, authPairing, tlsCert, httpStatus, unknown)
- Updates sync snackbar to show actionable category-specific failure text
- Augments sync error logs with operation + category tags

## Changes
- `phone/lib/screens/dashboard_screen.dart` — removed Jira badge block
- `phone/lib/models/snapshot.dart` — removed `unsyncedJiraCount` field
- `phone/lib/services/local_dashboard_provider.dart` — removed `_queryUnsyncedJiraCount()`
- `phone/lib/services/sync_error_classifier.dart` — new error classification utility
- `phone/lib/main.dart` — category-specific snackbar text in sync catch block
- `phone/lib/services/crdt_sync_service.dart` — augmented debugPrint with category tags

## Acceptance Criteria Checklist
- [x] AC-1: No Jira pending badge shown in dashboard (device verified)
- [x] AC-2: Sync status shows phone-laptop health only
- [x] AC-3: Actionable failure cause text shown on sync errors
- [x] AC-4: Automatic recovery after transient failure
- [x] AC-5: Diagnostic logs include operation + category tags

## Device Evidence
`phone/build/device-evidence-phase4.md` — adb verification on sinh-oppo:5555, all ACs pass.

## Verification
- `dart analyze phone/lib/` — clean
- `flutter build apk --debug` — succeeds
- Phase 3 recovery validation — retry/recovery behavior verified unchanged