### PR TITLE
AVO-100: split Android APK build and ABI-aware deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ docker-compose.override.yml
 # Direnv
 .direnv/
 .claude/todos.md
+phone/releases/

--- a/flake.nix
+++ b/flake.nix
@@ -117,7 +117,7 @@
           avo-run = pkgs.writeShellScriptBin "avo-run" "flutter run -d linux";
           avo-run-android = pkgs.writeShellScriptBin "avo-run-android" "cd $(git rev-parse --show-toplevel)/phone && flutter run -d android";
           avo-build = pkgs.writeShellScriptBin "avo-build" "flutter build linux --release";
-          avo-build-android = pkgs.writeShellScriptBin "avo-build-android" "cd $(git rev-parse --show-toplevel)/phone && flutter build apk --release";
+          avo-build-android = pkgs.writeShellScriptBin "avo-build-android" "cd $(git rev-parse --show-toplevel)/phone && flutter build apk --release --split-per-abi --target-platform android-arm,android-arm64";
           avo-test = pkgs.writeShellScriptBin "avo-test" "flutter test";
           avo-analyze = pkgs.writeShellScriptBin "avo-analyze" "flutter analyze";
           avo-clean = pkgs.writeShellScriptBin "avo-clean" "flutter clean && flutter pub get";

--- a/tool/apk-paths.sh
+++ b/tool/apk-paths.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+apk_output_dir() {
+  local root_dir="$1"
+  printf '%s/phone/build/app/outputs/flutter-apk' "$root_dir"
+}
+
+apk_path_for_abi() {
+  local root_dir="$1"
+  local abi="$2"
+  local out_dir
+  out_dir="$(apk_output_dir "$root_dir")"
+
+  case "$abi" in
+    arm64-v8a)
+      printf '%s/app-arm64-v8a-release.apk' "$out_dir"
+      ;;
+    armeabi-v7a)
+      printf '%s/app-armeabi-v7a-release.apk' "$out_dir"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+apk_label_for_abi() {
+  local abi="$1"
+  case "$abi" in
+    arm64-v8a)
+      printf 'arm64'
+      ;;
+    armeabi-v7a)
+      printf 'armv7'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}

--- a/tool/build-apk.sh
+++ b/tool/build-apk.sh
@@ -5,7 +5,12 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PHONE_DIR="$ROOT_DIR/phone"
 RELEASES_DIR="$PHONE_DIR/releases"
 PUBSPEC_PATH="$PHONE_DIR/pubspec.yaml"
-SPLIT_OUT_DIR="$PHONE_DIR/build/app/outputs/flutter-apk"
+
+# Shared ABI -> APK output path mapping.
+# shellcheck source=tool/apk-paths.sh
+source "$ROOT_DIR/tool/apk-paths.sh"
+
+SPLIT_OUT_DIR="$(apk_output_dir "$ROOT_DIR")"
 
 if [ ! -f "$PUBSPEC_PATH" ]; then
   echo "ERROR: pubspec.yaml not found at $PUBSPEC_PATH"
@@ -29,8 +34,8 @@ cd "$PHONE_DIR"
 echo "Building split release APKs for ARM targets..."
 flutter build apk --release --split-per-abi --target-platform android-arm,android-arm64
 
-ARM64_SRC="$SPLIT_OUT_DIR/app-arm64-v8a-release.apk"
-ARMV7_SRC="$SPLIT_OUT_DIR/app-armeabi-v7a-release.apk"
+ARM64_SRC="$(apk_path_for_abi "$ROOT_DIR" arm64-v8a)"
+ARMV7_SRC="$(apk_path_for_abi "$ROOT_DIR" armeabi-v7a)"
 
 if [ ! -f "$ARM64_SRC" ] || [ ! -f "$ARMV7_SRC" ]; then
   echo "ERROR: Expected split APKs were not generated."

--- a/tool/build-apk.sh
+++ b/tool/build-apk.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PHONE_DIR="$ROOT_DIR/phone"
+RELEASES_DIR="$PHONE_DIR/releases"
+PUBSPEC_PATH="$PHONE_DIR/pubspec.yaml"
+SPLIT_OUT_DIR="$PHONE_DIR/build/app/outputs/flutter-apk"
+
+if [ ! -f "$PUBSPEC_PATH" ]; then
+  echo "ERROR: pubspec.yaml not found at $PUBSPEC_PATH"
+  exit 1
+fi
+
+VERSION_LINE="$(grep -E '^version:' "$PUBSPEC_PATH" | head -n 1 || true)"
+if [ -z "$VERSION_LINE" ]; then
+  echo "ERROR: Could not extract version from $PUBSPEC_PATH"
+  exit 1
+fi
+
+APP_VERSION="$(printf '%s' "$VERSION_LINE" | sed -E 's/^version:[[:space:]]*([^+[:space:]]+).*/\1/')"
+if [ -z "$APP_VERSION" ]; then
+  echo "ERROR: Parsed empty version from $PUBSPEC_PATH"
+  exit 1
+fi
+
+cd "$PHONE_DIR"
+
+echo "Building split release APKs for ARM targets..."
+flutter build apk --release --split-per-abi --target-platform android-arm,android-arm64
+
+ARM64_SRC="$SPLIT_OUT_DIR/app-arm64-v8a-release.apk"
+ARMV7_SRC="$SPLIT_OUT_DIR/app-armeabi-v7a-release.apk"
+
+if [ ! -f "$ARM64_SRC" ] || [ ! -f "$ARMV7_SRC" ]; then
+  echo "ERROR: Expected split APKs were not generated."
+  echo "Missing files checked:"
+  echo "  $ARM64_SRC"
+  echo "  $ARMV7_SRC"
+  exit 1
+fi
+
+mkdir -p "$RELEASES_DIR"
+
+ARM64_DST="$RELEASES_DIR/avodah-viewer-v${APP_VERSION}-arm64.apk"
+ARMV7_DST="$RELEASES_DIR/avodah-viewer-v${APP_VERSION}-armv7.apk"
+
+cp "$ARM64_SRC" "$ARM64_DST"
+cp "$ARMV7_SRC" "$ARMV7_DST"
+
+echo "Release artifacts:"
+ls -lh "$ARM64_DST" "$ARMV7_DST"

--- a/tool/deploy.sh
+++ b/tool/deploy.sh
@@ -9,9 +9,18 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PHONE_DIR="$ROOT_DIR/phone"
 DEVICE_FILTER="${1:-}"
 
+# Shared ABI -> APK output path mapping.
+# shellcheck source=tool/apk-paths.sh
+source "$ROOT_DIR/tool/apk-paths.sh"
+
 cd "$ROOT_DIR"
 
 # --- Build ---
+if [ ! -f "$ROOT_DIR/tool/build-apk.sh" ]; then
+  echo "ERROR: Required build script not found: $ROOT_DIR/tool/build-apk.sh"
+  exit 1
+fi
+
 echo "Building split release APKs..."
 bash "$ROOT_DIR/tool/build-apk.sh"
 
@@ -23,8 +32,13 @@ if [ -z "$DEVICES" ]; then
   exit 1
 fi
 
-# --- Install ---
-INSTALLED=0
+# --- Collect install targets and required APKs ---
+SUPPORTED_MATCHED=0
+FILTER_MATCHED=0
+declare -a TARGET_SERIALS=()
+declare -A DEVICE_ABI=()
+declare -A REQUIRED_ABI=()
+
 for SERIAL in $DEVICES; do
   if [ -n "$DEVICE_FILTER" ]; then
     # Match filter against serial or device model
@@ -32,28 +46,55 @@ for SERIAL in $DEVICES; do
     if [[ "$SERIAL" != *"$DEVICE_FILTER"* && "$MODEL" != *"$DEVICE_FILTER"* ]]; then
       continue
     fi
+    FILTER_MATCHED=1
   fi
 
   ABI=$(adb -s "$SERIAL" shell getprop ro.product.cpu.abi 2>/dev/null | tr -d '\r')
-  case "$ABI" in
-    arm64-v8a)
-      APK_PATH="$PHONE_DIR/build/app/outputs/flutter-apk/app-arm64-v8a-release.apk"
-      ABI_LABEL="arm64"
-      ;;
-    armeabi-v7a)
-      APK_PATH="$PHONE_DIR/build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk"
-      ABI_LABEL="armv7"
-      ;;
-    *)
-      echo "Skipping $SERIAL: unsupported ABI '$ABI'"
-      continue
-      ;;
-  esac
+  if ! apk_path_for_abi "$ROOT_DIR" "$ABI" >/dev/null; then
+    echo "Skipping $SERIAL: unsupported ABI '$ABI'"
+    continue
+  fi
 
+  TARGET_SERIALS+=("$SERIAL")
+  DEVICE_ABI["$SERIAL"]="$ABI"
+  REQUIRED_ABI["$ABI"]=1
+  SUPPORTED_MATCHED=1
+done
+
+if [ -n "$DEVICE_FILTER" ] && [ "$FILTER_MATCHED" -eq 0 ]; then
+  echo "ERROR: No connected devices matched filter '$DEVICE_FILTER'."
+  echo "Connected devices:"
+  adb devices -l | tail -n +2
+  exit 1
+fi
+
+if [ "$SUPPORTED_MATCHED" -eq 0 ]; then
+  if [ -n "$DEVICE_FILTER" ]; then
+    echo "ERROR: Devices matched filter '$DEVICE_FILTER', but all had unsupported ABIs."
+  else
+    echo "ERROR: Connected devices found, but all had unsupported ABIs."
+  fi
+  echo "Connected devices:"
+  adb devices -l | tail -n +2
+  exit 1
+fi
+
+# Validate all APK paths before installing on any device.
+for ABI in "${!REQUIRED_ABI[@]}"; do
+  APK_PATH="$(apk_path_for_abi "$ROOT_DIR" "$ABI")"
+  ABI_LABEL="$(apk_label_for_abi "$ABI")"
   if [ ! -f "$APK_PATH" ]; then
-    echo "ERROR: Expected APK missing for $SERIAL ($ABI_LABEL): $APK_PATH"
+    echo "ERROR: Expected APK missing for ABI '$ABI_LABEL': $APK_PATH"
     exit 1
   fi
+done
+
+# --- Install ---
+INSTALLED=0
+for SERIAL in "${TARGET_SERIALS[@]}"; do
+  ABI="${DEVICE_ABI[$SERIAL]}"
+  APK_PATH="$(apk_path_for_abi "$ROOT_DIR" "$ABI")"
+  ABI_LABEL="$(apk_label_for_abi "$ABI")"
 
   echo "Installing $ABI_LABEL APK on $SERIAL (ABI: $ABI)..."
   adb -s "$SERIAL" install -r "$APK_PATH"
@@ -61,9 +102,7 @@ for SERIAL in $DEVICES; do
 done
 
 if [ "$INSTALLED" -eq 0 ]; then
-  echo "ERROR: No device matched filter '$DEVICE_FILTER'."
-  echo "Connected devices:"
-  adb devices -l | tail -n +2
+  echo "ERROR: No supported devices were selected for install."
   exit 1
 fi
 

--- a/tool/deploy.sh
+++ b/tool/deploy.sh
@@ -1,25 +1,19 @@
 #!/usr/bin/env bash
-# Build release APK and install on a connected Android device.
+# Build split release APKs and install on connected Android device(s).
 # Usage: ./tool/deploy.sh [device-name]
 #   device-name  Optional substring to match against adb device serial/model.
 #                If omitted, installs on all connected devices.
 set -euo pipefail
 
-cd "$(dirname "$0")/../phone"
-
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PHONE_DIR="$ROOT_DIR/phone"
 DEVICE_FILTER="${1:-}"
-APK_PATH="build/app/outputs/flutter-apk/app-release.apk"
+
+cd "$ROOT_DIR"
 
 # --- Build ---
-echo "Building release APK..."
-flutter build apk --release
-
-if [ ! -f "$APK_PATH" ]; then
-  echo "ERROR: APK not found at $APK_PATH"
-  exit 1
-fi
-
-echo "APK ready: $APK_PATH"
+echo "Building split release APKs..."
+bash "$ROOT_DIR/tool/build-apk.sh"
 
 # --- Detect devices ---
 DEVICES=$(adb devices | tail -n +2 | grep -w 'device' | awk '{print $1}')
@@ -40,7 +34,28 @@ for SERIAL in $DEVICES; do
     fi
   fi
 
-  echo "Installing on $SERIAL..."
+  ABI=$(adb -s "$SERIAL" shell getprop ro.product.cpu.abi 2>/dev/null | tr -d '\r')
+  case "$ABI" in
+    arm64-v8a)
+      APK_PATH="$PHONE_DIR/build/app/outputs/flutter-apk/app-arm64-v8a-release.apk"
+      ABI_LABEL="arm64"
+      ;;
+    armeabi-v7a)
+      APK_PATH="$PHONE_DIR/build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk"
+      ABI_LABEL="armv7"
+      ;;
+    *)
+      echo "Skipping $SERIAL: unsupported ABI '$ABI'"
+      continue
+      ;;
+  esac
+
+  if [ ! -f "$APK_PATH" ]; then
+    echo "ERROR: Expected APK missing for $SERIAL ($ABI_LABEL): $APK_PATH"
+    exit 1
+  fi
+
+  echo "Installing $ABI_LABEL APK on $SERIAL (ABI: $ABI)..."
   adb -s "$SERIAL" install -r "$APK_PATH"
   INSTALLED=$((INSTALLED + 1))
 done


### PR DESCRIPTION
## Summary
- Adds `tool/build-apk.sh` for split-per-ABI Android release builds and versioned release copies.
- Updates `tool/deploy.sh` to preserve the existing interface while selecting/installing the APK matching each device ABI.
- Updates `avo-build-android` and ignores generated `phone/releases/` APK artifacts.

## Verification
- `bash tool/build-apk.sh`
- `bash -n tool/deploy.sh`
- `bash tool/deploy.sh oppo`
- `nix develop --command avo-build-android`

## Acceptance Criteria
- [x] AC1 split APKs produced
- [ ] AC2 arm64 split APK under 30MB (measured 31.6MB; known caveat)
- [x] AC3 ABI-matched deploy script path verified
- [x] AC4 `tool/deploy.sh oppo` installed arm64 APK on sinh-oppo
- [x] AC5 self-update command compatibility preserved
- [ ] AC6 app launch/functionality parity remains UAT/manual
- [x] AC7 `avo-build-android` uses split-per-ABI
- [x] AC8 `phone/releases/` is gitignored
- [x] AC9 build script prints file sizes